### PR TITLE
test: 프론트엔드 테스트 커버리지 추가 (17→26 spec, 118→176 tests)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -75,13 +75,13 @@
 
 ### 1.3 프론트엔드 테스트 커버리지 (MEDIUM)
 
-현재 17개 spec 파일, 118 tests passing. 추가 필요:
+26개 spec 파일, 176 tests passing. ✅ 완료:
 
-- ⬜ `ClinicService` 테스트 — `clinic.service.spec.ts` 미작성
-- ⬜ `EquipmentService` 테스트 — `equipment.service.spec.ts` 미작성
-- ⬜ `RescheduleService` 테스트 — `reschedule.service.spec.ts` 미작성
-- ⬜ Calendar 컴포넌트 테스트 — `day-view`, `week-view`, `month-view` spec 없음
-- ⬜ Management 컴포넌트 테스트 — `doctor-list`, `treatment-type-list`, `clinic-list` spec 없음
+- ✅ `ClinicService` 테스트 — `clinic.service.spec.ts` (10 tests)
+- ✅ `EquipmentService` 테스트 — `equipment.service.spec.ts` (7 tests)
+- ✅ `RescheduleService` 테스트 — `reschedule.service.spec.ts` (8 tests)
+- ✅ Calendar 컴포넌트 테스트 — `day-view` (5), `week-view` (4), `month-view` (5)
+- ✅ Management 컴포넌트 테스트 — `doctor-list` (4), `treatment-type-list` (4), `clinic-list` (4)
 
 ---
 

--- a/frontend/appointment-frontend/src/app/core/services/clinic.service.spec.ts
+++ b/frontend/appointment-frontend/src/app/core/services/clinic.service.spec.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { ClinicService } from './clinic.service';
+
+describe('ClinicService', () => {
+  let service: ClinicService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(ClinicService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('서비스가 생성된다', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('초기 clinics signal은 빈 배열이다', () => {
+    expect(service.clinics()).toEqual([]);
+  });
+
+  it('초기 loading signal은 false이다', () => {
+    expect(service.loading()).toBe(false);
+  });
+
+  describe('getAll()', () => {
+    it('전체 클리닉 목록을 가져와 clinics signal에 설정한다', async () => {
+      const mockClinics = [
+        { id: 1, name: '서울 클리닉', phone: '02-1234-5678', address: '서울', slotDurationMinutes: 30 },
+        { id: 2, name: '부산 클리닉', phone: '051-9876-5432', address: '부산', slotDurationMinutes: 20 },
+      ];
+
+      const promise = service.getAll();
+
+      const req = httpTesting.expectOne('/api/clinics');
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: mockClinics });
+
+      const result = await promise;
+      expect(result).toEqual(mockClinics);
+      expect(service.clinics()).toEqual(mockClinics);
+    });
+
+    it('빈 응답 시 빈 배열이 설정된다', async () => {
+      const promise = service.getAll();
+
+      const req = httpTesting.expectOne('/api/clinics');
+      req.flush({ success: true, data: null });
+
+      const result = await promise;
+      expect(result).toEqual([]);
+      expect(service.clinics()).toEqual([]);
+    });
+
+    it('loading signal이 요청 중 true, 완료 후 false로 변경된다', async () => {
+      const promise = service.getAll();
+      expect(service.loading()).toBe(true);
+
+      const req = httpTesting.expectOne('/api/clinics');
+      req.flush({ success: true, data: [] });
+
+      await promise;
+      expect(service.loading()).toBe(false);
+    });
+  });
+
+  describe('getById()', () => {
+    it('특정 클리닉 정보를 반환한다', async () => {
+      const mockClinic = { id: 1, name: '서울 클리닉', phone: '02-1234-5678', address: '서울', slotDurationMinutes: 30 };
+
+      const promise = service.getById(1);
+
+      const req = httpTesting.expectOne('/api/clinics/1');
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: mockClinic });
+
+      const result = await promise;
+      expect(result).toEqual(mockClinic);
+    });
+  });
+
+  describe('getOperatingHours()', () => {
+    it('클리닉 영업시간 목록을 반환한다', async () => {
+      const mockHours = [
+        { id: 1, clinicId: 1, dayOfWeek: 'MONDAY', openTime: '09:00', closeTime: '18:00' },
+      ];
+
+      const promise = service.getOperatingHours(1);
+
+      const req = httpTesting.expectOne('/api/clinics/1/operating-hours');
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: mockHours });
+
+      const result = await promise;
+      expect(result).toEqual(mockHours);
+    });
+
+    it('빈 응답 시 빈 배열을 반환한다', async () => {
+      const promise = service.getOperatingHours(1);
+
+      const req = httpTesting.expectOne('/api/clinics/1/operating-hours');
+      req.flush({ success: true, data: null });
+
+      const result = await promise;
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getBreakTimes()', () => {
+    it('클리닉 휴식시간 목록을 반환한다', async () => {
+      const mockBreaks = [
+        { id: 1, clinicId: 1, startTime: '12:00', endTime: '13:00' },
+      ];
+
+      const promise = service.getBreakTimes(1);
+
+      const req = httpTesting.expectOne('/api/clinics/1/break-times');
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: mockBreaks });
+
+      const result = await promise;
+      expect(result).toEqual(mockBreaks);
+    });
+  });
+});

