### PR TITLE
refactor: AppointmentController에서 AppointmentService 서비스 레이어 추출

### DIFF
--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
@@ -7,20 +7,11 @@ import io.bluetape4k.clinic.appointment.api.dto.AppointmentResponse
 import io.bluetape4k.clinic.appointment.api.dto.CreateAppointmentRequest
 import io.bluetape4k.clinic.appointment.api.dto.UpdateStatusRequest
 import io.bluetape4k.clinic.appointment.api.dto.toResponse
-import io.bluetape4k.clinic.appointment.event.AppointmentDomainEvent
-import io.bluetape4k.clinic.appointment.model.dto.AppointmentRecord
-import io.bluetape4k.clinic.appointment.model.tables.AppointmentStateHistoryRecord
-import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
-import io.bluetape4k.clinic.appointment.repository.AppointmentStateHistoryRepository
-import io.bluetape4k.clinic.appointment.statemachine.AppointmentEvent
-import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
-import io.bluetape4k.clinic.appointment.statemachine.AppointmentStateMachine
+import io.bluetape4k.clinic.appointment.api.service.AppointmentService
 import io.bluetape4k.clinic.appointment.timezone.ClinicTimezoneService
-import org.jetbrains.exposed.v1.jdbc.transactions.transaction
-import org.springframework.context.ApplicationEventPublisher
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -32,32 +23,14 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
 
