### PR TITLE
feat: @Profile 기반 환경 분리 + ClinicTimezoneService API 연결

### DIFF
--- a/appointment-api/README.md
+++ b/appointment-api/README.md
@@ -62,6 +62,27 @@ Flyway — `src/main/resources/db/migration/V*.sql`
 ./gradlew :appointment-api:gatlingRun
 ```
 
+## 타임존
+
+API 응답(`AppointmentResponse`)에는 항상 `timezone` 과 `locale` 필드가 포함됩니다.
+
+```json
+{
+  "appointmentDate": "2026-04-01",
+  "startTime": "09:00:00",
+  "endTime": "09:30:00",
+  "timezone": "Asia/Seoul",
+  "locale": "ko-KR"
+}
+```
+
+- `appointmentDate` / `startTime` / `endTime` 은 **클리닉 현지 시간** 기준입니다.
+- 프론트엔드는 `timezone` 필드를 이용해 `ZonedDateTime` 으로 복원할 수 있습니다.
+- UTC 변환은 서버에서 수행하지 않습니다 — 날짜 경계 문제 방지.
+- `locale` 은 날짜/시간 표시 형식 전용으로, timezone과 독립적입니다.
+
+상세 설계: [appointment-core 타임존 설계](../appointment-core/README.md#타임존-설계)
+
 ## 테스트 실행
 
 ```bash

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/DatabaseConfig.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/DatabaseConfig.kt
@@ -21,27 +21,27 @@ import io.bluetape4k.clinic.appointment.model.tables.TreatmentTypes
 import org.jetbrains.exposed.v1.jdbc.SchemaUtils
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.springframework.boot.ApplicationRunner
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.core.annotation.Order
 
 /**
  * 데이터베이스 스키마 초기화 설정.
  *
- * - Flyway 활성(`spring.flyway.enabled=true`): Flyway SQL 마이그레이션이 스키마를 관리.
- *   → `flyway` 또는 `postgresql` profile 사용.
- * - Flyway 비활성(기본): Exposed SchemaUtils가 스키마를 생성.
- *   → 개발/테스트 환경 (H2 in-memory).
+ * dev/test 프로파일에서만 활성화됩니다.
+ * Exposed SchemaUtils로 in-memory 스키마를 생성합니다.
+ *
+ * prod에서는 Flyway SQL 마이그레이션이 스키마를 관리합니다.
  */
 @Configuration(proxyBeanMethods = false)