--- a/frontend/appointment-frontend/src/app/core/services/equipment.service.spec.ts
+++ b/frontend/appointment-frontend/src/app/core/services/equipment.service.spec.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { EquipmentService } from './equipment.service';
+
+describe('EquipmentService', () => {
+  let service: EquipmentService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(EquipmentService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('서비스가 생성된다', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('초기 equipments signal은 빈 배열이다', () => {
+    expect(service.equipments()).toEqual([]);
+  });
+
+  it('초기 loading signal은 false이다', () => {
+    expect(service.loading()).toBe(false);
+  });
+
+  describe('loadByClinic()', () => {
+    it('clinicId로 장비 목록을 로드하고 equipments signal에 설정한다', async () => {
+      const mockEquipments = [
+        { id: 1, clinicId: 1, name: 'X-ray', equipmentType: 'IMAGING' },
+        { id: 2, clinicId: 1, name: 'MRI', equipmentType: 'IMAGING' },
+      ];
+
+      const promise = service.loadByClinic(1);
+
+      const req = httpTesting.expectOne('/api/clinics/1/equipments');
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: mockEquipments });
+
+      const result = await promise;
+      expect(result).toEqual(mockEquipments);
+      expect(service.equipments()).toEqual(mockEquipments);
+    });
+
+    it('빈 응답 시 빈 배열이 설정된다', async () => {
+      const promise = service.loadByClinic(99);
+
+      const req = httpTesting.expectOne('/api/clinics/99/equipments');
+      req.flush({ success: true, data: null });
+
+      const result = await promise;
+      expect(result).toEqual([]);
+      expect(service.equipments()).toEqual([]);
+    });
+
+    it('loading signal이 요청 중 true, 완료 후 false로 변경된다', async () => {
+      const promise = service.loadByClinic(1);
+      expect(service.loading()).toBe(true);
+
+      const req = httpTesting.expectOne('/api/clinics/1/equipments');
+      req.flush({ success: true, data: [] });
+
+      await promise;
+      expect(service.loading()).toBe(false);
+    });
+  });
+
+  describe('getById()', () => {
+    it('특정 장비 정보를 반환한다', async () => {
+      const mockEquipment = { id: 1, clinicId: 1, name: 'X-ray', equipmentType: 'IMAGING' };
+
+      const promise = service.getById(1);
+
+      const req = httpTesting.expectOne('/api/equipments/1');
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: mockEquipment });
+
+      const result = await promise;
+      expect(result).toEqual(mockEquipment);
+    });
+  });
+});

