### PR TITLE
feat: ClinicListComponent MOCK_CLINICS 제거 및 ClinicService 연결

### DIFF
--- a/frontend/appointment-frontend/src/app/features/management/clinic-list/clinic-list.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/management/clinic-list/clinic-list.component.spec.ts
@@ -1,49 +1,77 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 
 import { ClinicListComponent } from './clinic-list.component';
 
+const MOCK_CLINICS = [
+  { id: 1, name: '서울 메인 클리닉', slotDurationMinutes: 30, timezone: 'Asia/Seoul', locale: 'ko-KR', maxConcurrentPatients: 5, openOnHolidays: false },
+  { id: 2, name: '부산 해운대 클리닉', slotDurationMinutes: 20, timezone: 'Asia/Seoul', locale: 'ko-KR', maxConcurrentPatients: 3, openOnHolidays: true },
+];
+
 describe('ClinicListComponent', () => {
+  let httpMock: HttpTestingController;
+
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [ClinicListComponent],
       providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
         provideAnimationsAsync(),
       ],
     });
+
+    httpMock = TestBed.inject(HttpTestingController);
   });
 
-  it('컴포넌트가 생성된다', () => {
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  async function createAndFlush(mockClinics: unknown[] = []) {
     const fixture = TestBed.createComponent(ClinicListComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    httpMock.match(() => true).forEach(req =>
+      req.flush({ success: true, data: mockClinics })
+    );
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('컴포넌트가 생성된다', async () => {
+    const fixture = await createAndFlush();
     expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('clinics 목록에 MOCK_CLINICS 데이터가 포함된다', () => {
-    const fixture = TestBed.createComponent(ClinicListComponent);
-    fixture.detectChanges();
-
-    const clinics = fixture.componentInstance.clinics;
-    expect(clinics.length).toBeGreaterThan(0);
+  it('API 응답 데이터가 clinics signal에 반영된다', async () => {
+    const fixture = await createAndFlush(MOCK_CLINICS);
+    expect(fixture.componentInstance.clinics()).toHaveLength(2);
+    expect(fixture.componentInstance.clinics()[0].name).toBe('서울 메인 클리닉');
   });
 
-  it('각 클리닉은 id, name, phone, address, slotDurationMinutes 필드를 가진다', () => {
-    const fixture = TestBed.createComponent(ClinicListComponent);
-    fixture.detectChanges();
-
-    const clinic = fixture.componentInstance.clinics[0];
+  it('각 클리닉은 id, name, slotDurationMinutes, timezone 필드를 가진다', async () => {
+    const fixture = await createAndFlush(MOCK_CLINICS);
+    const clinic = fixture.componentInstance.clinics()[0];
     expect(clinic).toHaveProperty('id');
     expect(clinic).toHaveProperty('name');
-    expect(clinic).toHaveProperty('phone');
-    expect(clinic).toHaveProperty('address');
     expect(clinic).toHaveProperty('slotDurationMinutes');
+    expect(clinic).toHaveProperty('timezone');
   });
 
-  it('클리닉 카드가 clinics 개수만큼 렌더된다', () => {
-    const fixture = TestBed.createComponent(ClinicListComponent);
-    fixture.detectChanges();
-
+  it('클리닉 카드가 clinics 개수만큼 렌더된다', async () => {
+    const fixture = await createAndFlush(MOCK_CLINICS);
     const cards = fixture.nativeElement.querySelectorAll('mat-card');
-    expect(cards.length).toBe(fixture.componentInstance.clinics.length);
+    expect(cards.length).toBe(fixture.componentInstance.clinics().length);
+  });
+
+  it('클리닉이 없을 때 clinics signal이 빈 배열이다', async () => {
+    const fixture = await createAndFlush([]);
+    expect(fixture.componentInstance.clinics()).toHaveLength(0);
   });
 });

--- a/frontend/appointment-frontend/src/app/features/management/clinic-list/clinic-list.component.ts
+++ b/frontend/appointment-frontend/src/app/features/management/clinic-list/clinic-list.component.ts
@@ -1,67 +1,54 @@
-import { Component } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-
-interface ClinicDisplay {
-  id: number;
-  name: string;
-  phone: string;
-  address: string;
-  slotDurationMinutes: number;
-}
-
-const MOCK_CLINICS: ClinicDisplay[] = [
-  {
-    id: 1,
-    name: '서울 메인 클리닉',
-    phone: '02-1234-5678',
-    address: '서울특별시 강남구 테헤란로 123',
-    slotDurationMinutes: 30,
-  },
-  {
-    id: 2,
-    name: '부산 해운대 클리닉',
-    phone: '051-9876-5432',
-    address: '부산광역시 해운대구 해운대로 456',
-    slotDurationMinutes: 20,
-  },
-];
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { ClinicService } from '../../../core/services/clinic.service';
 
 @Component({
   selector: 'app-clinic-list',
   standalone: true,
-  imports: [MatCardModule, MatIconModule],
+  imports: [MatCardModule, MatIconModule, MatProgressSpinnerModule],
   template: `
     <div class="page-container">
       <h1 class="page-title">클리닉 정보</h1>
 
-      <div class="clinic-grid">
-        @for (clinic of clinics; track clinic.id) {
-          <mat-card class="clinic-card">
-            <mat-card-header>
-              <mat-icon mat-card-avatar>local_hospital</mat-icon>
-              <mat-card-title>{{ clinic.name }}</mat-card-title>
-              <mat-card-subtitle>클리닉 #{{ clinic.id }}</mat-card-subtitle>
-            </mat-card-header>
-            <mat-card-content>
-              <ul class="info-list">
-                <li>
-                  <mat-icon>phone</mat-icon>
-                  <span>{{ clinic.phone }}</span>
-                </li>
-                <li>
-                  <mat-icon>location_on</mat-icon>
-                  <span>{{ clinic.address }}</span>
-                </li>
-                <li>
-                  <mat-icon>schedule</mat-icon>
-                  <span>슬롯 단위: {{ clinic.slotDurationMinutes }}분</span>
-                </li>
-              </ul>
-            </mat-card-content>
-          </mat-card>
-        }
-      </div>
+      @if (loading()) {
+        <div class="loading-container">
+          <mat-spinner diameter="48" />
+        </div>
+      } @else {
+        <div class="clinic-grid">
+          @for (clinic of clinics(); track clinic.id) {
+            <mat-card class="clinic-card">
+              <mat-card-header>
+                <mat-icon mat-card-avatar>local_hospital</mat-icon>
+                <mat-card-title>{{ clinic.name }}</mat-card-title>
+                <mat-card-subtitle>클리닉 #{{ clinic.id }}</mat-card-subtitle>
+              </mat-card-header>
+              <mat-card-content>
+                <ul class="info-list">
+                  <li>
+                    <mat-icon>schedule</mat-icon>
+                    <span>슬롯 단위: {{ clinic.slotDurationMinutes }}분</span>
+                  </li>
+                  <li>
+                    <mat-icon>language</mat-icon>
+                    <span>시간대: {{ clinic.timezone }}</span>
+                  </li>
+                  <li>
+                    <mat-icon>people</mat-icon>
+                    <span>최대 동시 환자: {{ clinic.maxConcurrentPatients }}명</span>
+                  </li>
+                  <li>
+                    <mat-icon>event_available</mat-icon>
+                    <span>공휴일 운영: {{ clinic.openOnHolidays ? '예' : '아니오' }}</span>
+                  </li>
+                </ul>
+              </mat-card-content>
+            </mat-card>
+          }
+        </div>
+      }
     </div>
   `,
   styles: [`
@@ -76,6 +63,12 @@ const MOCK_CLINICS: ClinicDisplay[] = [
       font-weight: 600;
       margin-bottom: 24px;
       color: #1a1a1a;
+    }
+
+    .loading-container {
+      display: flex;
+      justify-content: center;
+      padding: 48px;
     }
 
     .clinic-grid {
@@ -113,6 +106,13 @@ const MOCK_CLINICS: ClinicDisplay[] = [
     }
   `],
 })
-export class ClinicListComponent {
-  readonly clinics: ClinicDisplay[] = MOCK_CLINICS;
+export class ClinicListComponent implements OnInit {
+  private readonly clinicService = inject(ClinicService);
+
+  readonly clinics = this.clinicService.clinics;
+  readonly loading = this.clinicService.loading;
+
+  ngOnInit(): void {
+    this.clinicService.getAll();
+  }
 }


### PR DESCRIPTION
## TODO 3.2

ClinicListComponent가 하드코딩 MOCK_CLINICS를 사용하던 것을 ClinicService 실제 API로 교체.

## 변경 내용

### clinic-list.component.ts
- MOCK_CLINICS 상수 및 ClinicDisplay interface 제거
- ClinicService inject → ngOnInit에서 getAll() 호출
- clinics/loading signal을 ClinicService에서 위임
- @if (loading()) 로딩 스피너 추가
- template: phone/address 제거(API 미지원), timezone/maxConcurrentPatients/openOnHolidays 표시

### clinic-list.component.spec.ts
- HTTP mock 패턴으로 전면 교체 (provideHttpClient + HttpTestingController)
- createAndFlush() 헬퍼 도입 (다른 컴포넌트 spec과 동일 패턴)
- 테스트 5개: 생성, API 응답 반영, 필드 구조, 카드 렌더 개수, 빈 배열

## 테스트 결과

26 spec files — 170 tests passed (0 failed)