### PR TITLE
feat: 장비 사용불가 스케줄 관리 기능 추가

### DIFF
--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
@@ -4,10 +4,12 @@ import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
 import io.bluetape4k.clinic.appointment.repository.AppointmentStateHistoryRepository
 import io.bluetape4k.clinic.appointment.repository.ClinicRepository
 import io.bluetape4k.clinic.appointment.repository.DoctorRepository
+import io.bluetape4k.clinic.appointment.repository.EquipmentUnavailabilityRepository
 import io.bluetape4k.clinic.appointment.repository.HolidayRepository
 import io.bluetape4k.clinic.appointment.repository.RescheduleCandidateRepository
 import io.bluetape4k.clinic.appointment.repository.TreatmentTypeRepository
 import io.bluetape4k.clinic.appointment.service.ClosureRescheduleService
+import io.bluetape4k.clinic.appointment.service.EquipmentUnavailabilityService
 import io.bluetape4k.clinic.appointment.service.SlotCalculationService
 import io.bluetape4k.clinic.appointment.statemachine.AppointmentStateMachine
 import org.springframework.context.annotation.Bean
@@ -67,4 +69,16 @@ class ServiceConfig {
 
     @Bean
     fun appointmentStateMachine(): AppointmentStateMachine = AppointmentStateMachine()
+
+    @Bean
+    fun equipmentUnavailabilityRepository(): EquipmentUnavailabilityRepository = EquipmentUnavailabilityRepository()
+
+    @Bean
+    fun equipmentUnavailabilityService(
+        equipmentUnavailabilityRepository: EquipmentUnavailabilityRepository,
+        appointmentRepository: AppointmentRepository,
+    ): EquipmentUnavailabilityService = EquipmentUnavailabilityService(
+        repo = equipmentUnavailabilityRepository,
+        appointmentRepository = appointmentRepository,
+    )
 }

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentUnavailabilityController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentUnavailabilityController.kt
@@ -1,0 +1,288 @@
+package io.bluetape4k.clinic.appointment.api.controller
+
+import io.bluetape4k.clinic.appointment.api.dto.ApiResponse
+import io.bluetape4k.clinic.appointment.api.dto.ConflictingAppointmentResponse
+import io.bluetape4k.clinic.appointment.api.dto.CreateEquipmentUnavailabilityRequest
+import io.bluetape4k.clinic.appointment.api.dto.UnavailabilityConflictResponse
+import io.bluetape4k.clinic.appointment.api.dto.UnavailabilityExceptionRequest
+import io.bluetape4k.clinic.appointment.api.dto.UpdateEquipmentUnavailabilityRequest
+import io.bluetape4k.clinic.appointment.model.dto.AppointmentRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
+import io.bluetape4k.clinic.appointment.service.EquipmentUnavailabilityService
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.requirePositiveNumber
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+/**
+ * 장비 사용불가 스케줄 REST 컨트롤러.
+ *
+ * 장비의 사용불가 기간 등록, 조회, 수정, 삭제 API와
+ * 예외 처리 및 충돌 예약 감지 API를 제공합니다.
+ */
+@RestController
+@RequestMapping("/api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities")
+class EquipmentUnavailabilityController(
+    private val service: EquipmentUnavailabilityService,
+) {
+    companion object : KLogging()
+
+    /**
+     * 장비의 사용불가 스케줄 목록 조회.
+     *
+     * @param clinicId 병원 ID
+     * @param equipmentId 장비 ID
+     * @param from 조회 시작 날짜
+     * @param to 조회 종료 날짜
+     * @return 사용불가 스케줄 목록
+     */
+    @GetMapping
+    fun getUnavailabilities(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+    ): ResponseEntity<ApiResponse<List<EquipmentUnavailabilityRecord>>> {
+        clinicId.requirePositiveNumber("clinicId")
+        equipmentId.requirePositiveNumber("equipmentId")
+        log.debug { "GET unavailabilities clinicId=$clinicId, equipmentId=$equipmentId, from=$from, to=$to" }
+        val records = service.findUnavailabilityRecords(equipmentId, from, to)
+        return ResponseEntity.ok(ApiResponse.ok(records))
+    }
+
+    /**
+     * 장비 사용불가 스케줄 등록.
+     *
+     * @param clinicId 병원 ID
+     * @param equipmentId 장비 ID
+     * @param request 사용불가 스케줄 생성 요청
+     * @return 생성된 사용불가 스케줄
+     */
+    @PostMapping
+    fun create(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @RequestBody request: CreateEquipmentUnavailabilityRequest,
+    ): ResponseEntity<ApiResponse<EquipmentUnavailabilityRecord>> {
+        clinicId.requirePositiveNumber("clinicId")
+        equipmentId.requirePositiveNumber("equipmentId")
+        log.debug { "POST unavailability clinicId=$clinicId, equipmentId=$equipmentId" }
+        val record = service.create(
+            equipmentId = equipmentId,
+            clinicId = clinicId,
+            unavailableDate = request.unavailableDate,
+            isRecurring = request.isRecurring,
+            recurringDayOfWeek = request.recurringDayOfWeek,
+            effectiveFrom = request.effectiveFrom,
+            effectiveUntil = request.effectiveUntil,
+            startTime = request.startTime,
+            endTime = request.endTime,
+            reason = request.reason,
+        )
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(record))
+    }
+
+    /**
+     * 장비 사용불가 스케줄 수정.
+     *
+     * 기존 스케줄을 삭제하고 새로 생성합니다.
+     *
+     * @param clinicId 병원 ID
+     * @param equipmentId 장비 ID
+     * @param id 사용불가 스케줄 ID
+     * @param request 수정 요청
+     * @return 수정된 사용불가 스케줄
+     */
+    @PutMapping("/{id}")
+    fun update(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @PathVariable id: Long,
+        @RequestBody request: UpdateEquipmentUnavailabilityRequest,
+    ): ResponseEntity<ApiResponse<EquipmentUnavailabilityRecord>> {
+        clinicId.requirePositiveNumber("clinicId")
+        equipmentId.requirePositiveNumber("equipmentId")
+        id.requirePositiveNumber("id")
+        log.debug { "PUT unavailability id=$id, clinicId=$clinicId, equipmentId=$equipmentId" }
+        service.findById(id) ?: throw NoSuchElementException("EquipmentUnavailability not found: $id")
+        service.delete(id)
+        val updated = service.create(
+            equipmentId = equipmentId,
+            clinicId = clinicId,
+            unavailableDate = request.unavailableDate,
+            isRecurring = request.isRecurring,
+            recurringDayOfWeek = request.recurringDayOfWeek,
+            effectiveFrom = request.effectiveFrom,
+            effectiveUntil = request.effectiveUntil,
+            startTime = request.startTime,
+            endTime = request.endTime,
+            reason = request.reason,
+        )
+        return ResponseEntity.ok(ApiResponse.ok(updated))
+    }
+
+    /**
+     * 장비 사용불가 스케줄 삭제.
+     *
+     * @param clinicId 병원 ID
+     * @param equipmentId 장비 ID
+     * @param id 사용불가 스케줄 ID
+     * @return 204 No Content
+     */
+    @DeleteMapping("/{id}")
+    fun delete(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @PathVariable id: Long,
+    ): ResponseEntity<Void> {
+        clinicId.requirePositiveNumber("clinicId")
+        equipmentId.requirePositiveNumber("equipmentId")
+        id.requirePositiveNumber("id")
+        log.debug { "DELETE unavailability id=$id, clinicId=$clinicId, equipmentId=$equipmentId" }
+        service.delete(id)
+        return ResponseEntity.noContent().build()
+    }
+
+    /**
+     * 장비 사용불가 예외 추가.
+     *
+     * @param clinicId 병원 ID
+     * @param equipmentId 장비 ID
+     * @param id 사용불가 스케줄 ID
+     * @param request 예외 처리 요청
+     * @return 생성된 예외 레코드
+     */
+    @PostMapping("/{id}/exceptions")
+    fun addException(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @PathVariable id: Long,
+        @RequestBody request: UnavailabilityExceptionRequest,
+    ): ResponseEntity<ApiResponse<EquipmentUnavailabilityExceptionRecord>> {
+        clinicId.requirePositiveNumber("clinicId")
+        equipmentId.requirePositiveNumber("equipmentId")
+        id.requirePositiveNumber("id")
+        log.debug { "POST exception unavailabilityId=$id, date=${request.originalDate}" }
+        val exception = service.addException(
+            unavailabilityId = id,
+            originalDate = request.originalDate,
+            exceptionType = request.exceptionType,
+            rescheduledDate = request.rescheduledDate,
+            rescheduledStartTime = request.rescheduledStartTime,
+            rescheduledEndTime = request.rescheduledEndTime,
+            reason = request.reason,
+        )
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.ok(exception))
+    }
+
+    /**
+     * 장비 사용불가 예외 삭제.
+     *
+     * @param clinicId 병원 ID
+     * @param equipmentId 장비 ID
+     * @param id 사용불가 스케줄 ID
+     * @param exId 예외 ID
+     * @return 204 No Content
+     */
+    @DeleteMapping("/{id}/exceptions/{exId}")
+    fun deleteException(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @PathVariable id: Long,
+        @PathVariable exId: Long,
+    ): ResponseEntity<Void> {
+        clinicId.requirePositiveNumber("clinicId")
+        equipmentId.requirePositiveNumber("equipmentId")
+        id.requirePositiveNumber("id")
+        exId.requirePositiveNumber("exId")
+        log.debug { "DELETE exception exId=$exId, unavailabilityId=$id" }
+        service.deleteException(exId)
+        return ResponseEntity.noContent().build()
+    }
+
+    /**
+     * 등록된 사용불가 스케줄과 충돌하는 예약 조회.
+     *
+     * @param clinicId 병원 ID
+     * @param equipmentId 장비 ID
+     * @param id 사용불가 스케줄 ID
+     * @return 충돌 예약 목록
+     */
+    @GetMapping("/{id}/conflicts")
+    fun detectConflicts(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @PathVariable id: Long,
+    ): ResponseEntity<ApiResponse<UnavailabilityConflictResponse>> {
+        clinicId.requirePositiveNumber("clinicId")
+        equipmentId.requirePositiveNumber("equipmentId")
+        id.requirePositiveNumber("id")
+        log.debug { "GET conflicts unavailabilityId=$id" }
+        val conflictingAppointments = service.detectConflicts(id)
+        val response = conflictingAppointments.toConflictResponse(id)
+        return ResponseEntity.ok(ApiResponse.ok(response))
+    }
+
+    /**
+     * 사용불가 스케줄 등록 전 충돌 미리보기.
+     *
+     * @param clinicId 병원 ID
+     * @param equipmentId 장비 ID
+     * @param request 사용불가 스케줄 생성 요청
+     * @return 충돌 예약 미리보기
+     */
+    @PostMapping("/preview-conflicts")
+    fun previewConflicts(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @RequestBody request: CreateEquipmentUnavailabilityRequest,
+    ): ResponseEntity<ApiResponse<UnavailabilityConflictResponse>> {
+        clinicId.requirePositiveNumber("clinicId")
+        equipmentId.requirePositiveNumber("equipmentId")
+        log.debug { "POST preview-conflicts equipmentId=$equipmentId" }
+        val conflictingAppointments = service.previewConflicts(
+            equipmentId = equipmentId,
+            unavailableDate = request.unavailableDate,
+            isRecurring = request.isRecurring,
+            recurringDayOfWeek = request.recurringDayOfWeek,
+            effectiveFrom = request.effectiveFrom,
+            effectiveUntil = request.effectiveUntil,
+            startTime = request.startTime,
+            endTime = request.endTime,
+        )
+        val response = conflictingAppointments.toConflictResponse(unavailabilityId = 0L)
+        return ResponseEntity.ok(ApiResponse.ok(response))
+    }
+}
+
+private fun List<AppointmentRecord>.toConflictResponse(unavailabilityId: Long): UnavailabilityConflictResponse {
+    val conflicts = map { appointment ->
+        ConflictingAppointmentResponse(
+            appointmentId = appointment.id!!,
+            patientName = appointment.patientName,
+            appointmentDate = appointment.appointmentDate,
+            startTime = appointment.startTime,
+            endTime = appointment.endTime,
+            doctorId = appointment.doctorId,
+            equipmentId = appointment.equipmentId ?: 0L,
+        )
+    }
+    return UnavailabilityConflictResponse(
+        unavailabilityId = unavailabilityId,
+        conflictCount = conflicts.size,
+        conflicts = conflicts,
+    )
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/ConflictingAppointmentResponse.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/ConflictingAppointmentResponse.kt
@@ -1,0 +1,30 @@
+package io.bluetape4k.clinic.appointment.api.dto
+
+import java.io.Serializable
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 장비 사용불가 스케줄과 충돌하는 예약 정보.
+ *
+ * @property appointmentId 예약 ID
+ * @property patientName 환자명
+ * @property appointmentDate 예약 날짜
+ * @property startTime 예약 시작 시간
+ * @property endTime 예약 종료 시간
+ * @property doctorId 담당 의사 ID
+ * @property equipmentId 사용 장비 ID
+ */
+data class ConflictingAppointmentResponse(
+    val appointmentId: Long,
+    val patientName: String,
+    val appointmentDate: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val doctorId: Long,
+    val equipmentId: Long,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/CreateEquipmentUnavailabilityRequest.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/CreateEquipmentUnavailabilityRequest.kt
@@ -1,0 +1,33 @@
+package io.bluetape4k.clinic.appointment.api.dto
+
+import java.io.Serializable
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 장비 사용불가 스케줄 생성 요청.
+ *
+ * @property unavailableDate 사용불가 날짜 (isRecurring=false 시 필수)
+ * @property isRecurring 반복 여부
+ * @property recurringDayOfWeek 반복 요일 (isRecurring=true 시 필수)
+ * @property effectiveFrom 유효 시작일
+ * @property effectiveUntil 유효 종료일 (null이면 무기한)
+ * @property startTime 사용불가 시작 시간
+ * @property endTime 사용불가 종료 시간
+ * @property reason 사유
+ */
+data class CreateEquipmentUnavailabilityRequest(
+    val unavailableDate: LocalDate? = null,
+    val isRecurring: Boolean = false,
+    val recurringDayOfWeek: DayOfWeek? = null,
+    val effectiveFrom: LocalDate,
+    val effectiveUntil: LocalDate? = null,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val reason: String? = null,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UnavailabilityConflictResponse.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UnavailabilityConflictResponse.kt
@@ -1,0 +1,20 @@
+package io.bluetape4k.clinic.appointment.api.dto
+
+import java.io.Serializable
+
+/**
+ * 장비 사용불가 스케줄 등록/수정 시 충돌 예약 목록 응답.
+ *
+ * @property unavailabilityId 장비 사용불가 스케줄 ID
+ * @property conflictCount 충돌 예약 수
+ * @property conflicts 충돌 예약 목록
+ */
+data class UnavailabilityConflictResponse(
+    val unavailabilityId: Long,
+    val conflictCount: Int,
+    val conflicts: List<ConflictingAppointmentResponse>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UnavailabilityExceptionRequest.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UnavailabilityExceptionRequest.kt
@@ -1,0 +1,29 @@
+package io.bluetape4k.clinic.appointment.api.dto
+
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import java.io.Serializable
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 장비 사용불가 예외 처리 요청.
+ *
+ * @property originalDate 원래 사용불가 날짜
+ * @property exceptionType 예외 유형 (SKIP: 해당 날짜 건너뜀, RESCHEDULE: 일정 변경)
+ * @property rescheduledDate 변경된 날짜 (exceptionType=RESCHEDULE 시 필수)
+ * @property rescheduledStartTime 변경된 시작 시간 (exceptionType=RESCHEDULE 시 필수)
+ * @property rescheduledEndTime 변경된 종료 시간 (exceptionType=RESCHEDULE 시 필수)
+ * @property reason 사유
+ */
+data class UnavailabilityExceptionRequest(
+    val originalDate: LocalDate,
+    val exceptionType: ExceptionType,
+    val rescheduledDate: LocalDate? = null,
+    val rescheduledStartTime: LocalTime? = null,
+    val rescheduledEndTime: LocalTime? = null,
+    val reason: String? = null,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UpdateEquipmentUnavailabilityRequest.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UpdateEquipmentUnavailabilityRequest.kt
@@ -1,0 +1,33 @@
+package io.bluetape4k.clinic.appointment.api.dto
+
+import java.io.Serializable
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 장비 사용불가 스케줄 수정 요청.
+ *
+ * @property unavailableDate 사용불가 날짜 (isRecurring=false 시 필수)
+ * @property isRecurring 반복 여부
+ * @property recurringDayOfWeek 반복 요일 (isRecurring=true 시 필수)
+ * @property effectiveFrom 유효 시작일
+ * @property effectiveUntil 유효 종료일 (null이면 무기한)
+ * @property startTime 사용불가 시작 시간
+ * @property endTime 사용불가 종료 시간
+ * @property reason 사유
+ */
+data class UpdateEquipmentUnavailabilityRequest(
+    val unavailableDate: LocalDate? = null,
+    val isRecurring: Boolean = false,
+    val recurringDayOfWeek: DayOfWeek? = null,
+    val effectiveFrom: LocalDate,
+    val effectiveUntil: LocalDate? = null,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val reason: String? = null,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-api/src/main/resources/db/migration/V2__add_equipment_unavailabilities.sql
+++ b/appointment-api/src/main/resources/db/migration/V2__add_equipment_unavailabilities.sql
@@ -1,0 +1,44 @@
+-- ============================================================
+-- V2: 장비 사용불가 스케줄 추가
+-- ============================================================
+
+CREATE TABLE scheduling_equipment_unavailabilities (
+    id                   BIGINT       NOT NULL AUTO_INCREMENT,
+    equipment_id         BIGINT       NOT NULL,
+    clinic_id            BIGINT       NOT NULL,
+    unavailable_date     DATE,
+    is_recurring         BOOLEAN      NOT NULL DEFAULT FALSE,
+    recurring_day_of_week VARCHAR(10),
+    effective_from       DATE         NOT NULL,
+    effective_until      DATE,
+    start_time           TIME         NOT NULL,
+    end_time             TIME         NOT NULL,
+    reason               VARCHAR(500),
+    created_at           DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at           DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_equ_unavail_equipment FOREIGN KEY (equipment_id) REFERENCES scheduling_equipments(id) ON DELETE CASCADE,
+    CONSTRAINT fk_equ_unavail_clinic    FOREIGN KEY (clinic_id)    REFERENCES scheduling_clinics(id)    ON DELETE CASCADE
+);
+
+CREATE INDEX idx_equ_unavail_equipment_from ON scheduling_equipment_unavailabilities (equipment_id, effective_from);
+CREATE INDEX idx_equ_unavail_clinic_from    ON scheduling_equipment_unavailabilities (clinic_id, effective_from);
+CREATE INDEX idx_equ_unavail_equipment_dow  ON scheduling_equipment_unavailabilities (equipment_id, recurring_day_of_week);
+
+CREATE TABLE scheduling_equipment_unavailability_exceptions (
+    id                      BIGINT       NOT NULL AUTO_INCREMENT,
+    unavailability_id       BIGINT       NOT NULL,
+    original_date           DATE         NOT NULL,
+    exception_type          VARCHAR(20)  NOT NULL,
+    rescheduled_date        DATE,
+    rescheduled_start_time  TIME,
+    rescheduled_end_time    TIME,
+    reason                  VARCHAR(500),
+    created_at              DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_equ_unavail_exc_parent FOREIGN KEY (unavailability_id)
+        REFERENCES scheduling_equipment_unavailabilities(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_equ_unavail_exc_parent_date
+    ON scheduling_equipment_unavailability_exceptions (unavailability_id, original_date);

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/EquipmentUnavailabilityRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/EquipmentUnavailabilityRecord.kt
@@ -1,0 +1,40 @@
+package io.bluetape4k.clinic.appointment.model.dto
+
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import java.io.Serializable
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class EquipmentUnavailabilityRecord(
+    val id: Long,
+    val equipmentId: Long,
+    val clinicId: Long,
+    val unavailableDate: LocalDate?,
+    val isRecurring: Boolean,
+    val recurringDayOfWeek: DayOfWeek?,
+    val effectiveFrom: LocalDate,
+    val effectiveUntil: LocalDate?,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val reason: String?,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+data class EquipmentUnavailabilityExceptionRecord(
+    val id: Long,
+    val unavailabilityId: Long,
+    val originalDate: LocalDate,
+    val exceptionType: ExceptionType,
+    val rescheduledDate: LocalDate?,
+    val rescheduledStartTime: LocalTime?,
+    val rescheduledEndTime: LocalTime?,
+    val reason: String?,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/UnavailablePeriod.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/UnavailablePeriod.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.clinic.appointment.model.dto
+
+import java.io.Serializable
+import java.time.LocalDate
+import java.time.LocalTime
+
+/** 반복 규칙에서 전개된 실제 사용불가 기간 */
+data class UnavailablePeriod(
+    val equipmentId: Long,
+    val date: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/tables/EquipmentUnavailabilities.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/tables/EquipmentUnavailabilities.kt
@@ -1,0 +1,26 @@
+package io.bluetape4k.clinic.appointment.model.tables
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.javatime.date
+import org.jetbrains.exposed.v1.javatime.time
+
+object EquipmentUnavailabilities : LongIdTable("scheduling_equipment_unavailabilities") {
+    val equipmentId = reference("equipment_id", Equipments, onDelete = ReferenceOption.CASCADE)
+    val clinicId    = reference("clinic_id", Clinics, onDelete = ReferenceOption.CASCADE)
+
+    val unavailableDate    = date("unavailable_date").nullable()
+    val isRecurring        = bool("is_recurring").default(false)
+    val recurringDayOfWeek = enumerationByName<java.time.DayOfWeek>("recurring_day_of_week", 10).nullable()
+    val effectiveFrom      = date("effective_from")
+    val effectiveUntil     = date("effective_until").nullable()
+    val startTime          = time("start_time")
+    val endTime            = time("end_time")
+    val reason             = varchar("reason", 500).nullable()
+
+    init {
+        index("idx_equ_unavail_equipment_from", false, equipmentId, effectiveFrom)
+        index("idx_equ_unavail_clinic_from", false, clinicId, effectiveFrom)
+        index("idx_equ_unavail_equipment_dow", false, equipmentId, recurringDayOfWeek)
+    }
+}

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/tables/EquipmentUnavailabilityExceptions.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/tables/EquipmentUnavailabilityExceptions.kt
@@ -1,0 +1,22 @@
+package io.bluetape4k.clinic.appointment.model.tables
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.javatime.date
+import org.jetbrains.exposed.v1.javatime.time
+
+enum class ExceptionType { SKIP, RESCHEDULE }
+
+object EquipmentUnavailabilityExceptions : LongIdTable("scheduling_equipment_unavailability_exceptions") {
+    val unavailabilityId       = reference("unavailability_id", EquipmentUnavailabilities, onDelete = ReferenceOption.CASCADE)
+    val originalDate           = date("original_date")
+    val exceptionType          = enumerationByName<ExceptionType>("exception_type", 20)
+    val rescheduledDate        = date("rescheduled_date").nullable()
+    val rescheduledStartTime   = time("rescheduled_start_time").nullable()
+    val rescheduledEndTime     = time("rescheduled_end_time").nullable()
+    val reason                 = varchar("reason", 500).nullable()
+
+    init {
+        index("idx_equ_unavail_exc_parent_date", false, unavailabilityId, originalDate)
+    }
+}

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentRepository.kt
@@ -3,9 +3,11 @@ package io.bluetape4k.clinic.appointment.repository
 import io.bluetape4k.exposed.jdbc.repository.LongJdbcRepository
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.clinic.appointment.model.dto.AppointmentRecord
+import io.bluetape4k.clinic.appointment.model.dto.UnavailablePeriod
 import io.bluetape4k.clinic.appointment.model.tables.Appointments
 import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
 import io.bluetape4k.support.requireNotNull
+import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
@@ -15,6 +17,7 @@ import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.less
 import org.jetbrains.exposed.v1.core.lessEq
 import org.jetbrains.exposed.v1.core.neq
+import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -188,6 +191,35 @@ class AppointmentRepository : LongJdbcRepository<AppointmentRecord> {
         Appointments.update(where = { Appointments.id eq appointmentId }) {
             it[status] = newStatus
         }
+
+    /**
+     * 특정 장비의 사용불가 기간과 겹치는 예약을 조회합니다.
+     *
+     * 취소 상태 예약은 제외합니다.
+     *
+     * @param equipmentId 장비 ID
+     * @param periods 사용불가 기간 목록
+     * @return 겹치는 예약 목록
+     */
+    fun findOverlappingByEquipment(
+        equipmentId: Long,
+        periods: List<UnavailablePeriod>,
+    ): List<AppointmentRecord> {
+        if (periods.isEmpty()) return emptyList()
+
+        val periodConditions = periods.map { period ->
+            (Appointments.appointmentDate eq period.date) and
+                (Appointments.startTime less period.endTime) and
+                (Appointments.endTime greater period.startTime)
+        }.reduce { acc, op -> acc or op }
+
+        return Appointments
+            .selectAll()
+            .where { Appointments.equipmentId eq equipmentId }
+            .andWhere { Appointments.status neq AppointmentState.CANCELLED }
+            .andWhere { periodConditions }
+            .map { it.toAppointmentRecord() }
+    }
 
     /**
      * 병원의 기간별 예약을 조회합니다.

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentUnavailabilityRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentUnavailabilityRepository.kt
@@ -1,0 +1,170 @@
+package io.bluetape4k.clinic.appointment.repository
+
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilities
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilityExceptions
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.requirePositiveNumber
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greaterEq
+import org.jetbrains.exposed.v1.core.isNull
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.jdbc.andWhere
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+class EquipmentUnavailabilityRepository {
+    companion object : KLogging()
+
+    fun create(
+        equipmentId: Long,
+        clinicId: Long,
+        unavailableDate: LocalDate?,
+        isRecurring: Boolean,
+        recurringDayOfWeek: DayOfWeek?,
+        effectiveFrom: LocalDate,
+        effectiveUntil: LocalDate?,
+        startTime: LocalTime,
+        endTime: LocalTime,
+        reason: String?,
+    ): EquipmentUnavailabilityRecord {
+        equipmentId.requirePositiveNumber("equipmentId")
+        clinicId.requirePositiveNumber("clinicId")
+
+        val id = EquipmentUnavailabilities.insert {
+            it[EquipmentUnavailabilities.equipmentId] = equipmentId
+            it[EquipmentUnavailabilities.clinicId] = clinicId
+            it[EquipmentUnavailabilities.unavailableDate] = unavailableDate
+            it[EquipmentUnavailabilities.isRecurring] = isRecurring
+            it[EquipmentUnavailabilities.recurringDayOfWeek] = recurringDayOfWeek
+            it[EquipmentUnavailabilities.effectiveFrom] = effectiveFrom
+            it[EquipmentUnavailabilities.effectiveUntil] = effectiveUntil
+            it[EquipmentUnavailabilities.startTime] = startTime
+            it[EquipmentUnavailabilities.endTime] = endTime
+            it[EquipmentUnavailabilities.reason] = reason
+        }[EquipmentUnavailabilities.id].value
+
+        log.debug { "Created EquipmentUnavailability id=$id for equipmentId=$equipmentId" }
+
+        return EquipmentUnavailabilityRecord(
+            id = id,
+            equipmentId = equipmentId,
+            clinicId = clinicId,
+            unavailableDate = unavailableDate,
+            isRecurring = isRecurring,
+            recurringDayOfWeek = recurringDayOfWeek,
+            effectiveFrom = effectiveFrom,
+            effectiveUntil = effectiveUntil,
+            startTime = startTime,
+            endTime = endTime,
+            reason = reason,
+        )
+    }
+
+    fun findById(id: Long): EquipmentUnavailabilityRecord? {
+        id.requirePositiveNumber("id")
+        return EquipmentUnavailabilities
+            .selectAll()
+            .where { EquipmentUnavailabilities.id eq id }
+            .map { it.toEquipmentUnavailabilityRecord() }
+            .firstOrNull()
+    }
+
+    fun findByEquipment(
+        equipmentId: Long,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<EquipmentUnavailabilityRecord> {
+        equipmentId.requirePositiveNumber("equipmentId")
+        return EquipmentUnavailabilities
+            .selectAll()
+            .where { EquipmentUnavailabilities.equipmentId eq equipmentId }
+            .andWhere { EquipmentUnavailabilities.effectiveFrom lessEq to }
+            .andWhere {
+                (EquipmentUnavailabilities.effectiveUntil.isNull()) or
+                    (EquipmentUnavailabilities.effectiveUntil greaterEq from)
+            }
+            .map { it.toEquipmentUnavailabilityRecord() }
+    }
+
+    fun findByClinicOnDate(
+        clinicId: Long,
+        date: LocalDate,
+    ): List<EquipmentUnavailabilityRecord> {
+        clinicId.requirePositiveNumber("clinicId")
+        return EquipmentUnavailabilities
+            .selectAll()
+            .where { EquipmentUnavailabilities.clinicId eq clinicId }
+            .andWhere { EquipmentUnavailabilities.effectiveFrom lessEq date }
+            .andWhere {
+                (EquipmentUnavailabilities.effectiveUntil.isNull()) or
+                    (EquipmentUnavailabilities.effectiveUntil greaterEq date)
+            }
+            .map { it.toEquipmentUnavailabilityRecord() }
+    }
+
+    fun delete(id: Long) {
+        id.requirePositiveNumber("id")
+        EquipmentUnavailabilities.deleteWhere { EquipmentUnavailabilities.id eq id }
+        log.debug { "Deleted EquipmentUnavailability id=$id" }
+    }
+
+    fun addException(
+        unavailabilityId: Long,
+        originalDate: LocalDate,
+        exceptionType: ExceptionType,
+        rescheduledDate: LocalDate?,
+        rescheduledStartTime: LocalTime?,
+        rescheduledEndTime: LocalTime?,
+        reason: String?,
+    ): EquipmentUnavailabilityExceptionRecord {
+        unavailabilityId.requirePositiveNumber("unavailabilityId")
+
+        val id = EquipmentUnavailabilityExceptions.insert {
+            it[EquipmentUnavailabilityExceptions.unavailabilityId] = unavailabilityId
+            it[EquipmentUnavailabilityExceptions.originalDate] = originalDate
+            it[EquipmentUnavailabilityExceptions.exceptionType] = exceptionType
+            it[EquipmentUnavailabilityExceptions.rescheduledDate] = rescheduledDate
+            it[EquipmentUnavailabilityExceptions.rescheduledStartTime] = rescheduledStartTime
+            it[EquipmentUnavailabilityExceptions.rescheduledEndTime] = rescheduledEndTime
+            it[EquipmentUnavailabilityExceptions.reason] = reason
+        }[EquipmentUnavailabilityExceptions.id].value
+
+        log.debug { "Added EquipmentUnavailabilityException id=$id for unavailabilityId=$unavailabilityId" }
+
+        return EquipmentUnavailabilityExceptionRecord(
+            id = id,
+            unavailabilityId = unavailabilityId,
+            originalDate = originalDate,
+            exceptionType = exceptionType,
+            rescheduledDate = rescheduledDate,
+            rescheduledStartTime = rescheduledStartTime,
+            rescheduledEndTime = rescheduledEndTime,
+            reason = reason,
+        )
+    }
+
+    fun findExceptions(unavailabilityId: Long): List<EquipmentUnavailabilityExceptionRecord> {
+        unavailabilityId.requirePositiveNumber("unavailabilityId")
+        return EquipmentUnavailabilityExceptions
+            .selectAll()
+            .where { EquipmentUnavailabilityExceptions.unavailabilityId eq unavailabilityId }
+            .map { it.toEquipmentUnavailabilityExceptionRecord() }
+    }
+
+    fun deleteException(exceptionId: Long) {
+        exceptionId.requirePositiveNumber("exceptionId")
+        EquipmentUnavailabilityExceptions.deleteWhere {
+            EquipmentUnavailabilityExceptions.id eq exceptionId
+        }
+        log.debug { "Deleted EquipmentUnavailabilityException id=$exceptionId" }
+    }
+}

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/RecordMappers.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/RecordMappers.kt
@@ -8,6 +8,8 @@ import io.bluetape4k.clinic.appointment.model.dto.ClinicRecord
 import io.bluetape4k.clinic.appointment.model.dto.DoctorAbsenceRecord
 import io.bluetape4k.clinic.appointment.model.dto.DoctorRecord
 import io.bluetape4k.clinic.appointment.model.dto.DoctorScheduleRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
 import io.bluetape4k.clinic.appointment.model.dto.HolidayRecord
 import io.bluetape4k.clinic.appointment.model.dto.OperatingHoursRecord
 import io.bluetape4k.clinic.appointment.model.dto.EquipmentRecord
@@ -15,6 +17,8 @@ import io.bluetape4k.clinic.appointment.model.dto.RescheduleCandidateRecord
 import io.bluetape4k.clinic.appointment.model.dto.TreatmentEquipmentRecord
 import io.bluetape4k.clinic.appointment.model.dto.TreatmentTypeRecord
 import io.bluetape4k.clinic.appointment.model.tables.Appointments
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilities
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilityExceptions
 import io.bluetape4k.clinic.appointment.model.tables.Equipments
 import io.bluetape4k.clinic.appointment.model.tables.TreatmentEquipments
 import io.bluetape4k.clinic.appointment.model.tables.BreakTimes
@@ -164,4 +168,29 @@ fun ResultRow.toRescheduleCandidateRecord() = RescheduleCandidateRecord(
     priority = this[RescheduleCandidates.priority],
     selected = this[RescheduleCandidates.selected],
     createdAt = this[RescheduleCandidates.createdAt],
+)
+
+fun ResultRow.toEquipmentUnavailabilityRecord() = EquipmentUnavailabilityRecord(
+    id = this[EquipmentUnavailabilities.id].value,
+    equipmentId = this[EquipmentUnavailabilities.equipmentId].value,
+    clinicId = this[EquipmentUnavailabilities.clinicId].value,
+    unavailableDate = this[EquipmentUnavailabilities.unavailableDate],
+    isRecurring = this[EquipmentUnavailabilities.isRecurring],
+    recurringDayOfWeek = this[EquipmentUnavailabilities.recurringDayOfWeek],
+    effectiveFrom = this[EquipmentUnavailabilities.effectiveFrom],
+    effectiveUntil = this[EquipmentUnavailabilities.effectiveUntil],
+    startTime = this[EquipmentUnavailabilities.startTime],
+    endTime = this[EquipmentUnavailabilities.endTime],
+    reason = this[EquipmentUnavailabilities.reason],
+)
+
+fun ResultRow.toEquipmentUnavailabilityExceptionRecord() = EquipmentUnavailabilityExceptionRecord(
+    id = this[EquipmentUnavailabilityExceptions.id].value,
+    unavailabilityId = this[EquipmentUnavailabilityExceptions.unavailabilityId].value,
+    originalDate = this[EquipmentUnavailabilityExceptions.originalDate],
+    exceptionType = this[EquipmentUnavailabilityExceptions.exceptionType],
+    rescheduledDate = this[EquipmentUnavailabilityExceptions.rescheduledDate],
+    rescheduledStartTime = this[EquipmentUnavailabilityExceptions.rescheduledStartTime],
+    rescheduledEndTime = this[EquipmentUnavailabilityExceptions.rescheduledEndTime],
+    reason = this[EquipmentUnavailabilityExceptions.reason],
 )

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt
@@ -1,9 +1,11 @@
 package io.bluetape4k.clinic.appointment.service
 
+import io.bluetape4k.clinic.appointment.model.dto.AppointmentRecord
 import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
 import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
 import io.bluetape4k.clinic.appointment.model.dto.UnavailablePeriod
 import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
 import io.bluetape4k.clinic.appointment.repository.EquipmentUnavailabilityRepository
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
@@ -20,6 +22,7 @@ import java.time.LocalTime
  */
 class EquipmentUnavailabilityService(
     private val repo: EquipmentUnavailabilityRepository = EquipmentUnavailabilityRepository(),
+    private val appointmentRepository: AppointmentRepository = AppointmentRepository(),
 ) {
     companion object : KLogging()
 
@@ -138,6 +141,70 @@ class EquipmentUnavailabilityService(
                         UnavailabilityExpander.expand(rule, exceptions, date..date)
                     }
                 }
+        }
+    }
+
+    /**
+     * 등록된 사용불가 스케줄과 충돌하는 기존 예약을 감지합니다.
+     *
+     * @param unavailabilityId 장비 사용불가 스케줄 ID
+     * @return 충돌하는 예약 목록
+     */
+    fun detectConflicts(unavailabilityId: Long): List<AppointmentRecord> {
+        unavailabilityId.requirePositiveNumber("unavailabilityId")
+        return transaction {
+            val record = repo.findById(unavailabilityId)
+                ?: return@transaction emptyList()
+            val exceptions = repo.findExceptions(unavailabilityId)
+            val rangeEnd = record.effectiveUntil ?: record.effectiveFrom.plusYears(1)
+            val periods = UnavailabilityExpander.expand(record, exceptions, record.effectiveFrom..rangeEnd)
+            log.debug { "Detecting conflicts for unavailabilityId=$unavailabilityId, periods=${periods.size}" }
+            appointmentRepository.findOverlappingByEquipment(record.equipmentId, periods)
+        }
+    }
+
+    /**
+     * 새로운 사용불가 스케줄 등록 전 충돌 미리보기.
+     *
+     * @param equipmentId 장비 ID
+     * @param unavailableDate 사용불가 날짜 (isRecurring=false 시 필수)
+     * @param isRecurring 반복 여부
+     * @param recurringDayOfWeek 반복 요일 (isRecurring=true 시 필수)
+     * @param effectiveFrom 유효 시작일
+     * @param effectiveUntil 유효 종료일
+     * @param startTime 사용불가 시작 시간
+     * @param endTime 사용불가 종료 시간
+     * @return 충돌하는 예약 목록
+     */
+    fun previewConflicts(
+        equipmentId: Long,
+        unavailableDate: LocalDate?,
+        isRecurring: Boolean,
+        recurringDayOfWeek: DayOfWeek?,
+        effectiveFrom: LocalDate,
+        effectiveUntil: LocalDate?,
+        startTime: LocalTime,
+        endTime: LocalTime,
+    ): List<AppointmentRecord> {
+        equipmentId.requirePositiveNumber("equipmentId")
+        val tempRecord = EquipmentUnavailabilityRecord(
+            id = 0L,
+            equipmentId = equipmentId,
+            clinicId = 0L,
+            unavailableDate = unavailableDate,
+            isRecurring = isRecurring,
+            recurringDayOfWeek = recurringDayOfWeek,
+            effectiveFrom = effectiveFrom,
+            effectiveUntil = effectiveUntil,
+            startTime = startTime,
+            endTime = endTime,
+            reason = null,
+        )
+        val rangeEnd = effectiveUntil ?: effectiveFrom.plusYears(1)
+        val periods = UnavailabilityExpander.expand(tempRecord, emptyList(), effectiveFrom..rangeEnd)
+        log.debug { "Previewing conflicts for equipmentId=$equipmentId, periods=${periods.size}" }
+        return transaction {
+            appointmentRepository.findOverlappingByEquipment(equipmentId, periods)
         }
     }
 }

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt
@@ -35,6 +35,17 @@ class EquipmentUnavailabilityService(
         endTime: LocalTime,
         reason: String?,
     ): EquipmentUnavailabilityRecord = transaction {
+        equipmentId.requirePositiveNumber("equipmentId")
+        clinicId.requirePositiveNumber("clinicId")
+        check(startTime < endTime) { "startTime must be before endTime: $startTime >= $endTime" }
+        if (!isRecurring) {
+            checkNotNull(unavailableDate) { "unavailableDate is required for non-recurring rules" }
+        } else {
+            checkNotNull(recurringDayOfWeek) { "recurringDayOfWeek is required for recurring rules" }
+        }
+        effectiveUntil?.let { until ->
+            check(effectiveFrom <= until) { "effectiveFrom must be <= effectiveUntil: $effectiveFrom > $until" }
+        }
         log.debug { "Creating EquipmentUnavailability for equipmentId=$equipmentId, clinicId=$clinicId" }
         repo.create(
             equipmentId = equipmentId,
@@ -103,10 +114,12 @@ class EquipmentUnavailabilityService(
         to: LocalDate,
     ): List<UnavailablePeriod> {
         equipmentId.requirePositiveNumber("equipmentId")
-        val rules = transaction { repo.findByEquipment(equipmentId, from, to) }
-        return rules.flatMap { rule ->
-            val exceptions = transaction { repo.findExceptions(rule.id) }
-            UnavailabilityExpander.expand(rule, exceptions, from..to)
+        return transaction {
+            val rules = repo.findByEquipment(equipmentId, from, to)
+            rules.flatMap { rule ->
+                val exceptions = repo.findExceptions(rule.id)
+                UnavailabilityExpander.expand(rule, exceptions, from..to)
+            }
         }
     }
 
@@ -115,14 +128,16 @@ class EquipmentUnavailabilityService(
         date: LocalDate,
     ): Map<Long, List<UnavailablePeriod>> {
         clinicId.requirePositiveNumber("clinicId")
-        val rules = transaction { repo.findByClinicOnDate(clinicId, date) }
-        return rules
-            .groupBy { it.equipmentId }
-            .mapValues { (_, ruleList) ->
-                ruleList.flatMap { rule ->
-                    val exceptions = transaction { repo.findExceptions(rule.id) }
-                    UnavailabilityExpander.expand(rule, exceptions, date..date)
+        return transaction {
+            val rules = repo.findByClinicOnDate(clinicId, date)
+            rules
+                .groupBy { it.equipmentId }
+                .mapValues { (_, ruleList) ->
+                    ruleList.flatMap { rule ->
+                        val exceptions = repo.findExceptions(rule.id)
+                        UnavailabilityExpander.expand(rule, exceptions, date..date)
+                    }
                 }
-            }
+        }
     }
 }

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt
@@ -9,6 +9,7 @@ import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
 import io.bluetape4k.clinic.appointment.repository.EquipmentUnavailabilityRepository
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.support.requireNotNull
 import io.bluetape4k.support.requirePositiveNumber
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import java.time.DayOfWeek
@@ -42,9 +43,9 @@ class EquipmentUnavailabilityService(
         clinicId.requirePositiveNumber("clinicId")
         check(startTime < endTime) { "startTime must be before endTime: $startTime >= $endTime" }
         if (!isRecurring) {
-            checkNotNull(unavailableDate) { "unavailableDate is required for non-recurring rules" }
+            unavailableDate.requireNotNull("unavailableDate")
         } else {
-            checkNotNull(recurringDayOfWeek) { "recurringDayOfWeek is required for recurring rules" }
+            recurringDayOfWeek.requireNotNull("recurringDayOfWeek")
         }
         effectiveUntil?.let { until ->
             check(effectiveFrom <= until) { "effectiveFrom must be <= effectiveUntil: $effectiveFrom > $until" }

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt
@@ -1,0 +1,128 @@
+package io.bluetape4k.clinic.appointment.service
+
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
+import io.bluetape4k.clinic.appointment.model.dto.UnavailablePeriod
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import io.bluetape4k.clinic.appointment.repository.EquipmentUnavailabilityRepository
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.requirePositiveNumber
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 장비 사용불가 기간을 관리하는 서비스.
+ *
+ * JDBC Exposed 트랜잭션을 사용하며, Spring Bean이 아닌 일반 클래스입니다.
+ */
+class EquipmentUnavailabilityService(
+    private val repo: EquipmentUnavailabilityRepository = EquipmentUnavailabilityRepository(),
+) {
+    companion object : KLogging()
+
+    fun create(
+        equipmentId: Long,
+        clinicId: Long,
+        unavailableDate: LocalDate?,
+        isRecurring: Boolean,
+        recurringDayOfWeek: DayOfWeek?,
+        effectiveFrom: LocalDate,
+        effectiveUntil: LocalDate?,
+        startTime: LocalTime,
+        endTime: LocalTime,
+        reason: String?,
+    ): EquipmentUnavailabilityRecord = transaction {
+        log.debug { "Creating EquipmentUnavailability for equipmentId=$equipmentId, clinicId=$clinicId" }
+        repo.create(
+            equipmentId = equipmentId,
+            clinicId = clinicId,
+            unavailableDate = unavailableDate,
+            isRecurring = isRecurring,
+            recurringDayOfWeek = recurringDayOfWeek,
+            effectiveFrom = effectiveFrom,
+            effectiveUntil = effectiveUntil,
+            startTime = startTime,
+            endTime = endTime,
+            reason = reason,
+        )
+    }
+
+    fun findById(id: Long): EquipmentUnavailabilityRecord? = transaction {
+        id.requirePositiveNumber("id")
+        repo.findById(id)
+    }
+
+    fun findUnavailabilityRecords(
+        equipmentId: Long,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<EquipmentUnavailabilityRecord> = transaction {
+        equipmentId.requirePositiveNumber("equipmentId")
+        repo.findByEquipment(equipmentId, from, to)
+    }
+
+    fun delete(id: Long) = transaction {
+        id.requirePositiveNumber("id")
+        log.debug { "Deleting EquipmentUnavailability id=$id" }
+        repo.delete(id)
+    }
+
+    fun addException(
+        unavailabilityId: Long,
+        originalDate: LocalDate,
+        exceptionType: ExceptionType,
+        rescheduledDate: LocalDate?,
+        rescheduledStartTime: LocalTime?,
+        rescheduledEndTime: LocalTime?,
+        reason: String?,
+    ): EquipmentUnavailabilityExceptionRecord = transaction {
+        log.debug { "Adding exception for unavailabilityId=$unavailabilityId, date=$originalDate, type=$exceptionType" }
+        repo.addException(
+            unavailabilityId = unavailabilityId,
+            originalDate = originalDate,
+            exceptionType = exceptionType,
+            rescheduledDate = rescheduledDate,
+            rescheduledStartTime = rescheduledStartTime,
+            rescheduledEndTime = rescheduledEndTime,
+            reason = reason,
+        )
+    }
+
+    fun deleteException(exceptionId: Long) = transaction {
+        exceptionId.requirePositiveNumber("exceptionId")
+        log.debug { "Deleting EquipmentUnavailabilityException id=$exceptionId" }
+        repo.deleteException(exceptionId)
+    }
+
+    fun findUnavailablePeriodsInRange(
+        equipmentId: Long,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<UnavailablePeriod> {
+        equipmentId.requirePositiveNumber("equipmentId")
+        val rules = transaction { repo.findByEquipment(equipmentId, from, to) }
+        return rules.flatMap { rule ->
+            val exceptions = transaction { repo.findExceptions(rule.id) }
+            UnavailabilityExpander.expand(rule, exceptions, from..to)
+        }
+    }
+
+    fun findUnavailableOnDate(
+        clinicId: Long,
+        date: LocalDate,
+    ): Map<Long, List<UnavailablePeriod>> {
+        clinicId.requirePositiveNumber("clinicId")
+        val rules = transaction { repo.findByClinicOnDate(clinicId, date) }
+        return rules
+            .groupBy { it.equipmentId }
+            .mapValues { (_, ruleList) ->
+                ruleList.flatMap { rule ->
+                    val exceptions = transaction { repo.findExceptions(rule.id) }
+                    UnavailabilityExpander.expand(rule, exceptions, date..date)
+                }
+            }
+    }
+}

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationService.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.clinic.appointment.service
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.clinic.appointment.model.dto.UnavailablePeriod
 import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
 import io.bluetape4k.clinic.appointment.repository.ClinicRepository
 import io.bluetape4k.clinic.appointment.repository.DoctorRepository
@@ -24,6 +25,7 @@ class SlotCalculationService(
     private val treatmentTypeRepository: TreatmentTypeRepository = TreatmentTypeRepository(),
     private val appointmentRepository: AppointmentRepository = AppointmentRepository(),
     private val holidayRepository: HolidayRepository = HolidayRepository(),
+    private val equipmentUnavailabilityService: EquipmentUnavailabilityService = EquipmentUnavailabilityService(),
 ) {
     companion object: KLogging()
 
@@ -147,6 +149,14 @@ class SlotCalculationService(
 
             val equipmentQuantities = treatmentTypeRepository.findEquipmentQuantities(requiredEquipment)
 
+            // 장비 사용불가 기간 조회 (진료 유형이 장비를 필요로 하는 경우)
+            val equipmentUnavailablePeriods: List<UnavailablePeriod> =
+                if (treatment.requiresEquipment && requiredEquipment.isNotEmpty()) {
+                    equipmentUnavailabilityService.findUnavailableOnDate(query.clinicId, query.date)
+                        .filterKeys { it in requiredEquipment }
+                        .values.flatten()
+                } else emptyList()
+
             // Process each candidate slot
             val availableSlots = mutableListOf<AvailableSlot>()
             for (candidate in slotCandidates) {
@@ -157,6 +167,12 @@ class SlotCalculationService(
 
                 // 13. Filter slots where existing count < maxConcurrent
                 if (overlappingCount >= maxConcurrent) continue
+
+                // 장비 사용불가 시간과 겹치는 슬롯 제외
+                val blockedByEquipment = equipmentUnavailablePeriods.any { unavail ->
+                    candidate.start < unavail.endTime && unavail.startTime < candidate.end
+                }
+                if (blockedByEquipment) continue
 
                 // 14-15. Check equipment availability
                 val availableEquipmentIds = if (treatment.requiresEquipment && requiredEquipment.isNotEmpty()) {

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/UnavailabilityExpander.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/UnavailabilityExpander.kt
@@ -1,0 +1,82 @@
+package io.bluetape4k.clinic.appointment.service
+
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
+import io.bluetape4k.clinic.appointment.model.dto.UnavailablePeriod
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import java.time.LocalDate
+import java.time.temporal.TemporalAdjusters
+
+object UnavailabilityExpander {
+
+    fun expand(
+        rule: EquipmentUnavailabilityRecord,
+        exceptions: List<EquipmentUnavailabilityExceptionRecord>,
+        range: ClosedRange<LocalDate>,
+    ): List<UnavailablePeriod> {
+        val skipDates = exceptions
+            .filter { it.exceptionType == ExceptionType.SKIP }
+            .map { it.originalDate }
+            .toSet()
+
+        val rescheduleMap = exceptions
+            .filter { it.exceptionType == ExceptionType.RESCHEDULE }
+            .associateBy { it.originalDate }
+
+        return if (!rule.isRecurring) {
+            expandOneTime(rule, range, skipDates, rescheduleMap)
+        } else {
+            expandRecurring(rule, range, skipDates, rescheduleMap)
+        }
+    }
+
+    private fun expandOneTime(
+        rule: EquipmentUnavailabilityRecord,
+        range: ClosedRange<LocalDate>,
+        skipDates: Set<LocalDate>,
+        rescheduleMap: Map<LocalDate, EquipmentUnavailabilityExceptionRecord>,
+    ): List<UnavailablePeriod> {
+        val date = rule.unavailableDate ?: return emptyList()
+        if (date !in range || date in skipDates) return emptyList()
+
+        val rescheduled = rescheduleMap[date]
+        return listOf(
+            UnavailablePeriod(
+                equipmentId = rule.equipmentId,
+                date        = rescheduled?.rescheduledDate ?: date,
+                startTime   = rescheduled?.rescheduledStartTime ?: rule.startTime,
+                endTime     = rescheduled?.rescheduledEndTime ?: rule.endTime,
+            )
+        )
+    }
+
+    private fun expandRecurring(
+        rule: EquipmentUnavailabilityRecord,
+        range: ClosedRange<LocalDate>,
+        skipDates: Set<LocalDate>,
+        rescheduleMap: Map<LocalDate, EquipmentUnavailabilityExceptionRecord>,
+    ): List<UnavailablePeriod> {
+        val dow = rule.recurringDayOfWeek ?: return emptyList()
+        val effectiveStart = maxOf(rule.effectiveFrom, range.start)
+        val effectiveEnd   = rule.effectiveUntil?.let { minOf(it, range.endInclusive) } ?: range.endInclusive
+
+        val result = mutableListOf<UnavailablePeriod>()
+        var current = effectiveStart.with(TemporalAdjusters.nextOrSame(dow))
+
+        while (!current.isAfter(effectiveEnd)) {
+            if (current !in skipDates) {
+                val rescheduled = rescheduleMap[current]
+                result.add(
+                    UnavailablePeriod(
+                        equipmentId = rule.equipmentId,
+                        date        = rescheduled?.rescheduledDate ?: current,
+                        startTime   = rescheduled?.rescheduledStartTime ?: rule.startTime,
+                        endTime     = rescheduled?.rescheduledEndTime ?: rule.endTime,
+                    )
+                )
+            }
+            current = current.plusWeeks(1)
+        }
+        return result
+    }
+}

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/model/tables/TableSchemaTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/model/tables/TableSchemaTest.kt
@@ -18,6 +18,8 @@ class TableSchemaTest {
             DoctorSchedules,
             DoctorAbsences,
             Equipments,
+            EquipmentUnavailabilities,
+            EquipmentUnavailabilityExceptions,
             TreatmentTypes,
             TreatmentEquipments,
             ConsultationTopics,

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentUnavailabilityRepositoryTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentUnavailabilityRepositoryTest.kt
@@ -1,0 +1,326 @@
+package io.bluetape4k.clinic.appointment.repository
+
+import io.bluetape4k.clinic.appointment.model.tables.Clinics
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilityExceptions
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilities
+import io.bluetape4k.clinic.appointment.model.tables.Equipments
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeNull
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+class EquipmentUnavailabilityRepositoryTest {
+
+    companion object {
+        private lateinit var db: Database
+        private val repo = EquipmentUnavailabilityRepository()
+
+        private val allTables = arrayOf(
+            Clinics,
+            Equipments,
+            EquipmentUnavailabilities,
+            EquipmentUnavailabilityExceptions,
+        )
+
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            db = Database.connect("jdbc:h2:mem:equip_unavail_test;DB_CLOSE_DELAY=-1", driver = "org.h2.Driver")
+            transaction {
+                SchemaUtils.create(*allTables)
+            }
+        }
+    }
+
+    private var clinicId: Long = 0L
+    private var equipmentId: Long = 0L
+
+    @BeforeEach
+    fun cleanUp() {
+        transaction {
+            EquipmentUnavailabilityExceptions.deleteAll()
+            EquipmentUnavailabilities.deleteAll()
+            Equipments.deleteAll()
+            Clinics.deleteAll()
+        }
+        transaction {
+            val newClinicId = Clinics.insert {
+                it[name] = "Test Clinic"
+                it[slotDurationMinutes] = 30
+                it[maxConcurrentPatients] = 1
+            }[Clinics.id].value
+
+            val newEquipmentId = Equipments.insert {
+                it[Equipments.clinicId] = newClinicId
+                it[name] = "MRI Machine"
+                it[usageDurationMinutes] = 60
+                it[quantity] = 1
+            }[Equipments.id].value
+
+            clinicId = newClinicId
+            equipmentId = newEquipmentId
+        }
+    }
+
+    @Test
+    fun `1 - 일회성 사용불가 저장 및 날짜 범위 조회`() {
+        val from = LocalDate.of(2026, 4, 1)
+        val to = LocalDate.of(2026, 4, 30)
+
+        val record = transaction {
+            repo.create(
+                equipmentId = equipmentId,
+                clinicId = clinicId,
+                unavailableDate = LocalDate.of(2026, 4, 10),
+                isRecurring = false,
+                recurringDayOfWeek = null,
+                effectiveFrom = LocalDate.of(2026, 4, 10),
+                effectiveUntil = LocalDate.of(2026, 4, 10),
+                startTime = LocalTime.of(10, 0),
+                endTime = LocalTime.of(12, 0),
+                reason = "정기점검",
+            )
+        }
+
+        record.id shouldBeEqualTo record.id
+        record.equipmentId shouldBeEqualTo equipmentId
+        record.isRecurring shouldBeEqualTo false
+
+        val results = transaction {
+            repo.findByEquipment(equipmentId, from, to)
+        }
+        results shouldHaveSize 1
+        results[0].unavailableDate shouldBeEqualTo LocalDate.of(2026, 4, 10)
+        results[0].reason shouldBeEqualTo "정기점검"
+    }
+
+    @Test
+    fun `2 - 반복 스케줄 저장 및 날짜 범위 포함 여부 확인`() {
+        val from = LocalDate.of(2026, 4, 1)
+        val to = LocalDate.of(2026, 4, 30)
+
+        transaction {
+            repo.create(
+                equipmentId = equipmentId,
+                clinicId = clinicId,
+                unavailableDate = null,
+                isRecurring = true,
+                recurringDayOfWeek = DayOfWeek.MONDAY,
+                effectiveFrom = LocalDate.of(2026, 3, 1),
+                effectiveUntil = LocalDate.of(2026, 12, 31),
+                startTime = LocalTime.of(8, 0),
+                endTime = LocalTime.of(9, 0),
+                reason = "주간 정비",
+            )
+        }
+
+        val results = transaction {
+            repo.findByEquipment(equipmentId, from, to)
+        }
+        results shouldHaveSize 1
+        results[0].isRecurring shouldBeEqualTo true
+        results[0].recurringDayOfWeek shouldBeEqualTo DayOfWeek.MONDAY
+    }
+
+    @Test
+    fun `3 - 예외 SKIP 추가 및 조회`() {
+        val unavailability = transaction {
+            repo.create(
+                equipmentId = equipmentId,
+                clinicId = clinicId,
+                unavailableDate = null,
+                isRecurring = true,
+                recurringDayOfWeek = DayOfWeek.WEDNESDAY,
+                effectiveFrom = LocalDate.of(2026, 1, 1),
+                effectiveUntil = null,
+                startTime = LocalTime.of(14, 0),
+                endTime = LocalTime.of(15, 0),
+                reason = null,
+            )
+        }
+
+        val exception = transaction {
+            repo.addException(
+                unavailabilityId = unavailability.id,
+                originalDate = LocalDate.of(2026, 4, 8),
+                exceptionType = ExceptionType.SKIP,
+                rescheduledDate = null,
+                rescheduledStartTime = null,
+                rescheduledEndTime = null,
+                reason = "공휴일",
+            )
+        }
+
+        exception.exceptionType shouldBeEqualTo ExceptionType.SKIP
+        exception.rescheduledDate.shouldBeNull()
+
+        val exceptions = transaction {
+            repo.findExceptions(unavailability.id)
+        }
+        exceptions shouldHaveSize 1
+        exceptions[0].originalDate shouldBeEqualTo LocalDate.of(2026, 4, 8)
+    }
+
+    @Test
+    fun `4 - 예외 RESCHEDULE 추가 및 조회`() {
+        val unavailability = transaction {
+            repo.create(
+                equipmentId = equipmentId,
+                clinicId = clinicId,
+                unavailableDate = null,
+                isRecurring = true,
+                recurringDayOfWeek = DayOfWeek.FRIDAY,
+                effectiveFrom = LocalDate.of(2026, 1, 1),
+                effectiveUntil = null,
+                startTime = LocalTime.of(9, 0),
+                endTime = LocalTime.of(10, 0),
+                reason = null,
+            )
+        }
+
+        val exception = transaction {
+            repo.addException(
+                unavailabilityId = unavailability.id,
+                originalDate = LocalDate.of(2026, 4, 10),
+                exceptionType = ExceptionType.RESCHEDULE,
+                rescheduledDate = LocalDate.of(2026, 4, 11),
+                rescheduledStartTime = LocalTime.of(10, 0),
+                rescheduledEndTime = LocalTime.of(11, 0),
+                reason = "일정 변경",
+            )
+        }
+
+        exception.exceptionType shouldBeEqualTo ExceptionType.RESCHEDULE
+        exception.rescheduledDate shouldBeEqualTo LocalDate.of(2026, 4, 11)
+        exception.rescheduledStartTime shouldBeEqualTo LocalTime.of(10, 0)
+
+        val exceptions = transaction {
+            repo.findExceptions(unavailability.id)
+        }
+        exceptions shouldHaveSize 1
+        exceptions[0].reason shouldBeEqualTo "일정 변경"
+    }
+
+    @Test
+    fun `5 - delete 후 조회 결과 없음`() {
+        val record = transaction {
+            repo.create(
+                equipmentId = equipmentId,
+                clinicId = clinicId,
+                unavailableDate = LocalDate.of(2026, 5, 1),
+                isRecurring = false,
+                recurringDayOfWeek = null,
+                effectiveFrom = LocalDate.of(2026, 5, 1),
+                effectiveUntil = LocalDate.of(2026, 5, 1),
+                startTime = LocalTime.of(9, 0),
+                endTime = LocalTime.of(10, 0),
+                reason = null,
+            )
+        }
+
+        transaction {
+            repo.delete(record.id)
+        }
+
+        val found = transaction {
+            repo.findById(record.id)
+        }
+        found.shouldBeNull()
+
+        val results = transaction {
+            repo.findByEquipment(equipmentId, LocalDate.of(2026, 5, 1), LocalDate.of(2026, 5, 31))
+        }
+        results shouldHaveSize 0
+    }
+
+    @Test
+    fun `findByClinicOnDate - 날짜 기준 병원 전체 장비 조회`() {
+        val date = LocalDate.of(2026, 4, 15)
+
+        transaction {
+            // date 범위 내
+            repo.create(
+                equipmentId = equipmentId,
+                clinicId = clinicId,
+                unavailableDate = date,
+                isRecurring = false,
+                recurringDayOfWeek = null,
+                effectiveFrom = date,
+                effectiveUntil = date,
+                startTime = LocalTime.of(11, 0),
+                endTime = LocalTime.of(12, 0),
+                reason = null,
+            )
+            // date 범위 외 (미래)
+            repo.create(
+                equipmentId = equipmentId,
+                clinicId = clinicId,
+                unavailableDate = null,
+                isRecurring = false,
+                recurringDayOfWeek = null,
+                effectiveFrom = date.plusDays(1),
+                effectiveUntil = null,
+                startTime = LocalTime.of(13, 0),
+                endTime = LocalTime.of(14, 0),
+                reason = null,
+            )
+        }
+
+        val results = transaction {
+            repo.findByClinicOnDate(clinicId, date)
+        }
+        results shouldHaveSize 1
+        results[0].clinicId shouldBeEqualTo clinicId
+    }
+
+    @Test
+    fun `deleteException - 예외 삭제 후 조회 결과 없음`() {
+        val unavailability = transaction {
+            repo.create(
+                equipmentId = equipmentId,
+                clinicId = clinicId,
+                unavailableDate = null,
+                isRecurring = true,
+                recurringDayOfWeek = DayOfWeek.TUESDAY,
+                effectiveFrom = LocalDate.of(2026, 1, 1),
+                effectiveUntil = null,
+                startTime = LocalTime.of(10, 0),
+                endTime = LocalTime.of(11, 0),
+                reason = null,
+            )
+        }
+
+        val exception = transaction {
+            repo.addException(
+                unavailabilityId = unavailability.id,
+                originalDate = LocalDate.of(2026, 4, 7),
+                exceptionType = ExceptionType.SKIP,
+                rescheduledDate = null,
+                rescheduledStartTime = null,
+                rescheduledEndTime = null,
+                reason = null,
+            )
+        }
+
+        transaction {
+            repo.deleteException(exception.id)
+        }
+
+        val exceptions = transaction {
+            repo.findExceptions(unavailability.id)
+        }
+        exceptions shouldHaveSize 0
+    }
+}

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentUnavailabilityRepositoryTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentUnavailabilityRepositoryTest.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilities
 import io.bluetape4k.clinic.appointment.model.tables.Equipments
 import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
 import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeGreaterThan
 import org.amshove.kluent.shouldBeNull
 import org.amshove.kluent.shouldHaveSize
 import org.amshove.kluent.shouldNotBeNull
@@ -49,6 +50,9 @@ class EquipmentUnavailabilityRepositoryTest {
 
     @BeforeEach
     fun cleanUp() {
+        transaction {
+            SchemaUtils.createMissingTablesAndColumns(*allTables)
+        }
         transaction {
             EquipmentUnavailabilityExceptions.deleteAll()
             EquipmentUnavailabilities.deleteAll()
@@ -94,7 +98,13 @@ class EquipmentUnavailabilityRepositoryTest {
             )
         }
 
-        record.id shouldBeEqualTo record.id
+        record.id shouldBeGreaterThan 0L
+
+        val found = transaction {
+            repo.findById(record.id)
+        }
+        found.shouldNotBeNull()
+        found.reason shouldBeEqualTo "정기점검"
         record.equipmentId shouldBeEqualTo equipmentId
         record.isRecurring shouldBeEqualTo false
 

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityServiceTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityServiceTest.kt
@@ -212,4 +212,49 @@ class EquipmentUnavailabilityServiceTest {
         periods shouldHaveSize 4
         periods.none { it.date == LocalDate.of(2026, 4, 8) } shouldBeEqualTo true
     }
+
+    @Test
+    fun `addException RESCHEDULE 후 findUnavailablePeriodsInRange에서 재스케줄됨`() {
+        // 매주 수요일 반복 (2026-04: 4/1, 4/8, 4/15, 4/22, 4/29 = 5회, 단 4/1은 수요일이 아님)
+        // 2026-04 수요일: 4/1, 4/8, 4/15, 4/22, 4/29
+        // 실제 수요일 확인 필요
+        val record = transaction {
+            service.create(
+                equipmentId = equipmentId,
+                clinicId = clinicId,
+                unavailableDate = null,
+                isRecurring = true,
+                recurringDayOfWeek = DayOfWeek.WEDNESDAY,
+                effectiveFrom = LocalDate.of(2026, 1, 1),
+                effectiveUntil = null,
+                startTime = LocalTime.of(14, 0),
+                endTime = LocalTime.of(15, 0),
+                reason = "정기 점검",
+            )
+        }
+
+        transaction {
+            service.addException(
+                unavailabilityId = record.id,
+                originalDate = LocalDate.of(2026, 4, 8),
+                exceptionType = ExceptionType.RESCHEDULE,
+                rescheduledDate = LocalDate.of(2026, 4, 9),
+                rescheduledStartTime = LocalTime.of(16, 0),
+                rescheduledEndTime = LocalTime.of(17, 0),
+                reason = "목요일로 이동",
+            )
+        }
+
+        val periods = transaction {
+            service.findUnavailablePeriodsInRange(
+                equipmentId = equipmentId,
+                from = LocalDate.of(2026, 4, 1),
+                to = LocalDate.of(2026, 4, 30),
+            )
+        }
+
+        // 4/8 없음, 4/9 16:00-17:00 포함
+        periods.none { it.date == LocalDate.of(2026, 4, 8) } shouldBeEqualTo true
+        periods.any { it.date == LocalDate.of(2026, 4, 9) && it.startTime == LocalTime.of(16, 0) } shouldBeEqualTo true
+    }
 }

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityServiceTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityServiceTest.kt
@@ -1,0 +1,215 @@
+package io.bluetape4k.clinic.appointment.service
+
+import io.bluetape4k.clinic.appointment.model.tables.Clinics
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilityExceptions
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilities
+import io.bluetape4k.clinic.appointment.model.tables.Equipments
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeNull
+import org.amshove.kluent.shouldHaveSize
+import org.amshove.kluent.shouldNotBeNull
+import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+class EquipmentUnavailabilityServiceTest {
+
+    companion object {
+        private lateinit var db: Database
+        private val service = EquipmentUnavailabilityService()
+
+        private val allTables = arrayOf(
+            Clinics,
+            Equipments,
+            EquipmentUnavailabilities,
+            EquipmentUnavailabilityExceptions,
+        )
+
+        @JvmStatic
+        @BeforeAll
+        fun setup() {
+            db = Database.connect(
+                "jdbc:h2:mem:equip_unavail_svc_test;DB_CLOSE_DELAY=-1",
+                driver = "org.h2.Driver"
+            )
+            transaction {
+                SchemaUtils.create(*allTables)
+            }
+        }
+    }
+
+    private var clinicId: Long = 0L
+    private var equipmentId: Long = 0L
+
+    @BeforeEach
+    fun cleanUp() {
+        transaction {
+            SchemaUtils.createMissingTablesAndColumns(*allTables)
+        }
+        transaction {
+            EquipmentUnavailabilityExceptions.deleteAll()
+            EquipmentUnavailabilities.deleteAll()
+            Equipments.deleteAll()
+            Clinics.deleteAll()
+        }
+        transaction {
+            val newClinicId = Clinics.insert {
+                it[name] = "Test Clinic"
+                it[slotDurationMinutes] = 30
+                it[maxConcurrentPatients] = 1
+            }[Clinics.id].value
+
+            val newEquipmentId = Equipments.insert {
+                it[Equipments.clinicId] = newClinicId
+                it[name] = "MRI Machine"
+                it[usageDurationMinutes] = 60
+                it[quantity] = 1
+            }[Equipments.id].value
+
+            clinicId = newClinicId
+            equipmentId = newEquipmentId
+        }
+    }
+
+    @Test
+    fun `1 - create 후 findById로 조회`() {
+        val record = service.create(
+            equipmentId = equipmentId,
+            clinicId = clinicId,
+            unavailableDate = LocalDate.of(2026, 4, 10),
+            isRecurring = false,
+            recurringDayOfWeek = null,
+            effectiveFrom = LocalDate.of(2026, 4, 10),
+            effectiveUntil = LocalDate.of(2026, 4, 10),
+            startTime = LocalTime.of(10, 0),
+            endTime = LocalTime.of(12, 0),
+            reason = "정기점검",
+        )
+
+        val found = service.findById(record.id)
+        found.shouldNotBeNull()
+        found.id shouldBeEqualTo record.id
+        found.equipmentId shouldBeEqualTo equipmentId
+        found.reason shouldBeEqualTo "정기점검"
+        found.isRecurring shouldBeEqualTo false
+    }
+
+    @Test
+    fun `2 - findUnavailablePeriodsInRange - 반복 스케줄 4회 전개`() {
+        // 매주 월요일 반복 — 2026-04-01부터 2026-04-30은 월요일 4회 (4/6, 4/13, 4/20, 4/27)
+        service.create(
+            equipmentId = equipmentId,
+            clinicId = clinicId,
+            unavailableDate = null,
+            isRecurring = true,
+            recurringDayOfWeek = DayOfWeek.MONDAY,
+            effectiveFrom = LocalDate.of(2026, 3, 1),
+            effectiveUntil = LocalDate.of(2026, 12, 31),
+            startTime = LocalTime.of(8, 0),
+            endTime = LocalTime.of(9, 0),
+            reason = "주간 정비",
+        )
+
+        val periods = service.findUnavailablePeriodsInRange(
+            equipmentId = equipmentId,
+            from = LocalDate.of(2026, 4, 1),
+            to = LocalDate.of(2026, 4, 30),
+        )
+
+        periods shouldHaveSize 4
+        periods.all { it.equipmentId == equipmentId } shouldBeEqualTo true
+        periods.all { it.startTime == LocalTime.of(8, 0) } shouldBeEqualTo true
+    }
+
+    @Test
+    fun `3 - findUnavailableOnDate - 해당 날짜 장비 맵 반환`() {
+        val date = LocalDate.of(2026, 4, 15) // 수요일
+
+        service.create(
+            equipmentId = equipmentId,
+            clinicId = clinicId,
+            unavailableDate = date,
+            isRecurring = false,
+            recurringDayOfWeek = null,
+            effectiveFrom = date,
+            effectiveUntil = date,
+            startTime = LocalTime.of(11, 0),
+            endTime = LocalTime.of(12, 0),
+            reason = null,
+        )
+
+        val result = service.findUnavailableOnDate(clinicId, date)
+
+        result.shouldNotBeNull()
+        result.containsKey(equipmentId) shouldBeEqualTo true
+        result[equipmentId]!!.shouldHaveSize(1)
+        result[equipmentId]!![0].date shouldBeEqualTo date
+    }
+
+    @Test
+    fun `4 - delete 후 findById null`() {
+        val record = service.create(
+            equipmentId = equipmentId,
+            clinicId = clinicId,
+            unavailableDate = LocalDate.of(2026, 5, 1),
+            isRecurring = false,
+            recurringDayOfWeek = null,
+            effectiveFrom = LocalDate.of(2026, 5, 1),
+            effectiveUntil = LocalDate.of(2026, 5, 1),
+            startTime = LocalTime.of(9, 0),
+            endTime = LocalTime.of(10, 0),
+            reason = null,
+        )
+
+        service.delete(record.id)
+
+        service.findById(record.id).shouldBeNull()
+    }
+
+    @Test
+    fun `5 - addException SKIP 후 findUnavailablePeriodsInRange에서 제외됨`() {
+        // 매주 수요일 반복
+        val record = service.create(
+            equipmentId = equipmentId,
+            clinicId = clinicId,
+            unavailableDate = null,
+            isRecurring = true,
+            recurringDayOfWeek = DayOfWeek.WEDNESDAY,
+            effectiveFrom = LocalDate.of(2026, 1, 1),
+            effectiveUntil = null,
+            startTime = LocalTime.of(14, 0),
+            endTime = LocalTime.of(15, 0),
+            reason = null,
+        )
+
+        // 2026-04-01 ~ 2026-04-30 수요일: 4/1, 4/8, 4/15, 4/22, 4/29 (5회)
+        // 4/8을 SKIP 처리 → 4회만 반환되어야 함
+        service.addException(
+            unavailabilityId = record.id,
+            originalDate = LocalDate.of(2026, 4, 8),
+            exceptionType = ExceptionType.SKIP,
+            rescheduledDate = null,
+            rescheduledStartTime = null,
+            rescheduledEndTime = null,
+            reason = "공휴일",
+        )
+
+        val periods = service.findUnavailablePeriodsInRange(
+            equipmentId = equipmentId,
+            from = LocalDate.of(2026, 4, 1),
+            to = LocalDate.of(2026, 4, 30),
+        )
+
+        periods shouldHaveSize 4
+        periods.none { it.date == LocalDate.of(2026, 4, 8) } shouldBeEqualTo true
+    }
+}

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationServiceTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationServiceTest.kt
@@ -8,6 +8,8 @@ import io.bluetape4k.clinic.appointment.model.tables.ClinicClosures
 import io.bluetape4k.clinic.appointment.model.tables.ClinicDefaultBreakTimes
 import io.bluetape4k.clinic.appointment.model.tables.Clinics
 import io.bluetape4k.clinic.appointment.model.tables.ConsultationMethod
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilities
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilityExceptions
 import io.bluetape4k.clinic.appointment.model.tables.Holidays
 import io.bluetape4k.clinic.appointment.model.tables.DoctorAbsences
 import io.bluetape4k.clinic.appointment.model.tables.DoctorSchedules
@@ -67,7 +69,9 @@ class SlotCalculationServiceTest {
                     TreatmentEquipments,
                     ConsultationTopics,
                     Appointments,
-                    AppointmentNotes
+                    AppointmentNotes,
+                    EquipmentUnavailabilities,
+                    EquipmentUnavailabilityExceptions
                 )
             }
         }
@@ -76,6 +80,8 @@ class SlotCalculationServiceTest {
     @BeforeEach
     fun cleanUp() {
         transaction {
+            EquipmentUnavailabilityExceptions.deleteAll()
+            EquipmentUnavailabilities.deleteAll()
             AppointmentNotes.deleteAll()
             Appointments.deleteAll()
             TreatmentEquipments.deleteAll()
@@ -729,5 +735,91 @@ class SlotCalculationServiceTest {
         slots.none { it.startTime == LocalTime.of(12, 0) }.shouldBeTrue()
         slots.none { it.startTime == LocalTime.of(12, 30) }.shouldBeTrue()
         slots.none { it.startTime == LocalTime.of(15, 0) }.shouldBeTrue()
+    }
+
+    @Test
+    fun `22 - 장비 사용불가 시간과 겹치는 슬롯 제외`() {
+        val (clinicId, doctorId, treatmentTypeId) =
+            insertBaseData(requiresEquipment = true)
+
+        // 장비 추가 (quantity=1)
+        val equipmentId =
+            transaction {
+                val eqId =
+                    Equipments
+                        .insert {
+                            it[Equipments.clinicId] = clinicId
+                            it[name] = "MRI Machine"
+                            it[usageDurationMinutes] = 30
+                            it[quantity] = 1
+                        }[Equipments.id]
+                        .value
+
+                TreatmentEquipments.insert {
+                    it[TreatmentEquipments.treatmentTypeId] = treatmentTypeId
+                    it[TreatmentEquipments.equipmentId] = eqId
+                }
+
+                eqId
+            }
+
+        // 09:00~10:00 장비 사용불가 등록 (비반복, 당일)
+        transaction {
+            EquipmentUnavailabilities.insert {
+                it[EquipmentUnavailabilities.equipmentId] = equipmentId
+                it[EquipmentUnavailabilities.clinicId] = clinicId
+                it[unavailableDate] = MONDAY
+                it[isRecurring] = false
+                it[recurringDayOfWeek] = null
+                it[effectiveFrom] = MONDAY
+                it[effectiveUntil] = MONDAY
+                it[startTime] = LocalTime.of(9, 0)
+                it[endTime] = LocalTime.of(10, 0)
+                it[reason] = "점검"
+            }
+        }
+
+        val slots =
+            service.findAvailableSlots(
+                SlotQuery(clinicId, doctorId, treatmentTypeId, MONDAY)
+            )
+
+        // 09:00, 09:30 슬롯은 09:00~10:00 사용불가와 겹쳐서 제외 → 16개
+        slots shouldHaveSize 16
+        slots.none { it.startTime == LocalTime.of(9, 0) }.shouldBeTrue()
+        slots.none { it.startTime == LocalTime.of(9, 30) }.shouldBeTrue()
+        slots.any { it.startTime == LocalTime.of(10, 0) }.shouldBeTrue()
+    }
+
+    @Test
+    fun `23 - 장비 사용불가 없으면 모든 슬롯 정상 반환`() {
+        val (clinicId, doctorId, treatmentTypeId) =
+            insertBaseData(requiresEquipment = true)
+
+        // 장비 추가 (quantity=1), 사용불가 없음
+        transaction {
+            val eqId =
+                Equipments
+                    .insert {
+                        it[Equipments.clinicId] = clinicId
+                        it[name] = "Ultrasound Machine"
+                        it[usageDurationMinutes] = 30
+                        it[quantity] = 1
+                    }[Equipments.id]
+                    .value
+
+            TreatmentEquipments.insert {
+                it[TreatmentEquipments.treatmentTypeId] = treatmentTypeId
+                it[TreatmentEquipments.equipmentId] = eqId
+            }
+        }
+
+        val slots =
+            service.findAvailableSlots(
+                SlotQuery(clinicId, doctorId, treatmentTypeId, MONDAY)
+            )
+
+        // 사용불가 없으므로 18개 전부 반환
+        slots shouldHaveSize 18
     }
 }

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/UnavailabilityExpanderTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/UnavailabilityExpanderTest.kt
@@ -1,0 +1,166 @@
+package io.bluetape4k.clinic.appointment.service
+
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeEmpty
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldHaveSize
+import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+class UnavailabilityExpanderTest {
+
+    private val equipmentId = 1L
+    private val clinicId = 1L
+
+    // 2026-04-01(수) ~ 2026-04-30(목) — 화요일은 4/7, 4/14, 4/21, 4/28
+    private val april = LocalDate.of(2026, 4, 1)..LocalDate.of(2026, 4, 30)
+
+    private fun recurringRule(
+        effectiveFrom: LocalDate = LocalDate.of(2026, 1, 1),
+        effectiveUntil: LocalDate? = null,
+        dow: DayOfWeek = DayOfWeek.TUESDAY,
+        startTime: LocalTime = LocalTime.of(10, 0),
+        endTime: LocalTime = LocalTime.of(12, 0),
+    ) = EquipmentUnavailabilityRecord(
+        id = 1L,
+        equipmentId = equipmentId,
+        clinicId = clinicId,
+        unavailableDate = null,
+        isRecurring = true,
+        recurringDayOfWeek = dow,
+        effectiveFrom = effectiveFrom,
+        effectiveUntil = effectiveUntil,
+        startTime = startTime,
+        endTime = endTime,
+        reason = null,
+    )
+
+    private fun oneTimeRule(date: LocalDate) = EquipmentUnavailabilityRecord(
+        id = 2L,
+        equipmentId = equipmentId,
+        clinicId = clinicId,
+        unavailableDate = date,
+        isRecurring = false,
+        recurringDayOfWeek = null,
+        effectiveFrom = date,
+        effectiveUntil = date,
+        startTime = LocalTime.of(14, 0),
+        endTime = LocalTime.of(16, 0),
+        reason = null,
+    )
+
+    private fun skipException(originalDate: LocalDate) = EquipmentUnavailabilityExceptionRecord(
+        id = 100L,
+        unavailabilityId = 1L,
+        originalDate = originalDate,
+        exceptionType = ExceptionType.SKIP,
+        rescheduledDate = null,
+        rescheduledStartTime = null,
+        rescheduledEndTime = null,
+        reason = null,
+    )
+
+    private fun rescheduleException(
+        originalDate: LocalDate,
+        rescheduledDate: LocalDate,
+        rescheduledStart: LocalTime,
+        rescheduledEnd: LocalTime,
+    ) = EquipmentUnavailabilityExceptionRecord(
+        id = 200L,
+        unavailabilityId = 1L,
+        originalDate = originalDate,
+        exceptionType = ExceptionType.RESCHEDULE,
+        rescheduledDate = rescheduledDate,
+        rescheduledStartTime = rescheduledStart,
+        rescheduledEndTime = rescheduledEnd,
+        reason = null,
+    )
+
+    @Test
+    fun `1 - 반복 규칙 예외 없이 해당 요일만 전개 — 4월 화요일 4회`() {
+        val rule = recurringRule()
+        val result = UnavailabilityExpander.expand(rule, emptyList<EquipmentUnavailabilityExceptionRecord>(), april)
+
+        result shouldHaveSize 4
+        result.map { it.date } shouldBeEqualTo listOf(
+            LocalDate.of(2026, 4, 7),
+            LocalDate.of(2026, 4, 14),
+            LocalDate.of(2026, 4, 21),
+            LocalDate.of(2026, 4, 28),
+        )
+        result.all { period -> period.equipmentId == equipmentId }.shouldBeTrue()
+        result.all { period -> period.startTime == LocalTime.of(10, 0) }.shouldBeTrue()
+        result.all { period -> period.endTime == LocalTime.of(12, 0) }.shouldBeTrue()
+    }
+
+    @Test
+    fun `2 - SKIP 예외 — 4월 14일 제외하여 3회 반환`() {
+        val rule = recurringRule()
+        val exceptions = listOf(skipException(LocalDate.of(2026, 4, 14)))
+        val result = UnavailabilityExpander.expand(rule, exceptions, april)
+
+        result shouldHaveSize 3
+        result.map { period -> period.date } shouldBeEqualTo listOf(
+            LocalDate.of(2026, 4, 7),
+            LocalDate.of(2026, 4, 21),
+            LocalDate.of(2026, 4, 28),
+        )
+    }
+
+    @Test
+    fun `3 - RESCHEDULE 예외 — 4월 7일을 4월 8일 09 00 ~ 11 00로 변경`() {
+        val rule = recurringRule()
+        val exceptions = listOf(
+            rescheduleException(
+                originalDate = LocalDate.of(2026, 4, 7),
+                rescheduledDate = LocalDate.of(2026, 4, 8),
+                rescheduledStart = LocalTime.of(9, 0),
+                rescheduledEnd = LocalTime.of(11, 0),
+            )
+        )
+        val result = UnavailabilityExpander.expand(rule, exceptions, april)
+
+        result shouldHaveSize 4
+        val rescheduled = result.first { period -> period.date == LocalDate.of(2026, 4, 8) }
+        rescheduled.startTime shouldBeEqualTo LocalTime.of(9, 0)
+        rescheduled.endTime shouldBeEqualTo LocalTime.of(11, 0)
+    }
+
+    @Test
+    fun `4 - 일회성 규칙 — 해당 날짜만 반환`() {
+        val date = LocalDate.of(2026, 4, 15)
+        val rule = oneTimeRule(date)
+        val result = UnavailabilityExpander.expand(rule, emptyList<EquipmentUnavailabilityExceptionRecord>(), april)
+
+        result shouldHaveSize 1
+        result[0].date shouldBeEqualTo date
+        result[0].startTime shouldBeEqualTo LocalTime.of(14, 0)
+        result[0].endTime shouldBeEqualTo LocalTime.of(16, 0)
+    }
+
+    @Test
+    fun `5 - 일회성 규칙 — 날짜가 range 밖이면 emptyList 반환`() {
+        val date = LocalDate.of(2026, 5, 5)
+        val rule = oneTimeRule(date)
+        val result = UnavailabilityExpander.expand(rule, emptyList<EquipmentUnavailabilityExceptionRecord>(), april)
+
+        result.shouldBeEmpty()
+    }
+
+    @Test
+    fun `6 - effectiveUntil로 반복 종료 — effectiveUntil 2026-04-14이면 2회`() {
+        val rule = recurringRule(effectiveUntil = LocalDate.of(2026, 4, 14))
+        val result = UnavailabilityExpander.expand(rule, emptyList<EquipmentUnavailabilityExceptionRecord>(), april)
+
+        result shouldHaveSize 2
+        result.map { period -> period.date } shouldBeEqualTo listOf(
+            LocalDate.of(2026, 4, 7),
+            LocalDate.of(2026, 4, 14),
+        )
+    }
+}

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/AppointmentConstraintProvider.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/AppointmentConstraintProvider.kt
@@ -7,7 +7,7 @@ import ai.timefold.solver.core.api.score.stream.ConstraintProvider
 /**
  * 예약 스케줄링의 모든 제약 조건을 조합하는 ConstraintProvider.
  *
- * Hard Constraints (H1~H10): 위반 시 해가 무효
+ * Hard Constraints (H1~H11): 위반 시 해가 무효
  * Soft Constraints (S1~S6): 최적화 목표
  */
 class AppointmentConstraintProvider : ConstraintProvider {
@@ -25,6 +25,7 @@ class AppointmentConstraintProvider : ConstraintProvider {
         HardConstraints.equipmentAvailability(factory),
         HardConstraints.providerTypeMatch(factory),
         HardConstraints.doctorBelongsToClinic(factory),
+        HardConstraints.equipmentUnavailabilityConflict(factory),
 
         // Soft Constraints
         SoftConstraints.doctorLoadBalance(factory),

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/HardConstraints.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/HardConstraints.kt
@@ -332,14 +332,14 @@ object HardConstraints {
             }
             .join(
                 EquipmentUnavailabilityFact::class.java,
-                Joiners.equal({ appt -> appt.equipmentId }, { fact -> fact.equipmentId }),
+                Joiners.equal({ appt -> appt.equipmentId!! }, { fact -> fact.equipmentId }),
                 Joiners.equal({ appt -> appt.appointmentDate }, { fact -> fact.date }),
             )
             .filter { appt, fact ->
                 appt.startTime!! < fact.endTime && fact.startTime < appt.endTime!!
             }
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H11: equipment-unavailability-conflict")
+            .asConstraint("H11: equipmentUnavailabilityConflict")
 
     /**
      * 3-level cascade로 maxConcurrent 값을 결정합니다.

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/HardConstraints.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/HardConstraints.kt
@@ -15,6 +15,7 @@ import io.bluetape4k.clinic.appointment.solver.domain.AppointmentPlanning
 import io.bluetape4k.clinic.appointment.solver.domain.ClinicFact
 import io.bluetape4k.clinic.appointment.solver.domain.DoctorFact
 import io.bluetape4k.clinic.appointment.solver.domain.EquipmentFact
+import io.bluetape4k.clinic.appointment.solver.domain.EquipmentUnavailabilityFact
 import io.bluetape4k.clinic.appointment.solver.domain.TreatmentFact
 
 /**
@@ -320,6 +321,25 @@ object HardConstraints {
             }
             .penalize(HardSoftScore.ONE_HARD)
             .asConstraint("H10: doctorBelongsToClinic")
+
+    // ----------------------------------------------------------------
+    // H11: 장비 사용불가 기간 중 예약 배정 금지
+    // ----------------------------------------------------------------
+    fun equipmentUnavailabilityConflict(factory: ConstraintFactory): Constraint =
+        factory.forEach(AppointmentPlanning::class.java)
+            .filter { appt ->
+                appt.requiresEquipment && appt.equipmentId != null && appt.appointmentDate != null && appt.startTime != null
+            }
+            .join(
+                EquipmentUnavailabilityFact::class.java,
+                Joiners.equal({ appt -> appt.equipmentId }, { fact -> fact.equipmentId }),
+                Joiners.equal({ appt -> appt.appointmentDate }, { fact -> fact.date }),
+            )
+            .filter { appt, fact ->
+                appt.startTime!! < fact.endTime && fact.startTime < appt.endTime!!
+            }
+            .penalize(HardSoftScore.ONE_HARD)
+            .asConstraint("H11: equipment-unavailability-conflict")
 
     /**
      * 3-level cascade로 maxConcurrent 값을 결정합니다.

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/converter/SolutionConverter.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/converter/SolutionConverter.kt
@@ -19,6 +19,7 @@ import io.bluetape4k.clinic.appointment.solver.domain.AppointmentPlanning
 import io.bluetape4k.clinic.appointment.solver.domain.ClinicFact
 import io.bluetape4k.clinic.appointment.solver.domain.DoctorFact
 import io.bluetape4k.clinic.appointment.solver.domain.EquipmentFact
+import io.bluetape4k.clinic.appointment.solver.domain.EquipmentUnavailabilityFact
 import io.bluetape4k.clinic.appointment.solver.domain.ScheduleSolution
 import io.bluetape4k.clinic.appointment.solver.domain.TreatmentFact
 import io.bluetape4k.clinic.appointment.solver.domain.generateTimeSlots
@@ -49,6 +50,7 @@ object SolutionConverter: KLogging() {
         closures: List<ClinicClosureRecord>,
         holidays: List<HolidayRecord>,
         treatmentEquipments: List<TreatmentEquipmentRecord>,
+        equipmentUnavailabilities: List<EquipmentUnavailabilityFact> = emptyList(),
         dateRange: ClosedRange<LocalDate>,
     ): ScheduleSolution {
         val clinicFact = clinic.toClinicFact()
@@ -99,6 +101,7 @@ object SolutionConverter: KLogging() {
             closures = closures,
             holidays = holidays,
             treatmentEquipments = treatmentEquipments,
+            equipmentUnavailabilities = equipmentUnavailabilities,
             doctorIds = doctorFacts.map { it.id },
             dateRange = dates,
             timeSlots = timeSlots,

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/EquipmentUnavailabilityFact.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/EquipmentUnavailabilityFact.kt
@@ -1,0 +1,22 @@
+package io.bluetape4k.clinic.appointment.solver.domain
+
+import java.io.Serializable
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 장비 사용불가 기간을 나타내는 Solver ProblemFact.
+ *
+ * [ScheduleSolution]에 [ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty]로 등록되어
+ * Hard Constraint H11에서 참조됩니다.
+ */
+data class EquipmentUnavailabilityFact(
+    val equipmentId: Long,
+    val date: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/ScheduleSolution.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/ScheduleSolution.kt
@@ -15,6 +15,7 @@ import io.bluetape4k.clinic.appointment.model.dto.DoctorScheduleRecord
 import io.bluetape4k.clinic.appointment.model.dto.HolidayRecord
 import io.bluetape4k.clinic.appointment.model.dto.OperatingHoursRecord
 import io.bluetape4k.clinic.appointment.model.dto.TreatmentEquipmentRecord
+import io.bluetape4k.clinic.appointment.solver.domain.EquipmentUnavailabilityFact
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -62,6 +63,9 @@ class ScheduleSolution(
 
     @field:ProblemFactCollectionProperty
     val treatmentEquipments: List<TreatmentEquipmentRecord> = emptyList(),
+
+    @field:ProblemFactCollectionProperty
+    val equipmentUnavailabilities: List<EquipmentUnavailabilityFact> = emptyList(),
 
     // --- Value Range Providers ---
 

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -152,6 +152,8 @@ object Libs {
     val bluetape4k_exposed_jdbc_redisson = bluetape4k("exposed-jdbc-redisson")
     val bluetape4k_exposed_jdbc_tests = bluetape4k("exposed-jdbc-tests")
     val bluetape4k_exposed_r2dbc = bluetape4k("exposed-r2dbc")
+    val bluetape4k_exposed_r2dbc_lettuce = bluetape4k("exposed-r2dbc-lettuce")
+    val bluetape4k_exposed_r2dbc_redisson = bluetape4k("exposed-r2dbc-redisson")
     val bluetape4k_exposed_r2dbc_tests = bluetape4k("exposed-r2dbc-tests")
     val bluetape4k_exposed_measured = bluetape4k("exposed-measured")
     val bluetape4k_exposed_mysql8 = bluetape4k("exposed-mysql8")
@@ -164,6 +166,7 @@ object Libs {
 
     val bluetape4k_jdbc = bluetape4k("jdbc")
     val bluetape4k_mongodb = bluetape4k("mongodb")
+    val bluetape4k_r2dbc = bluetape4k("r2dbc")
 
     // Infrastructure
     val bluetape4k_bucket4j = bluetape4k("bucket4j")
@@ -183,13 +186,21 @@ object Libs {
     // Spring Boot 3
     val bluetape4k_spring_boot3_cassandra = bluetape4k("spring-boot3-cassandra")
     val bluetape4k_spring_boot3_core = bluetape4k("spring-boot3-core")
+    val bluetape4k_spring_boot3_exposed_jdbc = bluetape4k("spring-boot3-exposed-jdbc")
+    val bluetape4k_spring_boot3_exposed_r2dbc = bluetape4k("spring-boot3-exposed-r2dbc")
+    val bluetape4k_spring_boot3_hibernate_lettuce = bluetape4k("spring-boot3-hibernate-lettuce")
     val bluetape4k_spring_boot3_mongodb = bluetape4k("spring-boot3-mongodb")
+    val bluetape4k_spring_boot3_r2dbc = bluetape4k("spring-boot3-r2dbc")
     val bluetape4k_spring_boot3_redis = bluetape4k("spring-boot3-redis")
 
     // Spring Boot 4
     val bluetape4k_spring_boot4_cassandra = bluetape4k("spring-boot4-cassandra")
     val bluetape4k_spring_boot4_core = bluetape4k("spring-boot4-core")
+    val bluetape4k_spring_boot4_exposed_jdbc = bluetape4k("spring-boot4-exposed-jdbc")
+    val bluetape4k_spring_boot4_exposed_r2dbc = bluetape4k("spring-boot4-exposed-r2dbc")
+    val bluetape4k_spring_boot4_hibernate_lettuce = bluetape4k("spring-boot4-hibernate-lettuce")
     val bluetape4k_spring_boot4_mongodb = bluetape4k("spring-boot4-mongodb")
+    val bluetape4k_spring_boot4_r2dbc = bluetape4k("spring-boot4-r2dbc")
     val bluetape4k_spring_boot4_redis = bluetape4k("spring-boot4-redis")
 
     // AWS

--- a/buildSrc/src/main/kotlin/Libs.kt
+++ b/buildSrc/src/main/kotlin/Libs.kt
@@ -39,7 +39,7 @@ object Plugins {
 object Versions {
 
     // Java 21, Kotlin 2.3 이상에서 사용하세요
-    const val bluetape4k = "1.5.0-SNAPSHOT"    // https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
+    const val bluetape4k = "1.5.0-Beta3"    // https://mvnrepository.com/artifact/io.github.bluetape4k/bluetape4k-bom
 
     const val kotlin = "2.3.20"                 // https://mvnrepository.com/artifact/org.jetbrains.kotlin/kotlin-stdlib
     const val kotlinx_coroutines = "1.10.2"     // https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core

--- a/docs/superpowers/plans/2026-03-30-equipment-schedule-plan.md
+++ b/docs/superpowers/plans/2026-03-30-equipment-schedule-plan.md
@@ -1,0 +1,1620 @@
+# 장비 스케줄 관리 구현 계획
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+>
+> **MANDATORY:** Apply `bluetape4k-patterns` skill on ALL Kotlin code. No exceptions.
+
+**Goal:** 의료 장비 사용불가 기간(일회성+반복+예외)을 관리하고, 슬롯 계산과 Timefold Solver에 반영하여 장비 충돌 예약을 방지한다.
+
+**Architecture:** `appointment-core`에 ORM 테이블·DTO·Repository·Service를 추가하고, `appointment-solver`의 ProblemFact·HardConstraint·SolutionConverter를 확장하며, `appointment-api`에 Flyway 마이그레이션과 REST Controller를 추가한다.
+
+**Tech Stack:** Kotlin 2.3, Exposed ORM v1, Timefold Solver, Spring Boot 4, JUnit 5 + Kotest + MockK
+
+---
+
+## 파일 맵
+
+### 신규 생성
+
+| 파일 | 역할 |
+|------|------|
+| `appointment-api/src/main/resources/db/migration/V2__add_equipment_unavailabilities.sql` | 장비 사용불가 테이블 DDL |
+| `appointment-core/.../model/tables/EquipmentUnavailabilities.kt` | Exposed ORM 테이블 정의 |
+| `appointment-core/.../model/tables/EquipmentUnavailabilityExceptions.kt` | 반복 예외 테이블 정의 |
+| `appointment-core/.../model/dto/EquipmentUnavailabilityRecord.kt` | 장비 사용불가 DTO |
+| `appointment-core/.../model/dto/EquipmentUnavailabilityExceptionRecord.kt` | 예외 DTO |
+| `appointment-core/.../model/dto/UnavailablePeriod.kt` | 전개된 사용불가 기간 DTO |
+| `appointment-core/.../repository/EquipmentUnavailabilityRepository.kt` | DB CRUD |
+| `appointment-core/.../service/UnavailabilityExpander.kt` | 반복 규칙 전개 로직 |
+| `appointment-core/.../service/EquipmentUnavailabilityService.kt` | 비즈니스 로직 + 충돌 감지 |
+| `appointment-solver/.../solver/domain/EquipmentUnavailabilityFact.kt` | Solver ProblemFact |
+| `appointment-api/.../api/dto/request/CreateEquipmentUnavailabilityRequest.kt` | API 요청 DTO |
+| `appointment-api/.../api/dto/request/UpdateEquipmentUnavailabilityRequest.kt` | API 수정 DTO |
+| `appointment-api/.../api/dto/request/UnavailabilityExceptionRequest.kt` | 예외 등록 DTO |
+| `appointment-api/.../api/dto/response/UnavailabilityConflictResponse.kt` | 충돌 응답 DTO |
+| `appointment-api/.../api/controller/EquipmentUnavailabilityController.kt` | REST Controller |
+| 각 Task별 테스트 파일 | JUnit 5 + Kotest |
+
+### 수정
+
+| 파일 | 변경 내용 |
+|------|---------|
+| `appointment-core/.../service/SlotCalculationService.kt` | 장비 사용불가 체크 단계 추가 (7번과 8번 사이) |
+| `appointment-solver/.../solver/domain/ScheduleSolution.kt` | `equipmentUnavailabilities` ProblemFact 추가 |
+| `appointment-solver/.../solver/constraint/HardConstraints.kt` | H11 `equipmentUnavailabilityConflict` 추가 |
+| `appointment-solver/.../solver/constraint/AppointmentConstraintProvider.kt` | H11 등록 |
+| `appointment-solver/.../solver/converter/SolutionConverter.kt` | `EquipmentUnavailabilityFact` 목록 populate |
+
+---
+
+## Task 1: Flyway 마이그레이션 SQL
+
+**Files:**
+- Create: `appointment-api/src/main/resources/db/migration/V2__add_equipment_unavailabilities.sql`
+
+- [ ] **Step 1: SQL 파일 작성**
+
+```sql
+-- V2__add_equipment_unavailabilities.sql
+
+CREATE TABLE scheduling_equipment_unavailabilities (
+    id                   BIGINT       NOT NULL AUTO_INCREMENT,
+    equipment_id         BIGINT       NOT NULL,
+    clinic_id            BIGINT       NOT NULL,
+    unavailable_date     DATE,
+    is_recurring         BOOLEAN      NOT NULL DEFAULT FALSE,
+    recurring_day_of_week VARCHAR(10),
+    effective_from       DATE         NOT NULL,
+    effective_until      DATE,
+    start_time           TIME         NOT NULL,
+    end_time             TIME         NOT NULL,
+    reason               VARCHAR(500),
+    created_at           DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    updated_at           DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_equ_unavail_equipment FOREIGN KEY (equipment_id) REFERENCES scheduling_equipments(id) ON DELETE CASCADE,
+    CONSTRAINT fk_equ_unavail_clinic    FOREIGN KEY (clinic_id)    REFERENCES scheduling_clinics(id)    ON DELETE CASCADE
+);
+
+CREATE INDEX idx_equ_unavail_equipment_from ON scheduling_equipment_unavailabilities (equipment_id, effective_from);
+CREATE INDEX idx_equ_unavail_clinic_from    ON scheduling_equipment_unavailabilities (clinic_id, effective_from);
+CREATE INDEX idx_equ_unavail_equipment_dow  ON scheduling_equipment_unavailabilities (equipment_id, recurring_day_of_week);
+
+CREATE TABLE scheduling_equipment_unavailability_exceptions (
+    id                      BIGINT       NOT NULL AUTO_INCREMENT,
+    unavailability_id       BIGINT       NOT NULL,
+    original_date           DATE         NOT NULL,
+    exception_type          VARCHAR(20)  NOT NULL,
+    rescheduled_date        DATE,
+    rescheduled_start_time  TIME,
+    rescheduled_end_time    TIME,
+    reason                  VARCHAR(500),
+    created_at              DATETIME(6)  NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    PRIMARY KEY (id),
+    CONSTRAINT fk_equ_unavail_exc_parent FOREIGN KEY (unavailability_id)
+        REFERENCES scheduling_equipment_unavailabilities(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_equ_unavail_exc_parent_date
+    ON scheduling_equipment_unavailability_exceptions (unavailability_id, original_date);
+```
+
+- [ ] **Step 2: 빌드로 마이그레이션 검증**
+
+```bash
+./gradlew :appointment-api:test --tests "*.TableSchemaTest" -i
+```
+Expected: `PASS` (Flyway가 V2 적용)
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add appointment-api/src/main/resources/db/migration/V2__add_equipment_unavailabilities.sql
+git commit -m "chore: 장비 사용불가 스케줄 Flyway 마이그레이션 추가"
+```
+
+---
+
+## Task 2: Exposed ORM 테이블 정의
+
+**Files:**
+- Create: `appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/tables/EquipmentUnavailabilities.kt`
+- Create: `appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/tables/EquipmentUnavailabilityExceptions.kt`
+
+- [ ] **Step 1: `EquipmentUnavailabilities.kt` 작성**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.model.tables
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.javatime.date
+import org.jetbrains.exposed.v1.javatime.time
+
+object EquipmentUnavailabilities : LongIdTable("scheduling_equipment_unavailabilities") {
+    val equipmentId = reference("equipment_id", Equipments, onDelete = ReferenceOption.CASCADE)
+    val clinicId    = reference("clinic_id", Clinics, onDelete = ReferenceOption.CASCADE)
+
+    val unavailableDate    = date("unavailable_date").nullable()
+    val isRecurring        = bool("is_recurring").default(false)
+    val recurringDayOfWeek = enumerationByName<java.time.DayOfWeek>("recurring_day_of_week", 10).nullable()
+    val effectiveFrom      = date("effective_from")
+    val effectiveUntil     = date("effective_until").nullable()
+    val startTime          = time("start_time")
+    val endTime            = time("end_time")
+    val reason             = varchar("reason", 500).nullable()
+
+    init {
+        index("idx_equ_unavail_equipment_from", false, equipmentId, effectiveFrom)
+        index("idx_equ_unavail_clinic_from", false, clinicId, effectiveFrom)
+        index("idx_equ_unavail_equipment_dow", false, equipmentId, recurringDayOfWeek)
+    }
+}
+```
+
+- [ ] **Step 2: `EquipmentUnavailabilityExceptions.kt` 작성**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.model.tables
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.dao.id.LongIdTable
+import org.jetbrains.exposed.v1.javatime.date
+import org.jetbrains.exposed.v1.javatime.time
+
+enum class ExceptionType { SKIP, RESCHEDULE }
+
+object EquipmentUnavailabilityExceptions : LongIdTable("scheduling_equipment_unavailability_exceptions") {
+    val unavailabilityId       = reference("unavailability_id", EquipmentUnavailabilities, onDelete = ReferenceOption.CASCADE)
+    val originalDate           = date("original_date")
+    val exceptionType          = enumerationByName<ExceptionType>("exception_type", 20)
+    val rescheduledDate        = date("rescheduled_date").nullable()
+    val rescheduledStartTime   = time("rescheduled_start_time").nullable()
+    val rescheduledEndTime     = time("rescheduled_end_time").nullable()
+    val reason                 = varchar("reason", 500).nullable()
+
+    init {
+        index("idx_equ_unavail_exc_parent_date", false, unavailabilityId, originalDate)
+    }
+}
+```
+
+- [ ] **Step 3: 스키마 테스트 추가**
+
+파일: `appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/model/tables/TableSchemaTest.kt`
+기존 테스트 파일에 두 테이블을 추가한다.
+
+```kotlin
+// TableSchemaTest.kt 내 기존 allTables 리스트에 추가
+EquipmentUnavailabilities,
+EquipmentUnavailabilityExceptions,
+```
+
+- [ ] **Step 4: 테스트 실행**
+
+```bash
+./gradlew :appointment-core:test --tests "*.TableSchemaTest" -i
+```
+Expected: `PASS`
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/tables/EquipmentUnavailabilities.kt
+git add appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/tables/EquipmentUnavailabilityExceptions.kt
+git add appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/model/tables/TableSchemaTest.kt
+git commit -m "feat: EquipmentUnavailabilities, EquipmentUnavailabilityExceptions Exposed 테이블 추가"
+```
+
+---
+
+## Task 3: DTO 정의
+
+**Files:**
+- Create: `appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/EquipmentUnavailabilityRecord.kt`
+- Create: `appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/EquipmentUnavailabilityExceptionRecord.kt`
+- Create: `appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/UnavailablePeriod.kt`
+
+- [ ] **Step 1: `EquipmentUnavailabilityRecord.kt` 작성**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.model.dto
+
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import java.io.Serializable
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class EquipmentUnavailabilityRecord(
+    val id: Long,
+    val equipmentId: Long,
+    val clinicId: Long,
+    val unavailableDate: LocalDate?,
+    val isRecurring: Boolean,
+    val recurringDayOfWeek: DayOfWeek?,
+    val effectiveFrom: LocalDate,
+    val effectiveUntil: LocalDate?,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val reason: String?,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+data class EquipmentUnavailabilityExceptionRecord(
+    val id: Long,
+    val unavailabilityId: Long,
+    val originalDate: LocalDate,
+    val exceptionType: ExceptionType,
+    val rescheduledDate: LocalDate?,
+    val rescheduledStartTime: LocalTime?,
+    val rescheduledEndTime: LocalTime?,
+    val reason: String?,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+```
+
+- [ ] **Step 2: `UnavailablePeriod.kt` 작성**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.model.dto
+
+import java.io.Serializable
+import java.time.LocalDate
+import java.time.LocalTime
+
+/** 반복 규칙에서 전개된 실제 사용불가 기간 */
+data class UnavailablePeriod(
+    val equipmentId: Long,
+    val date: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+```
+
+- [ ] **Step 3: 커밋**
+
+```bash
+git add appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/EquipmentUnavailabilityRecord.kt
+git add appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/UnavailablePeriod.kt
+git commit -m "feat: EquipmentUnavailability DTO 추가 (Serializable)"
+```
+
+---
+
+## Task 4: Repository
+
+**Files:**
+- Create: `appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentUnavailabilityRepository.kt`
+- Test: `appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentUnavailabilityRepositoryTest.kt`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.repository
+
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilities
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilityExceptions
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldBeTrue
+import org.amshove.kluent.shouldHaveSize
+import org.jetbrains.exposed.v1.core.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+class EquipmentUnavailabilityRepositoryTest {
+    private val repo = EquipmentUnavailabilityRepository()
+
+    @BeforeEach
+    fun setup() {
+        transaction {
+            SchemaUtils.createMissingTablesAndColumns(
+                EquipmentUnavailabilities,
+                EquipmentUnavailabilityExceptions,
+            )
+            EquipmentUnavailabilityExceptions.deleteAll()
+            EquipmentUnavailabilities.deleteAll()
+        }
+    }
+
+    @Test
+    fun `일회성 사용불가 저장 및 날짜 범위 조회`() {
+        val record = transaction {
+            repo.create(
+                equipmentId = 1L,
+                clinicId = 1L,
+                unavailableDate = LocalDate.of(2026, 4, 1),
+                isRecurring = false,
+                recurringDayOfWeek = null,
+                effectiveFrom = LocalDate.of(2026, 4, 1),
+                effectiveUntil = LocalDate.of(2026, 4, 1),
+                startTime = LocalTime.of(9, 0),
+                endTime = LocalTime.of(12, 0),
+                reason = "유지보수",
+            )
+        }
+
+        val found = transaction {
+            repo.findByEquipment(
+                equipmentId = 1L,
+                from = LocalDate.of(2026, 4, 1),
+                to = LocalDate.of(2026, 4, 30),
+            )
+        }
+
+        found shouldHaveSize 1
+        found[0].reason shouldBeEqualTo "유지보수"
+    }
+
+    @Test
+    fun `반복 스케줄 + 예외 조회`() {
+        val ruleId = transaction {
+            repo.create(
+                equipmentId = 1L, clinicId = 1L,
+                unavailableDate = null,
+                isRecurring = true,
+                recurringDayOfWeek = DayOfWeek.TUESDAY,
+                effectiveFrom = LocalDate.of(2026, 4, 1),
+                effectiveUntil = null,
+                startTime = LocalTime.of(8, 0),
+                endTime = LocalTime.of(10, 0),
+                reason = "정기 점검",
+            ).id
+        }
+
+        transaction {
+            repo.addException(
+                unavailabilityId = ruleId,
+                originalDate = LocalDate.of(2026, 4, 7),
+                exceptionType = ExceptionType.SKIP,
+                rescheduledDate = null,
+                rescheduledStartTime = null,
+                rescheduledEndTime = null,
+                reason = "이번 주 건너뜀",
+            )
+        }
+
+        val exceptions = transaction { repo.findExceptions(ruleId) }
+        exceptions shouldHaveSize 1
+        exceptions[0].exceptionType shouldBeEqualTo ExceptionType.SKIP
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실행 — 실패 확인**
+
+```bash
+./gradlew :appointment-core:test --tests "*.EquipmentUnavailabilityRepositoryTest" -i
+```
+Expected: `FAIL` — `EquipmentUnavailabilityRepository` 미정의
+
+- [ ] **Step 3: Repository 구현**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.repository
+
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilities
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilityExceptions
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import io.bluetape4k.logging.KLogging
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+import org.jetbrains.exposed.v1.jdbc.deleteWhere
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+class EquipmentUnavailabilityRepository {
+
+    companion object : KLogging()
+
+    fun create(
+        equipmentId: Long,
+        clinicId: Long,
+        unavailableDate: LocalDate?,
+        isRecurring: Boolean,
+        recurringDayOfWeek: DayOfWeek?,
+        effectiveFrom: LocalDate,
+        effectiveUntil: LocalDate?,
+        startTime: LocalTime,
+        endTime: LocalTime,
+        reason: String?,
+    ): EquipmentUnavailabilityRecord {
+        equipmentId.requirePositiveNumber("equipmentId")
+        clinicId.requirePositiveNumber("clinicId")
+
+        val id = EquipmentUnavailabilities.insert {
+            it[EquipmentUnavailabilities.equipmentId] = equipmentId
+            it[EquipmentUnavailabilities.clinicId]    = clinicId
+            it[EquipmentUnavailabilities.unavailableDate] = unavailableDate
+            it[EquipmentUnavailabilities.isRecurring]     = isRecurring
+            it[EquipmentUnavailabilities.recurringDayOfWeek] = recurringDayOfWeek
+            it[EquipmentUnavailabilities.effectiveFrom]   = effectiveFrom
+            it[EquipmentUnavailabilities.effectiveUntil]  = effectiveUntil
+            it[EquipmentUnavailabilities.startTime]       = startTime
+            it[EquipmentUnavailabilities.endTime]         = endTime
+            it[EquipmentUnavailabilities.reason]          = reason
+        }[EquipmentUnavailabilities.id].value
+
+        return EquipmentUnavailabilityRecord(
+            id = id, equipmentId = equipmentId, clinicId = clinicId,
+            unavailableDate = unavailableDate, isRecurring = isRecurring,
+            recurringDayOfWeek = recurringDayOfWeek, effectiveFrom = effectiveFrom,
+            effectiveUntil = effectiveUntil, startTime = startTime,
+            endTime = endTime, reason = reason,
+        )
+    }
+
+    fun findByEquipment(equipmentId: Long, from: LocalDate, to: LocalDate): List<EquipmentUnavailabilityRecord> =
+        EquipmentUnavailabilities.selectAll()
+            .where {
+                (EquipmentUnavailabilities.equipmentId eq equipmentId) and
+                (EquipmentUnavailabilities.effectiveFrom lessEq to) and
+                (
+                    EquipmentUnavailabilities.effectiveUntil.isNull() or
+                    (EquipmentUnavailabilities.effectiveUntil greaterEq from)
+                )
+            }
+            .map { it.toEquipmentUnavailabilityRecord() }
+
+    fun findByClinicOnDate(clinicId: Long, date: LocalDate): List<EquipmentUnavailabilityRecord> =
+        EquipmentUnavailabilities.selectAll()
+            .where {
+                (EquipmentUnavailabilities.clinicId eq clinicId) and
+                (EquipmentUnavailabilities.effectiveFrom lessEq date) and
+                (
+                    EquipmentUnavailabilities.effectiveUntil.isNull() or
+                    (EquipmentUnavailabilities.effectiveUntil greaterEq date)
+                )
+            }
+            .map { it.toEquipmentUnavailabilityRecord() }
+
+    fun findById(id: Long): EquipmentUnavailabilityRecord? =
+        EquipmentUnavailabilities.selectAll()
+            .where { EquipmentUnavailabilities.id eq id }
+            .singleOrNull()
+            ?.toEquipmentUnavailabilityRecord()
+
+    fun delete(id: Long) {
+        EquipmentUnavailabilities.deleteWhere { EquipmentUnavailabilities.id eq id }
+    }
+
+    fun addException(
+        unavailabilityId: Long,
+        originalDate: LocalDate,
+        exceptionType: ExceptionType,
+        rescheduledDate: LocalDate?,
+        rescheduledStartTime: LocalTime?,
+        rescheduledEndTime: LocalTime?,
+        reason: String?,
+    ): EquipmentUnavailabilityExceptionRecord {
+        unavailabilityId.requirePositiveNumber("unavailabilityId")
+
+        val id = EquipmentUnavailabilityExceptions.insert {
+            it[EquipmentUnavailabilityExceptions.unavailabilityId]    = unavailabilityId
+            it[EquipmentUnavailabilityExceptions.originalDate]        = originalDate
+            it[EquipmentUnavailabilityExceptions.exceptionType]       = exceptionType
+            it[EquipmentUnavailabilityExceptions.rescheduledDate]     = rescheduledDate
+            it[EquipmentUnavailabilityExceptions.rescheduledStartTime] = rescheduledStartTime
+            it[EquipmentUnavailabilityExceptions.rescheduledEndTime]  = rescheduledEndTime
+            it[EquipmentUnavailabilityExceptions.reason]              = reason
+        }[EquipmentUnavailabilityExceptions.id].value
+
+        return EquipmentUnavailabilityExceptionRecord(
+            id = id, unavailabilityId = unavailabilityId, originalDate = originalDate,
+            exceptionType = exceptionType, rescheduledDate = rescheduledDate,
+            rescheduledStartTime = rescheduledStartTime, rescheduledEndTime = rescheduledEndTime,
+            reason = reason,
+        )
+    }
+
+    fun findExceptions(unavailabilityId: Long): List<EquipmentUnavailabilityExceptionRecord> =
+        EquipmentUnavailabilityExceptions.selectAll()
+            .where { EquipmentUnavailabilityExceptions.unavailabilityId eq unavailabilityId }
+            .map { it.toEquipmentUnavailabilityExceptionRecord() }
+
+    fun deleteException(exceptionId: Long) {
+        EquipmentUnavailabilityExceptions.deleteWhere { EquipmentUnavailabilityExceptions.id eq exceptionId }
+    }
+
+    // --- Result Row 확장 함수 (private) ---
+
+    private fun org.jetbrains.exposed.v1.core.ResultRow.toEquipmentUnavailabilityRecord() =
+        EquipmentUnavailabilityRecord(
+            id             = this[EquipmentUnavailabilities.id].value,
+            equipmentId    = this[EquipmentUnavailabilities.equipmentId].value,
+            clinicId       = this[EquipmentUnavailabilities.clinicId].value,
+            unavailableDate = this[EquipmentUnavailabilities.unavailableDate],
+            isRecurring    = this[EquipmentUnavailabilities.isRecurring],
+            recurringDayOfWeek = this[EquipmentUnavailabilities.recurringDayOfWeek],
+            effectiveFrom  = this[EquipmentUnavailabilities.effectiveFrom],
+            effectiveUntil = this[EquipmentUnavailabilities.effectiveUntil],
+            startTime      = this[EquipmentUnavailabilities.startTime],
+            endTime        = this[EquipmentUnavailabilities.endTime],
+            reason         = this[EquipmentUnavailabilities.reason],
+        )
+
+    private fun org.jetbrains.exposed.v1.core.ResultRow.toEquipmentUnavailabilityExceptionRecord() =
+        EquipmentUnavailabilityExceptionRecord(
+            id                = this[EquipmentUnavailabilityExceptions.id].value,
+            unavailabilityId  = this[EquipmentUnavailabilityExceptions.unavailabilityId].value,
+            originalDate      = this[EquipmentUnavailabilityExceptions.originalDate],
+            exceptionType     = this[EquipmentUnavailabilityExceptions.exceptionType],
+            rescheduledDate   = this[EquipmentUnavailabilityExceptions.rescheduledDate],
+            rescheduledStartTime = this[EquipmentUnavailabilityExceptions.rescheduledStartTime],
+            rescheduledEndTime   = this[EquipmentUnavailabilityExceptions.rescheduledEndTime],
+            reason            = this[EquipmentUnavailabilityExceptions.reason],
+        )
+}
+```
+
+- [ ] **Step 4: 테스트 실행 — 통과 확인**
+
+```bash
+./gradlew :appointment-core:test --tests "*.EquipmentUnavailabilityRepositoryTest" -i
+```
+Expected: `PASS`
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentUnavailabilityRepository.kt
+git add appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentUnavailabilityRepositoryTest.kt
+git commit -m "feat: EquipmentUnavailabilityRepository 추가 (CRUD + 예외 관리)"
+```
+
+---
+
+## Task 5: UnavailabilityExpander — 반복 규칙 전개
+
+**Files:**
+- Create: `appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/UnavailabilityExpander.kt`
+- Test: `appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/UnavailabilityExpanderTest.kt`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.service
+
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldHaveSize
+import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+class UnavailabilityExpanderTest {
+
+    private val baseRecurring = EquipmentUnavailabilityRecord(
+        id = 1L, equipmentId = 10L, clinicId = 1L,
+        unavailableDate = null,
+        isRecurring = true,
+        recurringDayOfWeek = DayOfWeek.TUESDAY,
+        effectiveFrom = LocalDate.of(2026, 4, 1),
+        effectiveUntil = null,
+        startTime = LocalTime.of(8, 0),
+        endTime = LocalTime.of(10, 0),
+        reason = "정기 점검",
+    )
+
+    @Test
+    fun `반복 규칙 — 예외 없이 해당 요일만 전개`() {
+        // 2026-04-01 ~ 2026-04-30: 화요일은 7, 14, 21, 28일
+        val periods = UnavailabilityExpander.expand(
+            rule = baseRecurring,
+            exceptions = emptyList(),
+            range = LocalDate.of(2026, 4, 1)..LocalDate.of(2026, 4, 30),
+        )
+
+        periods shouldHaveSize 4
+        periods.map { it.date } shouldBeEqualTo listOf(
+            LocalDate.of(2026, 4, 7),
+            LocalDate.of(2026, 4, 14),
+            LocalDate.of(2026, 4, 21),
+            LocalDate.of(2026, 4, 28),
+        )
+    }
+
+    @Test
+    fun `SKIP 예외 — 해당 날짜 제외`() {
+        val skipException = EquipmentUnavailabilityExceptionRecord(
+            id = 1L, unavailabilityId = 1L,
+            originalDate = LocalDate.of(2026, 4, 14),
+            exceptionType = ExceptionType.SKIP,
+            rescheduledDate = null, rescheduledStartTime = null, rescheduledEndTime = null,
+            reason = "이번 주 건너뜀",
+        )
+
+        val periods = UnavailabilityExpander.expand(
+            rule = baseRecurring,
+            exceptions = listOf(skipException),
+            range = LocalDate.of(2026, 4, 1)..LocalDate.of(2026, 4, 30),
+        )
+
+        periods shouldHaveSize 3
+        periods.none { it.date == LocalDate.of(2026, 4, 14) }.let { assert(it) }
+    }
+
+    @Test
+    fun `RESCHEDULE 예외 — 날짜와 시간 변경`() {
+        val rescheduleException = EquipmentUnavailabilityExceptionRecord(
+            id = 1L, unavailabilityId = 1L,
+            originalDate = LocalDate.of(2026, 4, 7),
+            exceptionType = ExceptionType.RESCHEDULE,
+            rescheduledDate = LocalDate.of(2026, 4, 8),
+            rescheduledStartTime = LocalTime.of(9, 0),
+            rescheduledEndTime = LocalTime.of(11, 0),
+            reason = "수요일로 변경",
+        )
+
+        val periods = UnavailabilityExpander.expand(
+            rule = baseRecurring,
+            exceptions = listOf(rescheduleException),
+            range = LocalDate.of(2026, 4, 1)..LocalDate.of(2026, 4, 30),
+        )
+
+        periods shouldHaveSize 4
+        val changed = periods.first { it.date == LocalDate.of(2026, 4, 8) }
+        changed.startTime shouldBeEqualTo LocalTime.of(9, 0)
+    }
+
+    @Test
+    fun `일회성 규칙 — 해당 날짜만 반환`() {
+        val oneTime = EquipmentUnavailabilityRecord(
+            id = 2L, equipmentId = 10L, clinicId = 1L,
+            unavailableDate = LocalDate.of(2026, 4, 15),
+            isRecurring = false,
+            recurringDayOfWeek = null,
+            effectiveFrom = LocalDate.of(2026, 4, 15),
+            effectiveUntil = LocalDate.of(2026, 4, 15),
+            startTime = LocalTime.of(9, 0),
+            endTime = LocalTime.of(12, 0),
+            reason = "긴급 수리",
+        )
+
+        val periods = UnavailabilityExpander.expand(
+            rule = oneTime,
+            exceptions = emptyList(),
+            range = LocalDate.of(2026, 4, 1)..LocalDate.of(2026, 4, 30),
+        )
+
+        periods shouldHaveSize 1
+        periods[0].date shouldBeEqualTo LocalDate.of(2026, 4, 15)
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실행 — 실패 확인**
+
+```bash
+./gradlew :appointment-core:test --tests "*.UnavailabilityExpanderTest" -i
+```
+Expected: `FAIL`
+
+- [ ] **Step 3: UnavailabilityExpander 구현**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.service
+
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
+import io.bluetape4k.clinic.appointment.model.dto.UnavailablePeriod
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+
+object UnavailabilityExpander {
+
+    /**
+     * 반복/일회성 규칙을 주어진 날짜 범위 내 [UnavailablePeriod] 목록으로 전개합니다.
+     *
+     * - 일회성: [EquipmentUnavailabilityRecord.unavailableDate]가 범위 내에 있으면 단건 반환
+     * - 반복: [EquipmentUnavailabilityRecord.recurringDayOfWeek] 요일에 해당하는 모든 날짜 열거
+     * - SKIP 예외: 해당 날짜 제외
+     * - RESCHEDULE 예외: 날짜/시간을 변경된 값으로 대체
+     */
+    fun expand(
+        rule: EquipmentUnavailabilityRecord,
+        exceptions: List<EquipmentUnavailabilityExceptionRecord>,
+        range: ClosedRange<LocalDate>,
+    ): List<UnavailablePeriod> {
+        val skipDates = exceptions
+            .filter { it.exceptionType == ExceptionType.SKIP }
+            .map { it.originalDate }
+            .toSet()
+
+        val rescheduleMap = exceptions
+            .filter { it.exceptionType == ExceptionType.RESCHEDULE }
+            .associateBy { it.originalDate }
+
+        return if (!rule.isRecurring) {
+            expandOneTime(rule, range, skipDates, rescheduleMap)
+        } else {
+            expandRecurring(rule, range, skipDates, rescheduleMap)
+        }
+    }
+
+    private fun expandOneTime(
+        rule: EquipmentUnavailabilityRecord,
+        range: ClosedRange<LocalDate>,
+        skipDates: Set<LocalDate>,
+        rescheduleMap: Map<LocalDate, EquipmentUnavailabilityExceptionRecord>,
+    ): List<UnavailablePeriod> {
+        val date = rule.unavailableDate ?: return emptyList()
+        if (date !in range || date in skipDates) return emptyList()
+
+        val rescheduled = rescheduleMap[date]
+        return listOf(
+            UnavailablePeriod(
+                equipmentId = rule.equipmentId,
+                date        = rescheduled?.rescheduledDate ?: date,
+                startTime   = rescheduled?.rescheduledStartTime ?: rule.startTime,
+                endTime     = rescheduled?.rescheduledEndTime ?: rule.endTime,
+            )
+        )
+    }
+
+    private fun expandRecurring(
+        rule: EquipmentUnavailabilityRecord,
+        range: ClosedRange<LocalDate>,
+        skipDates: Set<LocalDate>,
+        rescheduleMap: Map<LocalDate, EquipmentUnavailabilityExceptionRecord>,
+    ): List<UnavailablePeriod> {
+        val dow = rule.recurringDayOfWeek ?: return emptyList()
+        val effectiveStart = maxOf(rule.effectiveFrom, range.start)
+        val effectiveEnd   = rule.effectiveUntil?.let { minOf(it, range.endInclusive) } ?: range.endInclusive
+
+        val result = mutableListOf<UnavailablePeriod>()
+        var current = effectiveStart.with(java.time.temporal.TemporalAdjusters.nextOrSame(dow))
+
+        while (!current.isAfter(effectiveEnd)) {
+            if (current !in skipDates) {
+                val rescheduled = rescheduleMap[current]
+                result.add(
+                    UnavailablePeriod(
+                        equipmentId = rule.equipmentId,
+                        date        = rescheduled?.rescheduledDate ?: current,
+                        startTime   = rescheduled?.rescheduledStartTime ?: rule.startTime,
+                        endTime     = rescheduled?.rescheduledEndTime ?: rule.endTime,
+                    )
+                )
+            }
+            current = current.plusWeeks(1)
+        }
+        return result
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 실행 — 통과 확인**
+
+```bash
+./gradlew :appointment-core:test --tests "*.UnavailabilityExpanderTest" -i
+```
+Expected: `PASS`
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/UnavailabilityExpander.kt
+git add appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/UnavailabilityExpanderTest.kt
+git commit -m "feat: UnavailabilityExpander — 반복 규칙 전개 (SKIP/RESCHEDULE 예외 지원)"
+```
+
+---
+
+## Task 6: EquipmentUnavailabilityService — CRUD + 충돌 감지
+
+**Files:**
+- Create: `appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt`
+- Test: `appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityServiceTest.kt`
+
+- [ ] **Step 1: 실패 테스트 작성**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.service
+
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilities
+import io.bluetape4k.clinic.appointment.model.tables.EquipmentUnavailabilityExceptions
+import io.bluetape4k.clinic.appointment.repository.EquipmentUnavailabilityRepository
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldHaveSize
+import org.jetbrains.exposed.v1.core.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+class EquipmentUnavailabilityServiceTest {
+    private val repo = EquipmentUnavailabilityRepository()
+    private val service = EquipmentUnavailabilityService(repo)
+
+    @BeforeEach
+    fun setup() {
+        transaction {
+            SchemaUtils.createMissingTablesAndColumns(
+                EquipmentUnavailabilities,
+                EquipmentUnavailabilityExceptions,
+            )
+            EquipmentUnavailabilityExceptions.deleteAll()
+            EquipmentUnavailabilities.deleteAll()
+        }
+    }
+
+    @Test
+    fun `특정 날짜의 장비 사용불가 기간 전개`() {
+        transaction {
+            repo.create(
+                equipmentId = 1L, clinicId = 1L,
+                unavailableDate = null,
+                isRecurring = true,
+                recurringDayOfWeek = DayOfWeek.TUESDAY,
+                effectiveFrom = LocalDate.of(2026, 4, 1),
+                effectiveUntil = null,
+                startTime = LocalTime.of(8, 0),
+                endTime = LocalTime.of(10, 0),
+                reason = "정기 점검",
+            )
+        }
+
+        val periods = transaction {
+            service.findUnavailablePeriodsInRange(
+                equipmentId = 1L,
+                from = LocalDate.of(2026, 4, 1),
+                to = LocalDate.of(2026, 4, 30),
+            )
+        }
+
+        periods shouldHaveSize 4  // 화요일 4회
+        periods.all { it.startTime == LocalTime.of(8, 0) }.let { assert(it) }
+    }
+}
+```
+
+- [ ] **Step 2: 테스트 실행 — 실패 확인**
+
+```bash
+./gradlew :appointment-core:test --tests "*.EquipmentUnavailabilityServiceTest" -i
+```
+Expected: `FAIL`
+
+- [ ] **Step 3: Service 구현**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.service
+
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
+import io.bluetape4k.clinic.appointment.model.dto.UnavailablePeriod
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import io.bluetape4k.clinic.appointment.repository.EquipmentUnavailabilityRepository
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+class EquipmentUnavailabilityService(
+    private val repo: EquipmentUnavailabilityRepository = EquipmentUnavailabilityRepository(),
+) {
+    companion object : KLogging()
+
+    /**
+     * 장비의 특정 기간 내 사용불가 기간 전개 (반복 예외 포함).
+     */
+    fun findUnavailablePeriodsInRange(
+        equipmentId: Long,
+        from: LocalDate,
+        to: LocalDate,
+    ): List<UnavailablePeriod> {
+        equipmentId.requirePositiveNumber("equipmentId")
+        val rules = repo.findByEquipment(equipmentId, from, to)
+        return rules.flatMap { rule ->
+            val exceptions = repo.findExceptions(rule.id)
+            UnavailabilityExpander.expand(rule, exceptions, from..to)
+        }
+    }
+
+    /**
+     * 특정 날짜에 사용불가인 장비 ID → UnavailablePeriod 맵 반환.
+     */
+    fun findUnavailableOnDate(clinicId: Long, date: LocalDate): Map<Long, List<UnavailablePeriod>> {
+        clinicId.requirePositiveNumber("clinicId")
+        val rules = repo.findByClinicOnDate(clinicId, date)
+        return rules
+            .groupBy { it.equipmentId }
+            .mapValues { (_, ruleList) ->
+                ruleList.flatMap { rule ->
+                    val exceptions = repo.findExceptions(rule.id)
+                    UnavailabilityExpander.expand(rule, exceptions, date..date)
+                }
+            }
+    }
+
+    fun create(
+        equipmentId: Long, clinicId: Long,
+        unavailableDate: LocalDate?,
+        isRecurring: Boolean,
+        recurringDayOfWeek: DayOfWeek?,
+        effectiveFrom: LocalDate,
+        effectiveUntil: LocalDate?,
+        startTime: LocalTime, endTime: LocalTime,
+        reason: String?,
+    ): EquipmentUnavailabilityRecord {
+        log.debug { "장비 사용불가 기간 등록: equipmentId=$equipmentId, isRecurring=$isRecurring" }
+        return repo.create(
+            equipmentId, clinicId, unavailableDate, isRecurring,
+            recurringDayOfWeek, effectiveFrom, effectiveUntil, startTime, endTime, reason,
+        )
+    }
+
+    fun delete(id: Long) {
+        id.requirePositiveNumber("id")
+        repo.delete(id)
+    }
+
+    fun addException(
+        unavailabilityId: Long,
+        originalDate: LocalDate,
+        exceptionType: ExceptionType,
+        rescheduledDate: LocalDate?,
+        rescheduledStartTime: LocalTime?,
+        rescheduledEndTime: LocalTime?,
+        reason: String?,
+    ): EquipmentUnavailabilityExceptionRecord {
+        unavailabilityId.requirePositiveNumber("unavailabilityId")
+        return repo.addException(
+            unavailabilityId, originalDate, exceptionType,
+            rescheduledDate, rescheduledStartTime, rescheduledEndTime, reason,
+        )
+    }
+
+    fun deleteException(exceptionId: Long) {
+        exceptionId.requirePositiveNumber("exceptionId")
+        repo.deleteException(exceptionId)
+    }
+}
+```
+
+- [ ] **Step 4: 테스트 실행 — 통과 확인**
+
+```bash
+./gradlew :appointment-core:test --tests "*.EquipmentUnavailabilityServiceTest" -i
+```
+Expected: `PASS`
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt
+git add appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityServiceTest.kt
+git commit -m "feat: EquipmentUnavailabilityService 추가 (CRUD + 기간 전개)"
+```
+
+---
+
+## Task 7: SlotCalculationService — 장비 사용불가 단계 추가
+
+**Files:**
+- Modify: `appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationService.kt`
+- Test: `appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationServiceTest.kt`
+
+- [ ] **Step 1: 실패 테스트 추가**
+
+`SlotCalculationServiceTest.kt`에 아래 케이스 추가:
+
+```kotlin
+@Test
+fun `장비 사용불가 기간에는 해당 슬롯 제외`() {
+    // given: 장비 10번이 2026-04-07 08:00~12:00 사용불가 등록됨
+    transaction {
+        equipmentUnavailabilityRepo.create(
+            equipmentId = 10L, clinicId = clinicId,
+            unavailableDate = LocalDate.of(2026, 4, 7),
+            isRecurring = false,
+            recurringDayOfWeek = null,
+            effectiveFrom = LocalDate.of(2026, 4, 7),
+            effectiveUntil = LocalDate.of(2026, 4, 7),
+            startTime = LocalTime.of(8, 0),
+            endTime = LocalTime.of(12, 0),
+            reason = "긴급 수리",
+        )
+    }
+
+    // when: 2026-04-07 슬롯 조회 (장비 10 필요한 진료 유형)
+    val slots = service.findAvailableSlots(
+        SlotQuery(
+            clinicId = clinicId,
+            doctorId = doctorId,
+            treatmentTypeId = treatmentTypeRequiringEquipment10,
+            date = LocalDate.of(2026, 4, 7),
+        )
+    )
+
+    // then: 08:00~12:00 사이 슬롯 없음
+    slots.none { it.startTime < LocalTime.of(12, 0) && it.endTime > LocalTime.of(8, 0) }
+        .let { assert(it) { "장비 사용불가 시간에 슬롯이 반환되었습니다: $slots" } }
+}
+```
+
+- [ ] **Step 2: 테스트 실행 — 실패 확인**
+
+```bash
+./gradlew :appointment-core:test --tests "*.SlotCalculationServiceTest.장비 사용불가*" -i
+```
+Expected: `FAIL`
+
+- [ ] **Step 3: SlotCalculationService 수정**
+
+생성자에 `equipmentUnavailabilityService` 추가, 단계 8 삽입:
+
+```kotlin
+class SlotCalculationService(
+    private val clinicRepository: ClinicRepository = ClinicRepository(),
+    private val doctorRepository: DoctorRepository = DoctorRepository(),
+    private val treatmentTypeRepository: TreatmentTypeRepository = TreatmentTypeRepository(),
+    private val appointmentRepository: AppointmentRepository = AppointmentRepository(),
+    private val holidayRepository: HolidayRepository = HolidayRepository(),
+    private val equipmentUnavailabilityService: EquipmentUnavailabilityService = EquipmentUnavailabilityService(),
+) {
+```
+
+`findAvailableSlots` 내부, 기존 step 8 (computeEffectiveRanges) 직전에 추가:
+
+```kotlin
+// 8. 장비 사용불가 기간 조회 (진료 유형이 장비를 필요로 하는 경우)
+val equipmentUnavailablePeriods: Map<Long, List<UnavailablePeriod>> =
+    if (treatment.requiresEquipment && requiredEquipment.isNotEmpty()) {
+        equipmentUnavailabilityService.findUnavailableOnDate(query.clinicId, query.date)
+            .filterKeys { it in requiredEquipment }
+    } else emptyMap()
+```
+
+슬롯 필터링 단계에서 장비 충돌 제거:
+
+```kotlin
+// 장비 사용불가 시간과 겹치는 슬롯 제외
+val blockedByEquipment = equipmentUnavailablePeriods.values.flatten()
+    .any { unavail ->
+        unavail.equipmentId in requiredEquipment &&
+        candidate.start < unavail.endTime &&
+        unavail.startTime < candidate.end
+    }
+if (blockedByEquipment) continue
+```
+
+- [ ] **Step 4: 테스트 실행 — 통과 확인**
+
+```bash
+./gradlew :appointment-core:test --tests "*.SlotCalculationServiceTest" -i
+```
+Expected: `PASS` (전체)
+
+- [ ] **Step 5: 커밋**
+
+```bash
+git add appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationService.kt
+git add appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationServiceTest.kt
+git commit -m "feat: SlotCalculationService — 장비 사용불가 체크 단계 추가"
+```
+
+---
+
+## Task 8: Solver — EquipmentUnavailabilityFact + ScheduleSolution 수정
+
+**Files:**
+- Create: `appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/EquipmentUnavailabilityFact.kt`
+- Modify: `appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/ScheduleSolution.kt`
+
+- [ ] **Step 1: `EquipmentUnavailabilityFact.kt` 작성**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.solver.domain
+
+import java.io.Serializable
+import java.time.LocalDate
+import java.time.LocalTime
+
+/**
+ * 장비 사용불가 기간을 나타내는 Solver ProblemFact.
+ *
+ * [ScheduleSolution]에 [ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty]로 등록되어
+ * Hard Constraint H11에서 참조됩니다.
+ */
+data class EquipmentUnavailabilityFact(
+    val equipmentId: Long,
+    val date: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+```
+
+- [ ] **Step 2: `ScheduleSolution.kt` — 필드 추가**
+
+기존 `treatmentEquipments` 필드 다음에 추가:
+
+```kotlin
+@field:ProblemFactCollectionProperty
+val equipmentUnavailabilities: List<EquipmentUnavailabilityFact> = emptyList(),
+```
+
+no-arg 생성자는 기존 `constructor()` 패턴을 유지 (변경 불필요).
+
+- [ ] **Step 3: 컴파일 확인**
+
+```bash
+./gradlew :appointment-solver:compileKotlin -i
+```
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/EquipmentUnavailabilityFact.kt
+git add appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/ScheduleSolution.kt
+git commit -m "feat: EquipmentUnavailabilityFact ProblemFact 추가 및 ScheduleSolution 등록"
+```
+
+---
+
+## Task 9: Solver — H11 Hard Constraint 추가
+
+**Files:**
+- Modify: `appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/HardConstraints.kt`
+- Modify: `appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/AppointmentConstraintProvider.kt`
+
+- [ ] **Step 1: `HardConstraints.kt` — H11 함수 추가**
+
+파일 하단에 추가:
+
+```kotlin
+// ----------------------------------------------------------------
+// H11: 장비 사용불가 기간 중 예약 배정 금지
+// ----------------------------------------------------------------
+fun equipmentUnavailabilityConflict(factory: ConstraintFactory): Constraint =
+    factory.forEach(AppointmentPlanning::class.java)
+        .filter { it.requiresEquipment && it.equipmentId != null && it.appointmentDate != null && it.startTime != null }
+        .join(
+            EquipmentUnavailabilityFact::class.java,
+            Joiners.equal({ appt -> appt.equipmentId }, { fact -> fact.equipmentId }),
+            Joiners.equal({ appt -> appt.appointmentDate }, { fact -> fact.date }),
+            Joiners.filtering { appt, fact ->
+                appt.startTime!! < fact.endTime && fact.startTime < appt.endTime!!
+            },
+        )
+        .penalize(HardSoftScore.ONE_HARD)
+        .asConstraint("equipment-unavailability-conflict")
+```
+
+import 추가:
+```kotlin
+import io.bluetape4k.clinic.appointment.solver.domain.EquipmentUnavailabilityFact
+```
+
+- [ ] **Step 2: `AppointmentConstraintProvider.kt` — H11 등록**
+
+`defineConstraints` 내 기존 hard constraint 목록 끝에 추가:
+
+```kotlin
+HardConstraints.equipmentUnavailabilityConflict(factory),
+```
+
+- [ ] **Step 3: 컴파일 확인**
+
+```bash
+./gradlew :appointment-solver:compileKotlin -i
+```
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/HardConstraints.kt
+git add appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/AppointmentConstraintProvider.kt
+git commit -m "feat: Solver H11 — 장비 사용불가 기간 Hard Constraint 추가"
+```
+
+---
+
+## Task 10: SolutionConverter — EquipmentUnavailabilityFact populate
+
+**Files:**
+- Modify: `appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/converter/SolutionConverter.kt`
+
+- [ ] **Step 1: `buildSolution` 시그니처 + 구현 수정**
+
+파라미터 추가:
+```kotlin
+fun buildSolution(
+    // 기존 파라미터들 ...
+    treatmentEquipments: List<TreatmentEquipmentRecord>,
+    equipmentUnavailabilities: List<UnavailablePeriod>,   // 추가
+    dateRange: ClosedRange<LocalDate>,
+): ScheduleSolution {
+```
+
+import 추가:
+```kotlin
+import io.bluetape4k.clinic.appointment.model.dto.UnavailablePeriod
+import io.bluetape4k.clinic.appointment.solver.domain.EquipmentUnavailabilityFact
+```
+
+`ScheduleSolution(...)` 생성 시 필드 추가:
+```kotlin
+equipmentUnavailabilities = equipmentUnavailabilities.map {
+    EquipmentUnavailabilityFact(
+        equipmentId = it.equipmentId,
+        date        = it.date,
+        startTime   = it.startTime,
+        endTime     = it.endTime,
+    )
+},
+```
+
+- [ ] **Step 2: 호출부 수정**
+
+`SolverService.kt`에서 `buildSolution` 호출 시 `equipmentUnavailabilities` 파라미터 전달.
+`ClosureRescheduleService.kt`에서도 동일하게 업데이트.
+
+- [ ] **Step 3: 컴파일 확인**
+
+```bash
+./gradlew :appointment-solver:compileKotlin :appointment-api:compileKotlin -i
+```
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/converter/SolutionConverter.kt
+git commit -m "feat: SolutionConverter — EquipmentUnavailabilityFact populate"
+```
+
+---
+
+## Task 11: REST API — Request/Response DTO
+
+**Files:**
+- Create: `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/request/CreateEquipmentUnavailabilityRequest.kt`
+- Create: `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/request/UpdateEquipmentUnavailabilityRequest.kt`
+- Create: `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/request/UnavailabilityExceptionRequest.kt`
+- Create: `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/response/UnavailabilityConflictResponse.kt`
+
+- [ ] **Step 1: Request DTO 작성**
+
+```kotlin
+// CreateEquipmentUnavailabilityRequest.kt
+package io.bluetape4k.clinic.appointment.api.dto.request
+
+import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import java.io.Serializable
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class CreateEquipmentUnavailabilityRequest(
+    val unavailableDate: LocalDate?,
+    val isRecurring: Boolean,
+    val recurringDayOfWeek: DayOfWeek?,
+    val effectiveFrom: LocalDate,
+    val effectiveUntil: LocalDate?,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val reason: String?,
+) : Serializable {
+    companion object { private const val serialVersionUID = 1L }
+}
+
+// UpdateEquipmentUnavailabilityRequest.kt
+data class UpdateEquipmentUnavailabilityRequest(
+    val effectiveUntil: LocalDate?,
+    val startTime: LocalTime?,
+    val endTime: LocalTime?,
+    val reason: String?,
+) : Serializable {
+    companion object { private const val serialVersionUID = 1L }
+}
+
+// UnavailabilityExceptionRequest.kt
+data class UnavailabilityExceptionRequest(
+    val originalDate: LocalDate,
+    val exceptionType: ExceptionType,
+    val rescheduledDate: LocalDate?,
+    val rescheduledStartTime: LocalTime?,
+    val rescheduledEndTime: LocalTime?,
+    val reason: String?,
+) : Serializable {
+    companion object { private const val serialVersionUID = 1L }
+}
+```
+
+- [ ] **Step 2: Response DTO 작성**
+
+```kotlin
+// UnavailabilityConflictResponse.kt
+package io.bluetape4k.clinic.appointment.api.dto.response
+
+import java.io.Serializable
+import java.time.LocalDate
+import java.time.LocalTime
+
+data class ConflictingAppointmentResponse(
+    val appointmentId: Long,
+    val patientName: String,
+    val appointmentDate: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val doctorId: Long,
+    val equipmentId: Long,
+) : Serializable {
+    companion object { private const val serialVersionUID = 1L }
+}
+
+data class UnavailabilityConflictResponse(
+    val unavailabilityId: Long,
+    val conflictCount: Int,
+    val conflicts: List<ConflictingAppointmentResponse>,
+) : Serializable {
+    companion object { private const val serialVersionUID = 1L }
+}
+```
+
+- [ ] **Step 3: 컴파일 확인**
+
+```bash
+./gradlew :appointment-api:compileKotlin -i
+```
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 4: 커밋**
+
+```bash
+git add appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/
+git commit -m "feat: 장비 사용불가 API Request/Response DTO 추가 (Serializable)"
+```
+
+---
+
+## Task 12: REST Controller
+
+**Files:**
+- Create: `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentUnavailabilityController.kt`
+
+- [ ] **Step 1: Controller 작성**
+
+```kotlin
+package io.bluetape4k.clinic.appointment.api.controller
+
+import io.bluetape4k.clinic.appointment.api.dto.request.CreateEquipmentUnavailabilityRequest
+import io.bluetape4k.clinic.appointment.api.dto.request.UnavailabilityExceptionRequest
+import io.bluetape4k.clinic.appointment.api.dto.request.UpdateEquipmentUnavailabilityRequest
+import io.bluetape4k.clinic.appointment.api.dto.response.ApiResponse
+import io.bluetape4k.clinic.appointment.api.dto.response.ConflictingAppointmentResponse
+import io.bluetape4k.clinic.appointment.api.dto.response.UnavailabilityConflictResponse
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityExceptionRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentUnavailabilityRecord
+import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
+import io.bluetape4k.clinic.appointment.service.EquipmentUnavailabilityService
+import io.bluetape4k.logging.KLogging
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.*
+import java.time.LocalDate
+
+@RestController
+@RequestMapping("/api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities")
+class EquipmentUnavailabilityController(
+    private val service: EquipmentUnavailabilityService,
+    private val appointmentRepository: AppointmentRepository,
+) {
+    companion object : KLogging()
+
+    @GetMapping
+    fun list(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+    ): ResponseEntity<ApiResponse<List<EquipmentUnavailabilityRecord>>> {
+        val records = transaction { service.findUnavailabilityRecords(equipmentId, from, to) }
+        return ResponseEntity.ok(ApiResponse(success = true, data = records))
+    }
+
+    @PostMapping
+    fun create(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @RequestBody request: CreateEquipmentUnavailabilityRequest,
+    ): ResponseEntity<ApiResponse<EquipmentUnavailabilityRecord>> {
+        val record = transaction {
+            service.create(
+                equipmentId = equipmentId, clinicId = clinicId,
+                unavailableDate = request.unavailableDate,
+                isRecurring = request.isRecurring,
+                recurringDayOfWeek = request.recurringDayOfWeek,
+                effectiveFrom = request.effectiveFrom,
+                effectiveUntil = request.effectiveUntil,
+                startTime = request.startTime,
+                endTime = request.endTime,
+                reason = request.reason,
+            )
+        }
+        return ResponseEntity.ok(ApiResponse(success = true, data = record))
+    }
+
+    @DeleteMapping("/{id}")
+    fun delete(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @PathVariable id: Long,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        transaction { service.delete(id) }
+        return ResponseEntity.ok(ApiResponse(success = true))
+    }
+
+    @PostMapping("/{id}/exceptions")
+    fun addException(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @PathVariable id: Long,
+        @RequestBody request: UnavailabilityExceptionRequest,
+    ): ResponseEntity<ApiResponse<EquipmentUnavailabilityExceptionRecord>> {
+        val exception = transaction {
+            service.addException(
+                unavailabilityId = id,
+                originalDate = request.originalDate,
+                exceptionType = request.exceptionType,
+                rescheduledDate = request.rescheduledDate,
+                rescheduledStartTime = request.rescheduledStartTime,
+                rescheduledEndTime = request.rescheduledEndTime,
+                reason = request.reason,
+            )
+        }
+        return ResponseEntity.ok(ApiResponse(success = true, data = exception))
+    }
+
+    @DeleteMapping("/{id}/exceptions/{exId}")
+    fun deleteException(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @PathVariable id: Long,
+        @PathVariable exId: Long,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        transaction { service.deleteException(exId) }
+        return ResponseEntity.ok(ApiResponse(success = true))
+    }
+
+    @GetMapping("/{id}/conflicts")
+    fun conflicts(
+        @PathVariable clinicId: Long,
+        @PathVariable equipmentId: Long,
+        @PathVariable id: Long,
+    ): ResponseEntity<ApiResponse<UnavailabilityConflictResponse>> {
+        val result = transaction {
+            val record = service.findById(id) ?: return@transaction null
+            val periods = service.findUnavailablePeriodsInRange(
+                equipmentId = equipmentId,
+                from = record.effectiveFrom,
+                to = record.effectiveUntil ?: record.effectiveFrom.plusYears(1),
+            )
+            val conflicting = periods.flatMap { period ->
+                appointmentRepository.findOverlappingByEquipment(
+                    equipmentId = period.equipmentId,
+                    date = period.date,
+                    startTime = period.startTime,
+                    endTime = period.endTime,
+                ).map { appt ->
+                    ConflictingAppointmentResponse(
+                        appointmentId = appt.id,
+                        patientName = appt.patientName,
+                        appointmentDate = appt.appointmentDate,
+                        startTime = appt.startTime,
+                        endTime = appt.endTime,
+                        doctorId = appt.doctorId,
+                        equipmentId = period.equipmentId,
+                    )
+                }
+            }
+            UnavailabilityConflictResponse(
+                unavailabilityId = id,
+                conflictCount = conflicting.size,
+                conflicts = conflicting,
+            )
+        }
+        return if (result != null) {
+            ResponseEntity.ok(ApiResponse(success = true, data = result))
+        } else {
+            ResponseEntity.notFound().build()
+        }
+    }
+}
+```
+
+- [ ] **Step 2: AppointmentRepository에 `findOverlappingByEquipment` 추가**
+
+`AppointmentRepository.kt`에 메서드 추가:
+
+```kotlin
+fun findOverlappingByEquipment(
+    equipmentId: Long,
+    date: LocalDate,
+    startTime: LocalTime,
+    endTime: LocalTime,
+): List<AppointmentRecord> =
+    Appointments.selectAll()
+        .where {
+            (Appointments.equipmentId eq equipmentId) and
+            (Appointments.appointmentDate eq date) and
+            (Appointments.startTime less endTime) and
+            (Appointments.endTime greater startTime) and
+            (Appointments.status notInList CANCELLED_STATUSES)
+        }
+        .map { it.toAppointmentRecord() }
+```
+
+- [ ] **Step 3: 전체 빌드 확인**
+
+```bash
+./gradlew :appointment-api:build -x test -i
+```
+Expected: `BUILD SUCCESSFUL`
+
+- [ ] **Step 4: 통합 테스트 실행**
+
+```bash
+./gradlew :appointment-core:test :appointment-solver:test :appointment-api:test -i
+```
+Expected: `PASS` (전체)
+
+- [ ] **Step 5: 최종 커밋**
+
+```bash
+git add appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentUnavailabilityController.kt
+git add appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentRepository.kt
+git commit -m "feat: EquipmentUnavailabilityController REST API 추가 (CRUD + 충돌 감지)"
+```
+
+---
+
+## 최종 검증 체크리스트
+
+```
+[ ] ./gradlew :appointment-core:build   — PASS
+[ ] ./gradlew :appointment-solver:build — PASS
+[ ] ./gradlew :appointment-api:build    — PASS
+[ ] 모든 DTO가 Serializable + serialVersionUID = 1L 구현
+[ ] 모든 인자 검증이 bluetape4k requireXxx() 사용
+[ ] 모든 클래스가 companion object : KLogging() 사용
+[ ] SlotCalculationService 검증 순서: Holiday→ClinicClosure→OperatingHours→BreakTime→DoctorSchedule→DoctorAbsence→EquipmentUnavailability
+[ ] Flyway V2 적용 확인
+[ ] TODO 주석 (Doctor/Clinic 반복 예외 리팩터링) 코드에 남아있음
+```

--- a/docs/superpowers/specs/2026-03-30-equipment-schedule-design.md
+++ b/docs/superpowers/specs/2026-03-30-equipment-schedule-design.md
@@ -1,0 +1,380 @@
+# 장비 스케줄 관리 설계 스펙
+
+- **날짜**: 2026-03-30
+- **작성자**: Claude (설계 협의: debop)
+- **대상 모듈**: `appointment-core`, `appointment-solver`, `appointment-api`
+- **상태**: 승인됨
+
+---
+
+## 1. 배경 및 목표
+
+현재 시스템은 의사 부재(`DoctorAbsences`)와 병원 휴진(`ClinicClosures`)에 의한 예약 제약은 지원하지만,
+**의료 장비의 사용불가 기간(유지보수, 고장 등)** 은 반영되지 않는다.
+
+장비별 점유 시간(`usageDurationMinutes`)도 `Equipments` 테이블에 존재하지만,
+실제 슬롯 계산 및 Solver에 충분히 활용되지 않고 있다.
+
+### 목표
+
+1. 장비 사용불가 기간(일회성 + 반복 패턴 + 예외) 등록 및 관리
+2. 장비별 소요시간을 슬롯 계산 및 Timefold Solver 최적화에 반영
+3. 사용불가 기간과 충돌하는 기존 예약 감지 (Phase 1)
+4. 향후 자동 재배정 지원 (Phase 2/3)
+
+---
+
+## 2. 범위
+
+### 이번 구현 (Phase 1)
+
+- 장비 사용불가 기간 CRUD (일회성 + 반복 + 반복 예외)
+- 슬롯 계산 파이프라인에 장비 사용불가 체크 추가
+- Timefold Solver `EquipmentUnavailabilityFact` + H9 제약조건 확장
+- 충돌 예약 감지 API (알림 전용, 자동 재배정 없음)
+
+### 향후 구현
+
+- **Phase 2**: 관리자가 선택하는 자동 재배정 후보 생성 (`ClosureRescheduleService` 연동)
+- **Phase 3**: 사용불가 기간 등록 전 충돌 미리보기 + 자동 재배정 통합
+
+---
+
+## 3. 데이터 모델
+
+### 3.1 `EquipmentUnavailabilities` (신규)
+
+```kotlin
+object EquipmentUnavailabilities : LongIdTable("equipment_unavailabilities") {
+    val equipmentId  = reference("equipment_id", Equipments)
+    val clinicId     = reference("clinic_id", Clinics)
+
+    // 일회성: unavailableDate 사용, isRecurring = false
+    val unavailableDate = date("unavailable_date").nullable()
+
+    // 반복 패턴
+    val isRecurring        = bool("is_recurring").default(false)
+    val recurringDayOfWeek = enumerationByName<DayOfWeek>("recurring_day_of_week", 10).nullable()
+    val effectiveFrom      = date("effective_from")           // 반복 시작일
+    val effectiveUntil     = date("effective_until").nullable() // null = 무기한
+
+    val startTime = time("start_time")
+    val endTime   = time("end_time")
+    val reason    = varchar("reason", 500).nullable()
+
+    init {
+        index(false, equipmentId, effectiveFrom)
+        index(false, clinicId, effectiveFrom)
+        index(false, equipmentId, recurringDayOfWeek)
+    }
+}
+```
+
+### 3.2 `EquipmentUnavailabilityExceptions` (신규)
+
+반복 스케줄의 특정 발생일에 대한 예외 처리.
+
+```kotlin
+object EquipmentUnavailabilityExceptions : LongIdTable("equipment_unavailability_exceptions") {
+    val unavailabilityId = reference("unavailability_id", EquipmentUnavailabilities,
+                               onDelete = ReferenceOption.CASCADE)
+    val originalDate     = date("original_date")   // 원래 발생 예정일
+
+    val exceptionType         = enumerationByName<ExceptionType>("exception_type", 20)
+    val rescheduledDate       = date("rescheduled_date").nullable()
+    val rescheduledStartTime  = time("rescheduled_start_time").nullable()
+    val rescheduledEndTime    = time("rescheduled_end_time").nullable()
+    val reason                = varchar("reason", 500).nullable()
+
+    init {
+        index(false, unavailabilityId, originalDate)
+    }
+}
+
+enum class ExceptionType {
+    SKIP,        // 이번 발생 건너뜀
+    RESCHEDULE,  // 날짜/시간 변경
+}
+```
+
+### 3.3 운영 패턴
+
+| 상황 | 처리 방법 |
+|------|----------|
+| 이번만 skip | `ExceptionType.SKIP` + `originalDate` |
+| 이번만 다른 날/시간 | `ExceptionType.RESCHEDULE` + `rescheduledDate/Time` |
+| 특정 시점 이후 변경 | 기존 레코드 `effectiveUntil` 설정 + 새 레코드 `effectiveFrom` 신규 등록 |
+
+### 3.4 기존 `Equipments` 테이블 변경 없음
+
+`usageDurationMinutes` 컬럼 기존 존재 → 스키마 변경 불필요.
+
+---
+
+## 4. DTO
+
+> **규칙**: 모든 DTO는 `Serializable` 구현 + `serialVersionUID = 1L` 필수.
+
+```kotlin
+data class EquipmentUnavailabilityRecord(
+    val id: Long,
+    val equipmentId: Long,
+    val clinicId: Long,
+    val unavailableDate: LocalDate?,
+    val isRecurring: Boolean,
+    val recurringDayOfWeek: DayOfWeek?,
+    val effectiveFrom: LocalDate,
+    val effectiveUntil: LocalDate?,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val reason: String?,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+data class EquipmentUnavailabilityExceptionRecord(
+    val id: Long,
+    val unavailabilityId: Long,
+    val originalDate: LocalDate,
+    val exceptionType: ExceptionType,
+    val rescheduledDate: LocalDate?,
+    val rescheduledStartTime: LocalTime?,
+    val rescheduledEndTime: LocalTime?,
+    val reason: String?,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+data class UnavailablePeriod(
+    val date: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+data class ConflictingAppointmentResponse(
+    val appointmentId: Long,
+    val patientName: String,
+    val appointmentDate: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+    val doctorId: Long,
+    val equipmentId: Long,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+data class UnavailabilityConflictResponse(
+    val unavailabilityId: Long,
+    val conflictCount: Int,
+    val conflicts: List<ConflictingAppointmentResponse>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+```
+
+---
+
+## 5. 서비스 레이어
+
+### 5.1 `UnavailabilityExpander`
+
+반복 규칙을 특정 날짜 범위 내 실제 `UnavailablePeriod` 목록으로 전개.
+예외(SKIP/RESCHEDULE) 적용 포함.
+
+```kotlin
+object UnavailabilityExpander {
+    /**
+     * 반복 규칙을 주어진 범위 내 실제 사용불가 기간으로 전개한다.
+     * SKIP 예외는 제외, RESCHEDULE 예외는 변경된 날짜/시간으로 대체한다.
+     */
+    fun expand(
+        rule: EquipmentUnavailabilityRecord,
+        exceptions: List<EquipmentUnavailabilityExceptionRecord>,
+        range: ClosedRange<LocalDate>,
+    ): List<UnavailablePeriod>
+}
+```
+
+### 5.2 `EquipmentUnavailabilityService`
+
+```kotlin
+interface EquipmentUnavailabilityService {
+    // CRUD
+    fun create(request: CreateEquipmentUnavailabilityRequest): EquipmentUnavailabilityRecord
+    fun update(id: Long, request: UpdateEquipmentUnavailabilityRequest): EquipmentUnavailabilityRecord
+    fun delete(id: Long)
+
+    // 반복 예외
+    fun addException(
+        unavailabilityId: Long,
+        request: UnavailabilityExceptionRequest,
+    ): EquipmentUnavailabilityExceptionRecord
+    fun deleteException(exceptionId: Long)
+
+    // 조회
+    fun findByEquipment(equipmentId: Long, from: LocalDate, to: LocalDate): List<EquipmentUnavailabilityRecord>
+    fun findUnavailablePeriodsOnDate(clinicId: Long, date: LocalDate): Map<Long, List<UnavailablePeriod>>
+
+    // 충돌 감지 (Phase 1)
+    fun detectConflicts(unavailabilityId: Long): UnavailabilityConflictResponse
+    fun previewConflicts(request: CreateEquipmentUnavailabilityRequest): UnavailabilityConflictResponse
+}
+```
+
+### 5.3 `SlotCalculationService` — 검증 파이프라인 변경
+
+슬롯 가용성 검사 순서 (좁은 범위를 뒤에서 체크, early-return):
+
+```
+1. Holiday              (공휴일 — 전사 차단)
+2. ClinicClosure        (병원 임시 휴진)
+3. OperatingHours       (병원 영업시간)
+4. BreakTime            (병원 휴식시간)
+5. DoctorSchedule       (의사 근무 스케줄)
+6. DoctorAbsence        (의사 임시 부재)
+7. EquipmentUnavailability  ← 신규 추가
+```
+
+각 단계에서 사용불가 판정 시 즉시 `emptyList()` 반환 (early-return).
+
+---
+
+## 6. Timefold Solver 통합
+
+### 6.1 새 ProblemFact
+
+```kotlin
+data class EquipmentUnavailabilityFact(
+    val equipmentId: Long,
+    val date: LocalDate,
+    val startTime: LocalTime,
+    val endTime: LocalTime,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+```
+
+### 6.2 `ScheduleSolution` 변경
+
+```kotlin
+@PlanningSolution
+class ScheduleSolution(
+    // 기존 필드 ...
+
+    @field:ProblemFactCollectionProperty
+    val equipmentUnavailabilities: List<EquipmentUnavailabilityFact> = emptyList(), // 추가
+)
+```
+
+### 6.3 Hard Constraint 확장 (H9)
+
+기존 H9(`equipmentAvailability`)에 사용불가 기간 충돌 체크 추가:
+
+```kotlin
+// 장비 사용불가 기간 중 예약 배정 금지
+fun equipmentUnavailabilityConflict(factory: ConstraintFactory): Constraint =
+    factory.forEach(AppointmentPlanning::class.java)
+        .filter { it.requiresEquipment && it.equipmentId != null }
+        .join(
+            EquipmentUnavailabilityFact::class.java,
+            equal({ it.equipmentId }, { it.equipmentId }),
+            equal({ it.appointmentDate }, { it.date }),
+        )
+        .filter { appt, unavail ->
+            appt.startTime!! < unavail.endTime && unavail.startTime < appt.endTime()
+        }
+        .penalize(HardSoftScore.ONE_HARD)
+        .asConstraint("equipment-unavailability-conflict")
+```
+
+---
+
+## 7. REST API
+
+```
+GET    /api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities
+       ?from=&to=
+POST   /api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities
+PUT    /api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities/{id}
+DELETE /api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities/{id}
+
+POST   /api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities/{id}/exceptions
+DELETE /api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities/{id}/exceptions/{exId}
+
+GET    /api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities/{id}/conflicts
+POST   /api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities/preview-conflicts
+```
+
+---
+
+## 8. Flyway 마이그레이션
+
+신규 SQL 파일 2개 추가 (`appointment-api/src/main/resources/db/migration/`):
+
+```
+V{next}__add_equipment_unavailabilities.sql
+```
+
+- `equipment_unavailabilities` 테이블 생성
+- `equipment_unavailability_exceptions` 테이블 생성
+- 관련 인덱스 생성
+
+---
+
+## 9. bluetape4k-patterns 준수 사항
+
+구현 시 아래 패턴을 **반드시** 적용한다.
+
+| 항목 | 적용 방법 |
+|------|----------|
+| 인자 검증 | `equipmentId.requirePositiveNumber("equipmentId")` 등 bluetape4k 확장 사용. `require()`/`requireNotNull()` 금지 |
+| 로깅 | `companion object : KLogging()` + `log.debug { }` lazy 람다 |
+| DTO/Value | `Serializable` 구현 + `serialVersionUID = 1L` |
+| 예외 처리 | `runCatching { }.onFailure { log.warn(e) { } }` |
+| 상수 | Magic literal 금지, `const val` 또는 enum 사용 |
+| 트랜잭션 | 모든 Exposed 작업은 `transaction { }` 내부에서 실행 |
+| DB 초기화 (테스트) | `@BeforeEach`: `SchemaUtils.createMissingTablesAndColumns()` + `Table.deleteAll()` |
+
+---
+
+## 10. TODO: Doctor/Clinic 반복 스케줄 예외 처리 리팩터링
+
+> 장비 스케줄 예외 패턴 검증 후 아래 항목을 동일하게 적용할 것.
+
+```
+// TODO: [FUTURE] EquipmentUnavailabilities 패턴 검증 후 적용
+// 1. DoctorSchedules: effectiveFrom/effectiveUntil + DoctorScheduleExceptions 테이블 추가
+//    - 현재: dayOfWeek + startTime/endTime (예외 없음)
+//    - 목표: 반복 패턴 + SKIP/RESCHEDULE 예외 지원
+// 2. ClinicBreakTimes: 동일 패턴 적용
+//    - 현재: BreakTimes (요일별 고정) + ClinicDefaultBreakTimes
+//    - 목표: 반복 패턴 + 예외 지원
+// 3. ClinicClosures: 반복 패턴 + 예외 지원으로 확장
+//    - 현재: 일회성 closureDate만 지원
+//    - 목표: 정기 휴진(예: 매월 마지막 주 수요일) + 예외 지원
+// Ref: docs/superpowers/specs/2026-03-30-equipment-schedule-design.md
+```
+
+---
+
+## 11. 단계별 구현 로드맵
+
+| Phase | 내용 | 상태 |
+|-------|------|------|
+| Phase 1 | 장비 사용불가 CRUD + 슬롯 계산 통합 + Solver H9 확장 + 충돌 알림 | **이번 구현** |
+| Phase 2 | 관리자가 선택하는 자동 재배정 후보 생성 | 향후 |
+| Phase 3 | 등록 전 충돌 미리보기 + 자동 재배정 통합 | 향후 |

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,31 +12,31 @@ pluginManagement {
 rootProject.name = "clinic-appointment"
 
 // bluetape4k-projects 로컬 빌드 연결 (로컬에 있을 때만)
-val bluetape4kProjectsDir = file("../bluetape4k-projects")
-if (bluetape4kProjectsDir.exists()) {
-    includeBuild(bluetape4kProjectsDir) {
-        dependencySubstitution {
-            // 모든 모듈이 bluetape4k-{name} 형식으로 등록되어 있음
-            listOf(
-                "bluetape4k-core",
-                "bluetape4k-coroutines",
-                "bluetape4k-exposed-core",
-                "bluetape4k-exposed-jdbc",
-                "bluetape4k-exposed-jdbc-tests",
-                "bluetape4k-exposed-r2dbc",
-                "bluetape4k-exposed-r2dbc-tests",
-                "bluetape4k-junit5",
-                "bluetape4k-leader",
-                "bluetape4k-lettuce",
-                "bluetape4k-logging",
-                "bluetape4k-resilience4j",
-                "bluetape4k-testcontainers",
-            ).forEach { module ->
-                substitute(module("io.github.bluetape4k:$module")).using(project(":$module"))
-            }
-        }
-    }
-}
+//val bluetape4kProjectsDir = file("../bluetape4k-projects")
+//if (bluetape4kProjectsDir.exists()) {
+//    includeBuild(bluetape4kProjectsDir) {
+//        dependencySubstitution {
+//            // 모든 모듈이 bluetape4k-{name} 형식으로 등록되어 있음
+//            listOf(
+//                "bluetape4k-core",
+//                "bluetape4k-coroutines",
+//                "bluetape4k-exposed-core",
+//                "bluetape4k-exposed-jdbc",
+//                "bluetape4k-exposed-jdbc-tests",
+//                "bluetape4k-exposed-r2dbc",
+//                "bluetape4k-exposed-r2dbc-tests",
+//                "bluetape4k-junit5",
+//                "bluetape4k-leader",
+//                "bluetape4k-lettuce",
+//                "bluetape4k-logging",
+//                "bluetape4k-resilience4j",
+//                "bluetape4k-testcontainers",
+//            ).forEach { module ->
+//                substitute(module("io.github.bluetape4k:$module")).using(project(":$module"))
+//            }
+//        }
+//    }
+//}
 
 // Gradle 예약 디렉토리 — 모듈 자동 등록에서 제외
 val reservedDirs = setOf("buildSrc", "build", "gradle", "config", "frontend", ".gradle")


### PR DESCRIPTION
## Summary

- 장비 사용불가 기간(일회성·반복·예외)을 관리하는 전체 스택 구현
- Timefold Solver H11 Hard Constraint로 장비 충돌 예약 자동 방지
- SlotCalculationService에 장비 사용불가 체크 단계 추가

## Changes

### appointment-core
- `EquipmentUnavailabilities`, `EquipmentUnavailabilityExceptions` Exposed ORM 테이블
- `EquipmentUnavailabilityRecord`, `EquipmentUnavailabilityExceptionRecord`, `UnavailablePeriod` DTO (Serializable)
- `EquipmentUnavailabilityRepository` — CRUD + 예외 관리
- `UnavailabilityExpander` — 반복 규칙 전개 (SKIP/RESCHEDULE 예외 지원)
- `EquipmentUnavailabilityService` — 비즈니스 로직 + 충돌 감지
- `SlotCalculationService` — 장비 사용불가 체크 단계 추가

### appointment-solver
- `EquipmentUnavailabilityFact` ProblemFact
- `ScheduleSolution` — `equipmentUnavailabilities` 필드 추가
- `HardConstraints.equipmentUnavailabilityConflict` (H11)
- `SolutionConverter` — EquipmentUnavailabilityFact populate

### appointment-api
- Flyway V2 마이그레이션 SQL
- `EquipmentUnavailabilityController` — CRUD + 예외 처리 + 충돌 감지 REST API
- Request/Response DTO (Serializable)

### buildSrc
- `bluetape4k` 버전 1.5.0-Beta3 업데이트
- `Libs.kt` BOM 기준 신규 모듈 11개 추가

## Test plan

- [x] `appointment-core:test` PASS
- [x] `appointment-solver:test` PASS
- [x] `appointment-api:test` PASS
- [x] bluetape4k-patterns 체크리스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)