--- a/frontend/appointment-frontend/src/app/core/services/reschedule.service.spec.ts
+++ b/frontend/appointment-frontend/src/app/core/services/reschedule.service.spec.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { RescheduleService } from './reschedule.service';
+
+describe('RescheduleService', () => {
+  let service: RescheduleService;
+  let httpTesting: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(RescheduleService);
+    httpTesting = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpTesting.verify();
+  });
+
+  it('서비스가 생성된다', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('getClosureCandidates()', () => {
+    it('휴진 일괄 재배정 후보를 Map으로 반환한다', async () => {
+      const mockData = {
+        10: [{ id: 1, appointmentId: 10, doctorId: 2, appointmentDate: '2026-04-25', startTime: '09:00', endTime: '09:30' }],
+        11: [{ id: 2, appointmentId: 11, doctorId: 2, appointmentDate: '2026-04-25', startTime: '10:00', endTime: '10:30' }],
+      };
+
+      const promise = service.getClosureCandidates(10, 1, '2026-04-22', 7);
+
+      const req = httpTesting.expectOne(
+        r => r.url === '/api/appointments/10/reschedule/closure'
+          && r.params.get('clinicId') === '1'
+          && r.params.get('closureDate') === '2026-04-22'
+          && r.params.get('searchDays') === '7'
+      );
+      expect(req.request.method).toBe('POST');
+      req.flush({ success: true, data: mockData });
+
+      const result = await promise;
+      expect(result).toBeInstanceOf(Map);
+      expect(result.get(10)).toHaveLength(1);
+      expect(result.get(11)).toHaveLength(1);
+    });
+
+    it('빈 응답 시 빈 Map을 반환한다', async () => {
+      const promise = service.getClosureCandidates(99, 1, '2026-04-22', 7);
+
+      const req = httpTesting.expectOne(r => r.url === '/api/appointments/99/reschedule/closure');
+      req.flush({ success: true, data: null });
+
+      const result = await promise;
+      expect(result.size).toBe(0);
+    });
+  });
+
+  describe('getCandidates()', () => {
+    it('개별 예약 재배정 후보 목록을 반환한다', async () => {
+      const mockCandidates = [
+        { id: 1, appointmentId: 10, doctorId: 2, appointmentDate: '2026-04-25', startTime: '09:00', endTime: '09:30' },
+        { id: 2, appointmentId: 10, doctorId: 3, appointmentDate: '2026-04-26', startTime: '14:00', endTime: '14:30' },
+      ];
+
+      const promise = service.getCandidates(10);
+
+      const req = httpTesting.expectOne('/api/appointments/10/reschedule/candidates');
+      expect(req.request.method).toBe('GET');
+      req.flush({ success: true, data: mockCandidates });
+
+      const result = await promise;
+      expect(result).toEqual(mockCandidates);
+    });
+
+    it('빈 응답 시 빈 배열을 반환한다', async () => {
+      const promise = service.getCandidates(999);
+
+      const req = httpTesting.expectOne('/api/appointments/999/reschedule/candidates');
+      req.flush({ success: true, data: null });
+
+      const result = await promise;
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('confirm()', () => {
+    it('선택한 후보로 재배정을 확정하고 새 appointmentId를 반환한다', async () => {
+      const promise = service.confirm(10, 1);
+
+      const req = httpTesting.expectOne('/api/appointments/10/reschedule/confirm/1');
+      expect(req.request.method).toBe('POST');
+      req.flush({ success: true, data: 42 });
+
+      const result = await promise;
+      expect(result).toBe(42);
+    });
+  });
+
+  describe('autoReschedule()', () => {
+    it('최적 후보로 자동 재배정하고 새 appointmentId를 반환한다', async () => {
+      const promise = service.autoReschedule(10);
+
+      const req = httpTesting.expectOne('/api/appointments/10/reschedule/auto');
+      expect(req.request.method).toBe('POST');
+      req.flush({ success: true, data: 55 });
+
+      const result = await promise;
+      expect(result).toBe(55);
+    });
+
+    it('자동 배정 불가 시 null을 반환한다', async () => {
+      const promise = service.autoReschedule(10);
+
+      const req = httpTesting.expectOne('/api/appointments/10/reschedule/auto');
+      req.flush({ success: true, data: null });
+
+      const result = await promise;
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/frontend/appointment-frontend/src/app/features/calendar/day-view/day-view.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/calendar/day-view/day-view.component.spec.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { provideLocationMocks } from '@angular/common/testing';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { signal } from '@angular/core';
+
+import { DayViewComponent } from './day-view.component';
+
+describe('DayViewComponent', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [DayViewComponent],
+      providers: [
+        provideRouter([{ path: 'calendar/day/:date', component: DayViewComponent }]),
+        provideLocationMocks(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideAnimationsAsync(),
+      ],
+    });
+
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  async function createAndFlush() {
+    const fixture = TestBed.createComponent(DayViewComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    httpMock.match(() => true).forEach(req => req.flush({ success: true, data: [] }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('컴포넌트가 생성된다', async () => {
+    const fixture = await createAndFlush();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('08:00~18:00 범위의 timeSlots가 생성된다', async () => {
+    const fixture = await createAndFlush();
+    const slots = fixture.componentInstance['timeSlots'];
+    expect(slots.length).toBe(20); // (18-8) * 2 = 20 슬롯
+    expect(slots[0].label).toBe('08:00');
+    expect(slots[slots.length - 1].label).toBe('17:30');
+  });
+
+  it('getAppointmentsForSlot은 해당 슬롯에 맞는 예약만 반환한다', async () => {
+    const fixture = await createAndFlush();
+    const comp = fixture.componentInstance;
+
+    // appointmentService.appointments signal에 목 데이터 주입
+    const mockAppt = { id: 1, doctorId: 2, startTime: '09:00', endTime: '09:30', status: 'CONFIRMED' } as any;
+    comp['appointmentService']['_appointments'].set([mockAppt]);
+
+    const slot = { label: '09:00', hour: 9, minute: 0 };
+    const result = comp['getAppointmentsForSlot'](2, slot);
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe(1);
+  });
+
+  it('getAppointmentsForSlot은 다른 의사의 예약을 반환하지 않는다', async () => {
+    const fixture = await createAndFlush();
+    const comp = fixture.componentInstance;
+
+    const mockAppt = { id: 1, doctorId: 3, startTime: '09:00', endTime: '09:30', status: 'CONFIRMED' } as any;
+    comp['appointmentService']['_appointments'].set([mockAppt]);
+
+    const slot = { label: '09:00', hour: 9, minute: 0 };
+    const result = comp['getAppointmentsForSlot'](2, slot);
+    expect(result).toHaveLength(0);
+  });
+
+  it('statusColor는 상태별로 올바른 색상을 반환한다', async () => {
+    const fixture = await createAndFlush();
+    const comp = fixture.componentInstance;
+
+    expect(comp['statusColor']('CONFIRMED')).toBe('#4CAF50');
+    expect(comp['statusColor']('CANCELLED')).toBe('#F44336');
+    expect(comp['statusColor']('UNKNOWN')).toBe('#9E9E9E');
+  });
+});

--- a/frontend/appointment-frontend/src/app/features/calendar/month-view/month-view.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/calendar/month-view/month-view.component.spec.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { provideLocationMocks } from '@angular/common/testing';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+
+import { MonthViewComponent } from './month-view.component';
+
+describe('MonthViewComponent', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [MonthViewComponent],
+      providers: [
+        provideRouter([{ path: 'calendar/month/:date', component: MonthViewComponent }]),
+        provideLocationMocks(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideAnimationsAsync(),
+      ],
+    });
+
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  async function createAndFlush() {
+    const fixture = TestBed.createComponent(MonthViewComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    httpMock.match(() => true).forEach(req => req.flush({ success: true, data: [] }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('컴포넌트가 생성된다', async () => {
+    const fixture = await createAndFlush();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('weekdays가 7개 레이블을 가진다', async () => {
+    const fixture = await createAndFlush();
+    expect(fixture.componentInstance['weekdays']).toHaveLength(7);
+  });
+
+  it('cells는 최소 28개 이상의 날짜 셀을 가진다', async () => {
+    const fixture = await createAndFlush();
+    const cells = fixture.componentInstance['cells']();
+    expect(cells.length).toBeGreaterThanOrEqual(28);
+  });
+
+  it('cells의 각 항목은 date, dateStr, day, isCurrentMonth 필드를 가진다', async () => {
+    const fixture = await createAndFlush();
+    const cell = fixture.componentInstance['cells']()[0];
+    expect(cell).toHaveProperty('date');
+    expect(cell).toHaveProperty('dateStr');
+    expect(cell).toHaveProperty('day');
+    expect(cell).toHaveProperty('isCurrentMonth');
+  });
+
+  it('loading signal이 초기에 false이다', async () => {
+    const fixture = await createAndFlush();
+    expect(fixture.componentInstance['loading']()).toBe(false);
+  });
+});

--- a/frontend/appointment-frontend/src/app/features/calendar/week-view/week-view.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/calendar/week-view/week-view.component.spec.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { provideLocationMocks } from '@angular/common/testing';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+
+import { WeekViewComponent } from './week-view.component';
+
+describe('WeekViewComponent', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [WeekViewComponent],
+      providers: [
+        provideRouter([{ path: 'calendar/week/:date', component: WeekViewComponent }]),
+        provideLocationMocks(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideAnimationsAsync(),
+      ],
+    });
+
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  async function createAndFlush() {
+    const fixture = TestBed.createComponent(WeekViewComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    httpMock.match(() => true).forEach(req => req.flush({ success: true, data: [] }));
+    fixture.detectChanges();
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('컴포넌트가 생성된다', async () => {
+    const fixture = await createAndFlush();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('08:00~18:00 범위의 timeSlots가 생성된다', async () => {
+    const fixture = await createAndFlush();
+    const slots = fixture.componentInstance['timeSlots'];
+    expect(slots.length).toBe(20);
+    expect(slots[0].label).toBe('08:00');
+    expect(slots[slots.length - 1].label).toBe('17:30');
+  });
+
+  it('weekDays가 7일을 포함한다', async () => {
+    const fixture = await createAndFlush();
+    const weekDays = fixture.componentInstance['weekDays'];
+    expect(weekDays()).toHaveLength(7);
+  });
+
+  it('loading signal이 초기에 false이다', async () => {
+    const fixture = await createAndFlush();
+    expect(fixture.componentInstance['loading']()).toBe(false);
+  });
+});

--- a/frontend/appointment-frontend/src/app/features/management/clinic-list/clinic-list.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/management/clinic-list/clinic-list.component.spec.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+
+import { ClinicListComponent } from './clinic-list.component';
+
+describe('ClinicListComponent', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ClinicListComponent],
+      providers: [
+        provideAnimationsAsync(),
+      ],
+    });
+  });
+
+  it('컴포넌트가 생성된다', () => {
+    const fixture = TestBed.createComponent(ClinicListComponent);
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('clinics 목록에 MOCK_CLINICS 데이터가 포함된다', () => {
+    const fixture = TestBed.createComponent(ClinicListComponent);
+    fixture.detectChanges();
+
+    const clinics = fixture.componentInstance.clinics;
+    expect(clinics.length).toBeGreaterThan(0);
+  });
+
+  it('각 클리닉은 id, name, phone, address, slotDurationMinutes 필드를 가진다', () => {
+    const fixture = TestBed.createComponent(ClinicListComponent);
+    fixture.detectChanges();
+
+    const clinic = fixture.componentInstance.clinics[0];
+    expect(clinic).toHaveProperty('id');
+    expect(clinic).toHaveProperty('name');
+    expect(clinic).toHaveProperty('phone');
+    expect(clinic).toHaveProperty('address');
+    expect(clinic).toHaveProperty('slotDurationMinutes');
+  });
+
+  it('클리닉 카드가 clinics 개수만큼 렌더된다', () => {
+    const fixture = TestBed.createComponent(ClinicListComponent);
+    fixture.detectChanges();
+
+    const cards = fixture.nativeElement.querySelectorAll('mat-card');
+    expect(cards.length).toBe(fixture.componentInstance.clinics.length);
+  });
+});

--- a/frontend/appointment-frontend/src/app/features/management/doctor-list/doctor-list.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/management/doctor-list/doctor-list.component.spec.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { provideLocationMocks } from '@angular/common/testing';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+
+import { DoctorListComponent } from './doctor-list.component';
+
+describe('DoctorListComponent', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [DoctorListComponent],
+      providers: [
+        provideRouter([]),
+        provideLocationMocks(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideAnimationsAsync(),
+      ],
+    });
+
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  async function createAndFlush(mockDoctors: unknown[] = []) {
+    const fixture = TestBed.createComponent(DoctorListComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    httpMock.match(() => true).forEach(req =>
+      req.flush({ success: true, data: mockDoctors })
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('컴포넌트가 생성된다', async () => {
+    const fixture = await createAndFlush();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('displayedColumns가 name, specialty, providerType을 포함한다', async () => {
+    const fixture = await createAndFlush();
+    expect(fixture.componentInstance.displayedColumns).toContain('name');
+    expect(fixture.componentInstance.displayedColumns).toContain('specialty');
+    expect(fixture.componentInstance.displayedColumns).toContain('providerType');
+  });
+
+  it('의사 목록 데이터가 주입되면 doctors signal에 반영된다', async () => {
+    const mockDoctors = [
+      { id: 1, clinicId: 1, name: '김민준', specialty: '일반의', providerType: 'DOCTOR' },
+    ];
+    const fixture = await createAndFlush(mockDoctors);
+    expect(fixture.componentInstance.doctors()).toHaveLength(1);
+    expect(fixture.componentInstance.doctors()[0].name).toBe('김민준');
+  });
+
+  it('의사가 없을 때 doctors signal이 빈 배열이다', async () => {
+    const fixture = await createAndFlush([]);
+    expect(fixture.componentInstance.doctors()).toHaveLength(0);
+  });
+});

--- a/frontend/appointment-frontend/src/app/features/management/treatment-list/treatment-type-list.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/management/treatment-list/treatment-type-list.component.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
+import { provideLocationMocks } from '@angular/common/testing';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+
+import { TreatmentTypeListComponent } from './treatment-type-list.component';
+
+describe('TreatmentTypeListComponent', () => {
+  let httpMock: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [TreatmentTypeListComponent],
+      providers: [
+        provideRouter([]),
+        provideLocationMocks(),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideAnimationsAsync(),
+      ],
+    });
+
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  async function createAndFlush(mockTypes: unknown[] = []) {
+    const fixture = TestBed.createComponent(TreatmentTypeListComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    httpMock.match(() => true).forEach(req =>
+      req.flush({ success: true, data: mockTypes })
+    );
+    fixture.detectChanges();
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  it('컴포넌트가 생성된다', async () => {
+    const fixture = await createAndFlush();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('displayedColumns가 name, category, duration, requiresEquipment을 포함한다', async () => {
+    const fixture = await createAndFlush();
+    expect(fixture.componentInstance.displayedColumns).toContain('name');
+    expect(fixture.componentInstance.displayedColumns).toContain('category');
+    expect(fixture.componentInstance.displayedColumns).toContain('duration');
+    expect(fixture.componentInstance.displayedColumns).toContain('requiresEquipment');
+  });
+
+  it('진료유형 목록이 주입되면 treatmentTypes signal에 반영된다', async () => {
+    const mockTypes = [
+      { id: 1, clinicId: 1, name: '일반진료', category: 'GENERAL', defaultDurationMinutes: 30, requiresEquipment: false },
+    ];
+    const fixture = await createAndFlush(mockTypes);
+    expect(fixture.componentInstance.treatmentTypes()).toHaveLength(1);
+    expect(fixture.componentInstance.treatmentTypes()[0].name).toBe('일반진료');
+  });
+
+  it('진료유형이 없을 때 treatmentTypes signal이 빈 배열이다', async () => {
+    const fixture = await createAndFlush([]);
+    expect(fixture.componentInstance.treatmentTypes()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## 변경 내용

TODO 1.3 — 누락된 9개 spec 파일 작성으로 프론트엔드 테스트 커버리지 확충

### 서비스 spec 3개 신규 추가

| 파일 | 테스트 수 | 검증 항목 |
|------|----------|---------|
| clinic.service.spec.ts | 10 | getAll, getById, getOperatingHours, getBreakTimes, loading signal |
| equipment.service.spec.ts | 7 | loadByClinic, getById, equipments signal, loading signal |
  reschedule.service.spec.ts | 8 | getClosureCandidates, getCandidates, confirm, autoReschedule |

### 컴포넌트 spec 6개 신규 추가

| 파일 | 테스트 수 | 검증 항목 |
|------|----------|---------|
| day-view.component.spec.ts | 5 | timeSlots 20개, getAppointmentsForSlot 필터링, statusColor |
| week-view.component.spec.ts | 4 | timeSlots 20개, weekDays 7개, loading 초기값 |
| month-view.component.spec.ts | 5 | weekdays 7개, cells 구조, isCurrentMonth |
| doctor-list.component.spec.ts | 4 | displayedColumns, doctors signal |
| treatment-type-list.component.spec.ts | 4 | displayedColumns, treatmentTypes signal |
| clinic-list.component.spec.ts | 4 | MOCK_CLINICS 검증, 필드 구조, mat-card 렌더 개수 |

## 테스트 결과

26 spec files — 176 tests passed (0 failed)