+@Profile("dev", "test")
 class SchemaInitConfig {
     /**
-     * Flyway가 비활성일 때 Exposed SchemaUtils로 스키마 생성.
+     * Exposed SchemaUtils로 스키마 생성 (dev/test 전용).
      */
     @Bean
     @Order(1)
-    @ConditionalOnProperty(name = ["spring.flyway.enabled"], havingValue = "false", matchIfMissing = true)
     fun schemaInitializer(): ApplicationRunner =
         ApplicationRunner {
             transaction {

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
@@ -12,6 +12,7 @@ import io.bluetape4k.clinic.appointment.service.ClosureRescheduleService
 import io.bluetape4k.clinic.appointment.service.EquipmentUnavailabilityService
 import io.bluetape4k.clinic.appointment.service.SlotCalculationService
 import io.bluetape4k.clinic.appointment.statemachine.AppointmentStateMachine
+import io.bluetape4k.clinic.appointment.timezone.ClinicTimezoneService
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 
@@ -69,6 +70,10 @@ class ServiceConfig {
 
     @Bean
     fun appointmentStateMachine(): AppointmentStateMachine = AppointmentStateMachine()
+
+    @Bean
+    fun clinicTimezoneService(clinicRepository: ClinicRepository): ClinicTimezoneService =
+        ClinicTimezoneService(clinicRepository)
 
     @Bean
     fun equipmentUnavailabilityRepository(): EquipmentUnavailabilityRepository = EquipmentUnavailabilityRepository()

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/TestDataSeeder.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/TestDataSeeder.kt
@@ -13,6 +13,7 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.springframework.boot.ApplicationRunner
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.core.annotation.Order
 import java.time.DayOfWeek
 import java.time.LocalTime
@@ -22,8 +23,11 @@ import java.time.LocalTime
  *
  * 클리닉, 의사, 영업시간, 의사 스케줄, 진료 유형을 생성합니다.
  * 이미 데이터가 존재하면 건너뜁니다.
+ *
+ * dev/test 프로파일에서만 활성화됩니다.
  */
 @Configuration(proxyBeanMethods = false)
+@Profile("dev", "test")
 class TestDataSeederConfig {
     companion object : KLogging() {
         private val WEEKDAYS =

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
@@ -15,6 +15,7 @@ import io.bluetape4k.clinic.appointment.repository.AppointmentStateHistoryReposi
 import io.bluetape4k.clinic.appointment.statemachine.AppointmentEvent
 import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
 import io.bluetape4k.clinic.appointment.statemachine.AppointmentStateMachine
+import io.bluetape4k.clinic.appointment.timezone.ClinicTimezoneService
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.http.HttpStatus
@@ -45,6 +46,7 @@ class AppointmentController(
     private val stateMachine: AppointmentStateMachine,
     private val eventPublisher: ApplicationEventPublisher,
     private val stateHistoryRepository: AppointmentStateHistoryRepository,
+    private val timezoneService: ClinicTimezoneService,
 ) {
     companion object : KLogging()
 
@@ -64,7 +66,8 @@ class AppointmentController(
     ): ResponseEntity<ApiResponse<List<AppointmentResponse>>> {
         log.debug { "GET /api/appointments?clinicId=$clinicId&startDate=$startDate&endDate=$endDate" }
         val records = transaction { appointmentRepository.findByClinicAndDateRange(clinicId, startDate..endDate) }
-        return ResponseEntity.ok(ApiResponse.ok(records.map { it.toResponse() }))
+        val (timezone, locale) = timezoneService.getTimezoneAndLocale(clinicId)
+        return ResponseEntity.ok(ApiResponse.ok(records.map { it.toResponse(timezone, locale) }))
     }
 
     /**
@@ -79,7 +82,8 @@ class AppointmentController(
         log.debug { "GET /api/appointments/$id" }
         val record = transaction { appointmentRepository.findByIdOrNull(id) }
             ?: throw NoSuchElementException("Appointment not found: $id")
-        return ResponseEntity.ok(ApiResponse.ok(record.toResponse()))
+        val (timezone, locale) = timezoneService.getTimezoneAndLocale(record.clinicId)
+        return ResponseEntity.ok(ApiResponse.ok(record.toResponse(timezone, locale)))
     }
 
     /**
@@ -113,8 +117,9 @@ class AppointmentController(
                 clinicId = saved.clinicId,
             )
         )
+        val (timezone, locale) = timezoneService.getTimezoneAndLocale(saved.clinicId)
         return ResponseEntity.status(HttpStatus.CREATED)
-            .body(ApiResponse.ok(saved.toResponse()))
+            .body(ApiResponse.ok(saved.toResponse(timezone, locale)))
     }
 
     /**
@@ -167,7 +172,8 @@ class AppointmentController(
         )
 
         val updated = transaction { appointmentRepository.findByIdOrNull(id) }!!
-        return ResponseEntity.ok(ApiResponse.ok(updated.toResponse()))
+        val (timezone, locale) = timezoneService.getTimezoneAndLocale(updated.clinicId)
+        return ResponseEntity.ok(ApiResponse.ok(updated.toResponse(timezone, locale)))
     }
 
     /**
@@ -213,7 +219,8 @@ class AppointmentController(
         )
 
         val updated = transaction { appointmentRepository.findByIdOrNull(id) }!!
-        return ResponseEntity.ok(ApiResponse.ok(updated.toResponse()))
+        val (timezone, locale) = timezoneService.getTimezoneAndLocale(updated.clinicId)
+        return ResponseEntity.ok(ApiResponse.ok(updated.toResponse(timezone, locale)))
     }
 }
 

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityConfig.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityConfig.kt
@@ -2,10 +2,10 @@ package io.bluetape4k.clinic.appointment.api.security
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.info
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.http.HttpMethod
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
@@ -14,16 +14,11 @@ import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 /**
- * JWT 보안 설정 (scheduling.security.jwt.enabled=true).
+ * JWT 보안 설정. dev/test 외 모든 환경(prod, staging 등)에서 활성화됩니다.
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
-@ConditionalOnProperty(
-    prefix = "scheduling.security.jwt",
-    name = ["enabled"],
-    havingValue = "true",
-    matchIfMissing = false,
-)
+@Profile("!dev & !test")
 @EnableConfigurationProperties(JwtSecurityProperties::class)
 class SecurityConfig {
 
@@ -64,16 +59,11 @@ class SecurityConfig {
 }
 
 /**
- * JWT 비활성화 시 모든 요청 허용 (test/dev 프로파일).
+ * dev/test 프로파일 전용 — 모든 요청 허용 (JWT 인증 없음).
  */
-@Configuration
+@Configuration(proxyBeanMethods = false)
 @EnableWebSecurity
-@ConditionalOnProperty(
-    prefix = "scheduling.security.jwt",
-    name = ["enabled"],
-    havingValue = "false",
-    matchIfMissing = true,
-)
+@Profile("dev", "test")
 class NoOpSecurityConfig {
 
     companion object : KLogging()

--- a/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentControllerTest.kt
+++ b/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentControllerTest.kt
@@ -96,6 +96,7 @@ class AppointmentControllerTest {
                 it[name] = "Test Clinic"
                 it[slotDurationMinutes] = 30
                 it[timezone] = "Asia/Seoul"
+                it[locale] = "ko-KR"
                 it[maxConcurrentPatients] = 3
                 it[openOnHolidays] = false
             }.value
@@ -160,6 +161,8 @@ class AppointmentControllerTest {
             .andExpect(jsonPath("$.data.patientName").value("John Doe"))
             .andExpect(jsonPath("$.data.status").value("REQUESTED"))
             .andExpect(jsonPath("$.data.id").isNotEmpty())
+            .andExpect(jsonPath("$.data.timezone").value("Asia/Seoul"))
+            .andExpect(jsonPath("$.data.locale").value("ko-KR"))
     }
 
     @Test
@@ -171,6 +174,8 @@ class AppointmentControllerTest {
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.id").value(appointmentId))
             .andExpect(jsonPath("$.data.patientName").value("Jane Doe"))
+            .andExpect(jsonPath("$.data.timezone").value("Asia/Seoul"))
+            .andExpect(jsonPath("$.data.locale").value("ko-KR"))
     }
 
     @Test
@@ -232,6 +237,61 @@ class AppointmentControllerTest {
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.status").value("CANCELLED"))
+    }
+
+    @Test
+    fun `POST - 응답에 timezone과 locale이 클리닉 설정과 일치`() {
+        // 교민 병원: locale=ko-KR 이지만 timezone은 미국 (LA 교민 병원 시나리오)
+        val expatClinicId = transaction {
+            Clinics.insertAndGetId {
+                it[name] = "LA 교민 클리닉"
+                it[slotDurationMinutes] = 30
+                it[timezone] = "America/Los_Angeles"
+                it[locale] = "ko-KR"
+                it[maxConcurrentPatients] = 1
+            }.value
+        }
+        val expatDoctorId = transaction {
+            Doctors.insertAndGetId {
+                it[Doctors.clinicId] = expatClinicId
+                it[name] = "Dr. Kim"
+                it[specialty] = "General"
+                it[providerType] = "DOCTOR"
+                it[maxConcurrentPatients] = 1
+            }.value
+        }
+        val expatTreatmentId = transaction {
+            TreatmentTypes.insertAndGetId {
+                it[TreatmentTypes.clinicId] = expatClinicId
+                it[name] = "General Checkup"
+                it[category] = "GENERAL"
+                it[defaultDurationMinutes] = 30
+                it[requiredProviderType] = "DOCTOR"
+                it[requiresEquipment] = false
+                it[maxConcurrentPatients] = 1
+            }.value
+        }
+
+        val body = """
+            {
+                "clinicId": $expatClinicId,
+                "doctorId": $expatDoctorId,
+                "treatmentTypeId": $expatTreatmentId,
+                "patientName": "김철수",
+                "appointmentDate": "2026-04-06",
+                "startTime": "10:00",
+                "endTime": "10:30"
+            }
+        """.trimIndent()
+
+        mockMvc.perform(
+            post("/api/appointments")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+        )
+            .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.data.timezone").value("America/Los_Angeles"))
+            .andExpect(jsonPath("$.data.locale").value("ko-KR"))  // timezone과 독립적
     }
 
     private fun createTestAppointment(): Long =

--- a/appointment-core/README.md
+++ b/appointment-core/README.md
@@ -77,6 +77,51 @@ val newState = machine.transition(
 > 테스트에서 DB 초기화: `@BeforeEach` — `SchemaUtils.createMissingTablesAndColumns(Table)` + `Table.deleteAll()`
 > Testcontainers: `@Testcontainers` 어노테이션 없이 bluetape4k singleton 패턴 사용
 
+## 타임존 설계
+
+### 저장 원칙
+
+| 컬럼 | 타입 | 기준 |
+|------|------|------|
+| `appointment_date` | `LocalDate` | 클리닉 현지 날짜 |
+| `start_time` / `end_time` | `LocalTime` | 클리닉 현지 시간 |
+| `created_at` / `updated_at` | `Instant` (UTC) | 시스템 감사 타임스탬프 |
+
+**예약 시간은 UTC 변환 없이 클리닉 현지 시간으로 저장합니다.**
+
+UTC로 변환하지 않는 이유:
+- 예약은 본질적으로 현지 이벤트 — "서울 클리닉 23:00" 를 UTC로 변환하면 날짜가 바뀜
+- `WHERE appointment_date = '2026-04-01'` 같은 날짜 기반 쿼리가 timezone에 무관하게 정확
+- 슬롯 계산, 영업시간 비교가 동일 timezone 안에서 단순하게 유지됨
+
+### 다국가 SaaS 지원
+
+각 클리닉은 `Clinics.timezone` 컬럼으로 ZoneId를 보유합니다 (예: `"Asia/Seoul"`, `"America/New_York"`).
+`Clinics.locale` 은 날짜/시간 **표시 형식**과 언어 용도로만 사용합니다 — 타임존과는 별개입니다
+(교민 병원처럼 `locale="ko-KR"` 이지만 timezone이 `"America/Los_Angeles"` 일 수 있음).
+
+### API 흐름
+
+```
+Frontend  →  LocalDate + LocalTime (클리닉 현지)
+               ↓  변환 없이 저장
+DB        →  LocalDate + LocalTime (클리닉 현지)
+               ↓  응답 시 Clinics.timezone / locale 포함
+Frontend  →  ZonedDateTime 복원 가능 (appointmentDate + startTime + timezone)
+```
+
+### ClinicTimezoneService
+
+`ClinicTimezoneService` 는 API 경계에서 timezone 정보를 조합할 때 사용합니다:
+
+```kotlin
+// 응답에 timezone/locale 포함 (단일 DB 조회)
+val (timezone, locale) = timezoneService.getTimezoneAndLocale(clinicId)
+
+// 크로스-클리닉 비교 시 ZonedDateTime 변환
+val zoned: ZonedDateTime = timezoneService.toClinicTime(clinicId, date, time)
+```
+
 ## 설계 문서
 
 - [도메인 모델 전체](../docs/requirements/domain-model.md)

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/timezone/ClinicTimezoneService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/timezone/ClinicTimezoneService.kt
@@ -16,8 +16,29 @@ import java.util.Locale
 /**
  * 클리닉별 타임존 변환 서비스.
  *
- * 내부 저장은 UTC 기준 LocalDate/LocalTime이며,
- * 외부 표시 시 클리닉의 timezone으로 변환합니다.
+ * ## 타임존 설계 원칙
+ *
+ * `appointment_date` / `start_time` / `end_time` 은 **클리닉 현지 시간** 그대로 DB에 저장됩니다.
+ * UTC로 변환하지 않는 이유:
+ * - 예약 시간은 본질적으로 "현지 이벤트" — "서울 클리닉 오전 9시" 는 항상 서울 시간
+ * - UTC 변환 시 날짜 경계(예: 23:00 KST → 14:00 UTC 다음 날)로 인해 날짜 기반 쿼리가 깨짐
+ * - 슬롯 계산/영업시간 비교가 동일 timezone 내에서 단순하게 유지됨
+ *
+ * `created_at` / `updated_at` 은 UTC [java.time.Instant] 로 저장됩니다 (시스템 감사 목적).
+ *
+ * ## 다국가 SaaS 지원
+ *
+ * [Clinics.timezone] 컬럼이 각 클리닉의 ZoneId를 보유합니다.
+ * API 응답에 `timezone` 필드를 포함시켜 프론트엔드가 `LocalDate + LocalTime + timezone` 으로
+ * `ZonedDateTime` 을 복원할 수 있게 합니다.
+ *
+ * ```
+ * Frontend (LocalDate + LocalTime)
+ *     ↓  변환 없이 저장
+ * DB  (LocalDate + LocalTime — 클리닉 현지 기준)
+ *     ↓  응답 시 Clinics.timezone 포함
+ * Frontend (ZonedDateTime 복원 가능)
+ * ```
  */
 class ClinicTimezoneService(
     private val clinicRepository: ClinicRepository,
@@ -79,6 +100,18 @@ class ClinicTimezoneService(
     fun nowAtClinic(clinicId: Long): ZonedDateTime {
         val clinic = getClinic(clinicId)
         return ZonedDateTime.now(ZoneId.of(clinic.timezone))
+    }
+
+    /**
+     * 클리닉의 `timezone` 과 `locale` 을 한 번의 DB 조회로 반환합니다.
+     *
+     * API 응답에 두 값을 모두 포함할 때 N+1 조회를 방지합니다.
+     *
+     * @return `timezone` (예: "Asia/Seoul") to `locale` (예: "ko-KR") Pair
+     */
+    fun getTimezoneAndLocale(clinicId: Long): Pair<String, String> {
+        val clinic = getClinic(clinicId)
+        return clinic.timezone to clinic.locale
     }
 
     /**

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/timezone/ClinicTimezoneServiceTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/timezone/ClinicTimezoneServiceTest.kt
@@ -130,4 +130,41 @@ class ClinicTimezoneServiceTest {
 
         now.zone.shouldBeEqualTo(ZoneId.of("Asia/Seoul"))
     }
+
+    @Test
+    fun `getTimezoneAndLocale - timezone과 locale을 한 번의 DB 조회로 반환`() {
+        val (timezone, locale) = service.getTimezoneAndLocale(seoulClinicId)
+
+        timezone.shouldBeEqualTo("Asia/Seoul")
+        locale.shouldBeEqualTo("ko-KR")
+    }
+
+    @Test
+    fun `getTimezoneAndLocale - 클리닉별 각각 올바른 값 반환`() {
+        val (nyTimezone, nyLocale) = service.getTimezoneAndLocale(nyClinicId)
+        nyTimezone.shouldBeEqualTo("America/New_York")
+        nyLocale.shouldBeEqualTo("en-US")
+
+        val (tokyoTimezone, tokyoLocale) = service.getTimezoneAndLocale(tokyoClinicId)
+        tokyoTimezone.shouldBeEqualTo("Asia/Tokyo")
+        tokyoLocale.shouldBeEqualTo("ja-JP")
+    }
+
+    @Test
+    fun `getTimezoneAndLocale - 교민 병원 - locale과 timezone이 독립적`() {
+        // locale="ko-KR" 이지만 LA 소재 교민 병원
+        val expatClinicId = transaction {
+            Clinics.insert {
+                it[name] = "LA 교민 클리닉"
+                it[slotDurationMinutes] = 30
+                it[timezone] = "America/Los_Angeles"
+                it[locale] = "ko-KR"
+            }[Clinics.id].value
+        }
+
+        val (timezone, locale) = service.getTimezoneAndLocale(expatClinicId)
+
+        timezone.shouldBeEqualTo("America/Los_Angeles")
+        locale.shouldBeEqualTo("ko-KR")  // timezone과 무관하게 locale 유지
+    }
 }


### PR DESCRIPTION
## Summary

- `@ConditionalOnProperty` → `@Profile` 로 환경 분리 명시화 (`dev`/`test`/`prod`)
- `ClinicTimezoneService` dead code 해소 — `AppointmentController` 모든 응답에 `timezone`/`locale` 포함
- `getTimezoneAndLocale()` 신규 메서드로 N+1 DB 조회 방지
- 타임존 설계 원칙 KDoc + README 문서화

## 변경 상세

### @Profile 환경 분리
| 클래스 | 이전 | 이후 |
|---|---|---|
| `SchemaInitConfig` | `@ConditionalOnProperty(flyway.enabled=false)` | `@Profile("dev", "test")` |
| `TestDataSeederConfig` | 조건 없음 (항상 실행) | `@Profile("dev", "test")` |
| `NoOpSecurityConfig` | `@ConditionalOnProperty(jwt.enabled=false)` | `@Profile("dev", "test")` |
| `SecurityConfig` | `@ConditionalOnProperty(jwt.enabled=true)` | `@Profile("!dev & !test")` |

### 타임존 설계 원칙
- `appointment_date` / `start_time` / `end_time` → 클리닉 현지 시간 그대로 저장 (UTC 변환 X)
- `Clinics.timezone` 으로 ZoneId 보유, API 응답에 포함 → 프론트엔드가 `ZonedDateTime` 복원
- `locale` ≠ `timezone`: 교민 병원(`locale=ko-KR`, `timezone=America/Los_Angeles`) 지원

## Test plan
- [x] `appointment-api:test` — 12 passing (교민병원 시나리오 포함)
- [x] `appointment-core:test` — 110 passing (`getTimezoneAndLocale` 3개 신규)

🤖 Generated with [Claude Code](https://claude.com/claude-code)