-/**
- * 예약 관리 REST 컨트롤러.
- *
- * 예약의 조회, 생성, 상태 변경, 취소 API를 제공합니다.
- * 모든 상태 변경은 [AppointmentStateMachine]을 통해 유효성 검증되며,
- * 변경 완료 시 [ApplicationEventPublisher]로 도메인 이벤트를 발행합니다.
- */
 @RestController
 @RequestMapping("/api/appointments")
 class AppointmentController(
-    private val appointmentRepository: AppointmentRepository,
-    private val stateMachine: AppointmentStateMachine,
-    private val eventPublisher: ApplicationEventPublisher,
-    private val stateHistoryRepository: AppointmentStateHistoryRepository,
+    private val appointmentService: AppointmentService,
     private val timezoneService: ClinicTimezoneService,
 ) {
     companion object : KLogging()
 
-    /**
-     * 기간별 예약 조회.
-     *
-     * @param clinicId 병원 ID
-     * @param startDate 조회 시작 날짜
-     * @param endDate 조회 종료 날짜
-     * @return 기간 내 예약 목록
-     */
     @GetMapping
     fun getByDateRange(
         @RequestParam clinicId: Long,
@@ -65,175 +38,44 @@ class AppointmentController(
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate,
     ): ResponseEntity<ApiResponse<List<AppointmentResponse>>> {
         log.debug { "GET /api/appointments?clinicId=$clinicId&startDate=$startDate&endDate=$endDate" }
-        val records = transaction { appointmentRepository.findByClinicAndDateRange(clinicId, startDate..endDate) }
+        val records = appointmentService.getByDateRange(clinicId, startDate, endDate)
         val (timezone, locale) = timezoneService.getTimezoneAndLocale(clinicId)
         return ResponseEntity.ok(ApiResponse.ok(records.map { it.toResponse(timezone, locale) }))
     }
 
-    /**
-     * 예약 단건 조회.
-     *
-     * @param id 예약 ID
-     * @return 예약 정보
-     * @throws NoSuchElementException 예약이 없으면
-     */
     @GetMapping("/{id}")
     fun getById(@PathVariable id: Long): ResponseEntity<ApiResponse<AppointmentResponse>> {
         log.debug { "GET /api/appointments/$id" }
-        val record = transaction { appointmentRepository.findByIdOrNull(id) }
-            ?: throw NoSuchElementException("Appointment not found: $id")
+        val record = appointmentService.getById(id)
         val (timezone, locale) = timezoneService.getTimezoneAndLocale(record.clinicId)
         return ResponseEntity.ok(ApiResponse.ok(record.toResponse(timezone, locale)))
     }
 
-    /**
-     * 예약 생성.
-     *
-     * 생성된 예약의 초기 상태는 [AppointmentState.REQUESTED]입니다.
-     * 예약 생성 완료 시 [AppointmentDomainEvent.Created] 이벤트를 발행합니다.
-     *
-     * @param request 예약 생성 요청
-     * @return 생성된 예약
-     */
     @PostMapping
     fun create(@RequestBody request: CreateAppointmentRequest): ResponseEntity<ApiResponse<AppointmentResponse>> {
         log.debug { "POST /api/appointments - patient=${request.patientName}" }
-        val record = AppointmentRecord(
-            clinicId = request.clinicId,
-            doctorId = request.doctorId,
-            treatmentTypeId = request.treatmentTypeId,
-            equipmentId = request.equipmentId,
-            patientName = request.patientName,
-            patientPhone = request.patientPhone,
-            appointmentDate = request.appointmentDate,
-            startTime = request.startTime,
-            endTime = request.endTime,
-            status = AppointmentState.REQUESTED,
-        )
-        val saved = transaction { appointmentRepository.save(record) }
-        eventPublisher.publishEvent(
-            AppointmentDomainEvent.Created(
-                appointmentId = saved.id!!,
-                clinicId = saved.clinicId,
-            )
-        )
+        val saved = appointmentService.create(request)
         val (timezone, locale) = timezoneService.getTimezoneAndLocale(saved.clinicId)
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.ok(saved.toResponse(timezone, locale)))
     }
 
-    /**
-     * 예약 상태 변경.
-     *
-     * [AppointmentStateMachine]으로 유효한 전이만 허용합니다.
-     * 상태 변경 이력은 [AppointmentStateHistory] 테이블에 기록됩니다.
-     * 변경 완료 시 [AppointmentDomainEvent.StatusChanged] 이벤트를 발행합니다.
-     *
-     * @param id 예약 ID
-     * @param request 변경 대상 상태와 사유
-     * @return 업데이트된 예약
-     * @throws IllegalStateException 허용되지 않은 상태 전이인 경우
-     * @throws NoSuchElementException 예약이 없으면
-     */
     @PatchMapping("/{id}/status")
     suspend fun updateStatus(
         @PathVariable id: Long,
         @RequestBody request: UpdateStatusRequest,
     ): ResponseEntity<ApiResponse<AppointmentResponse>> {
         log.debug { "PATCH /api/appointments/$id/status - target=${request.status}" }
-        val record = transaction { appointmentRepository.findByIdOrNull(id) }
-            ?: throw NoSuchElementException("Appointment not found: $id")
-
-        val currentState = record.status
-        val event = parseEvent(request.status, request.reason)
-
-        val nextState = stateMachine.transition(currentState, event)
-
-        transaction {
-            appointmentRepository.updateStatus(id, nextState)
-            stateHistoryRepository.save(
-                AppointmentStateHistoryRecord(
-                    appointmentId = id,
-                    fromState = currentState,
-                    toState = nextState,
-                    reason = request.reason,
-                )
-            )
-        }
-
-        eventPublisher.publishEvent(
-            AppointmentDomainEvent.StatusChanged(
-                appointmentId = id,
-                clinicId = record.clinicId,
-                fromState = record.status.name,
-                toState = nextState.name,
-                reason = request.reason,
-            )
-        )
-
-        val updated = transaction { appointmentRepository.findByIdOrNull(id) }!!
+        val updated = appointmentService.updateStatus(id, request.status, request.reason)
         val (timezone, locale) = timezoneService.getTimezoneAndLocale(updated.clinicId)
         return ResponseEntity.ok(ApiResponse.ok(updated.toResponse(timezone, locale)))
     }
 
-    /**
-     * 예약 취소.
-     *
-     * 예약을 [AppointmentState.CANCELLED] 상태로 변경합니다.
-     * 취소 이력은 [AppointmentStateHistory]에 기록되며,
-     * [AppointmentDomainEvent.Cancelled] 이벤트를 발행합니다.
-     *
-     * @param id 예약 ID
-     * @return 취소된 예약
-     * @throws NoSuchElementException 예약이 없으면
-     */
     @DeleteMapping("/{id}")
     suspend fun cancel(@PathVariable id: Long): ResponseEntity<ApiResponse<AppointmentResponse>> {
         log.debug { "DELETE /api/appointments/$id" }
-        val record = transaction { appointmentRepository.findByIdOrNull(id) }
-            ?: throw NoSuchElementException("Appointment not found: $id")
-
-        val currentState = record.status
-        val cancelEvent = AppointmentEvent.Cancel(reason = "Cancelled by user")
-
-        stateMachine.transition(currentState, cancelEvent)
-
-        transaction {
-            appointmentRepository.updateStatus(id, AppointmentState.CANCELLED)
-            stateHistoryRepository.save(
-                AppointmentStateHistoryRecord(
-                    appointmentId = id,
-                    fromState = currentState,
-                    toState = AppointmentState.CANCELLED,
-                    reason = "Cancelled by user",
-                )
-            )
-        }
-
-        eventPublisher.publishEvent(
-            AppointmentDomainEvent.Cancelled(
-                appointmentId = id,
-                clinicId = record.clinicId,
-                reason = "Cancelled by user",
-            )
-        )
-
-        val updated = transaction { appointmentRepository.findByIdOrNull(id) }!!
-        val (timezone, locale) = timezoneService.getTimezoneAndLocale(updated.clinicId)
-        return ResponseEntity.ok(ApiResponse.ok(updated.toResponse(timezone, locale)))
+        val cancelled = appointmentService.cancel(id)
+        val (timezone, locale) = timezoneService.getTimezoneAndLocale(cancelled.clinicId)
+        return ResponseEntity.ok(ApiResponse.ok(cancelled.toResponse(timezone, locale)))
     }
-}
-
-internal fun parseEvent(targetStatus: String, reason: String? = null): AppointmentEvent = when (targetStatus) {
-    "REQUESTED" -> AppointmentEvent.Request
-    "CONFIRMED" -> AppointmentEvent.Confirm
-    "CHECKED_IN" -> AppointmentEvent.CheckIn
-    "IN_PROGRESS" -> AppointmentEvent.StartTreatment
-    "COMPLETED" -> AppointmentEvent.Complete
-    "CANCELLED" -> AppointmentEvent.Cancel(reason = reason ?: "Cancelled")
-    "NO_SHOW" -> AppointmentEvent.MarkNoShow
-    "PENDING_RESCHEDULE" -> AppointmentEvent.RequestReschedule(reason = reason ?: "Reschedule requested")
-    "RESCHEDULED" -> AppointmentEvent.ConfirmReschedule
-    "PENDING" -> AppointmentEvent.Reschedule
-    else -> throw IllegalArgumentException("Unknown target status: $targetStatus")
 }

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/AppointmentService.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/AppointmentService.kt
@@ -1,0 +1,141 @@
+package io.bluetape4k.clinic.appointment.api.service
+
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.clinic.appointment.api.dto.CreateAppointmentRequest
+import io.bluetape4k.clinic.appointment.event.AppointmentDomainEvent
+import io.bluetape4k.clinic.appointment.model.dto.AppointmentRecord
+import io.bluetape4k.clinic.appointment.model.tables.AppointmentStateHistoryRecord
+import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
+import io.bluetape4k.clinic.appointment.repository.AppointmentStateHistoryRepository
+import io.bluetape4k.clinic.appointment.statemachine.AppointmentEvent
+import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
+import io.bluetape4k.clinic.appointment.statemachine.AppointmentStateMachine
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.springframework.context.ApplicationEventPublisher
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+@Service
+class AppointmentService(
+    private val appointmentRepository: AppointmentRepository,
+    private val stateMachine: AppointmentStateMachine,
+    private val eventPublisher: ApplicationEventPublisher,
+    private val stateHistoryRepository: AppointmentStateHistoryRepository,
+) {
+    companion object : KLogging()
+
+    fun getByDateRange(clinicId: Long, startDate: LocalDate, endDate: LocalDate): List<AppointmentRecord> {
+        log.debug { "getByDateRange: clinicId=$clinicId, $startDate..$endDate" }
+        return transaction { appointmentRepository.findByClinicAndDateRange(clinicId, startDate..endDate) }
+    }
+
+    fun getById(id: Long): AppointmentRecord {
+        log.debug { "getById: id=$id" }
+        return transaction { appointmentRepository.findByIdOrNull(id) }
+            ?: throw NoSuchElementException("Appointment not found: $id")
+    }
+
+    fun create(request: CreateAppointmentRequest): AppointmentRecord {
+        log.debug { "create: patient=${request.patientName}" }
+        val record = AppointmentRecord(
+            clinicId = request.clinicId,
+            doctorId = request.doctorId,
+            treatmentTypeId = request.treatmentTypeId,
+            equipmentId = request.equipmentId,
+            patientName = request.patientName,
+            patientPhone = request.patientPhone,
+            appointmentDate = request.appointmentDate,
+            startTime = request.startTime,
+            endTime = request.endTime,
+            status = AppointmentState.REQUESTED,
+        )
+        val saved = transaction { appointmentRepository.save(record) }
+        eventPublisher.publishEvent(
+            AppointmentDomainEvent.Created(
+                appointmentId = saved.id!!,
+                clinicId = saved.clinicId,
+            )
+        )
+        return saved
+    }
+
+    suspend fun updateStatus(id: Long, targetStatus: String, reason: String?): AppointmentRecord {
+        log.debug { "updateStatus: id=$id, target=$targetStatus" }
+        val record = transaction { appointmentRepository.findByIdOrNull(id) }
+            ?: throw NoSuchElementException("Appointment not found: $id")
+
+        val currentState = record.status
+        val event = parseEvent(targetStatus, reason)
+        val nextState = stateMachine.transition(currentState, event)
+
+        transaction {
+            appointmentRepository.updateStatus(id, nextState)
+            stateHistoryRepository.save(
+                AppointmentStateHistoryRecord(
+                    appointmentId = id,
+                    fromState = currentState,
+                    toState = nextState,
+                    reason = reason,
+                )
+            )
+        }
+
+        eventPublisher.publishEvent(
+            AppointmentDomainEvent.StatusChanged(
+                appointmentId = id,
+                clinicId = record.clinicId,
+                fromState = currentState.name,
+                toState = nextState.name,
+                reason = reason,
+            )
+        )
+
+        return transaction { appointmentRepository.findByIdOrNull(id) }!!
+    }
+
+    suspend fun cancel(id: Long): AppointmentRecord {
+        log.debug { "cancel: id=$id" }
+        val record = transaction { appointmentRepository.findByIdOrNull(id) }
+            ?: throw NoSuchElementException("Appointment not found: $id")
+
+        val currentState = record.status
+        stateMachine.transition(currentState, AppointmentEvent.Cancel(reason = "Cancelled by user"))
+
+        transaction {
+            appointmentRepository.updateStatus(id, AppointmentState.CANCELLED)
+            stateHistoryRepository.save(
+                AppointmentStateHistoryRecord(
+                    appointmentId = id,
+                    fromState = currentState,
+                    toState = AppointmentState.CANCELLED,
+                    reason = "Cancelled by user",
+                )
+            )
+        }
+
+        eventPublisher.publishEvent(
+            AppointmentDomainEvent.Cancelled(
+                appointmentId = id,
+                clinicId = record.clinicId,
+                reason = "Cancelled by user",
+            )
+        )
+
+        return transaction { appointmentRepository.findByIdOrNull(id) }!!
+    }
+}
+
+internal fun parseEvent(targetStatus: String, reason: String? = null): AppointmentEvent = when (targetStatus) {
+    "REQUESTED" -> AppointmentEvent.Request
+    "CONFIRMED" -> AppointmentEvent.Confirm
+    "CHECKED_IN" -> AppointmentEvent.CheckIn
+    "IN_PROGRESS" -> AppointmentEvent.StartTreatment
+    "COMPLETED" -> AppointmentEvent.Complete
+    "CANCELLED" -> AppointmentEvent.Cancel(reason = reason ?: "Cancelled")
+    "NO_SHOW" -> AppointmentEvent.MarkNoShow
+    "PENDING_RESCHEDULE" -> AppointmentEvent.RequestReschedule(reason = reason ?: "Reschedule requested")
+    "RESCHEDULED" -> AppointmentEvent.ConfirmReschedule
+    "PENDING" -> AppointmentEvent.Reschedule
+    else -> throw IllegalArgumentException("Unknown target status: $targetStatus")
+}


### PR DESCRIPTION
## 변경 내용

### 신규 파일
- `AppointmentService.kt`: 비즈니스 로직 5개 메서드(getByDateRange, getById, create, updateStatus, cancel) + parseEvent() 내부 함수

### 수정 파일
- `AppointmentController.kt`: 의존성 5개 → 2개(AppointmentService, ClinicTimezoneService)로 축소
  - 각 핸들러는 service 위임 + timezone 변환 + DTO 변환만 담당

## 동기
AppointmentController가 Repository를 직접 호출하는 안티패턴 제거.
RescheduleController와 일관된 서비스 레이어 구조로 통일.