### PR TITLE
refactor: service/model → model/service 패키지 이동

### DIFF
--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/SlotController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/SlotController.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.clinic.appointment.api.dto.ApiResponse
 import io.bluetape4k.clinic.appointment.api.dto.SlotResponse
 import io.bluetape4k.clinic.appointment.api.dto.toResponse
 import io.bluetape4k.clinic.appointment.service.SlotCalculationService
-import io.bluetape4k.clinic.appointment.service.model.SlotQuery
+import io.bluetape4k.clinic.appointment.model.service.SlotQuery
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/SlotResponse.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/SlotResponse.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.clinic.appointment.api.dto
 
-import io.bluetape4k.clinic.appointment.service.model.AvailableSlot
+import io.bluetape4k.clinic.appointment.model.service.AvailableSlot
 import java.io.Serializable
 import java.time.LocalDate
 import java.time.LocalTime

--- a/appointment-core/README.md
+++ b/appointment-core/README.md
@@ -53,6 +53,14 @@ val newState = machine.transition(
 
 > **중요**: 모든 리포지토리 호출은 `transaction { }` 블록 안에서 실행해야 함.
 
+### 서비스 value type (`model/service/`)
+
+| 클래스 | 역할 |
+|--------|------|
+| `SlotQuery` | 슬롯 조회 파라미터 (clinicId, doctorId, treatmentTypeId, date) |
+| `AvailableSlot` | 계산된 가용 슬롯 결과 (date, startTime, endTime, doctorId, remainingCapacity) |
+| `TimeRange` | 시간 범위 value type + `subtractRanges`, `computeEffectiveRanges` top-level 함수 |
+
 ### 서비스
 
 | 클래스 | 역할 |

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/AvailableSlot.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/AvailableSlot.kt
@@ -1,4 +1,4 @@
-package io.bluetape4k.clinic.appointment.service.model
+package io.bluetape4k.clinic.appointment.model.service
 
 import java.time.LocalDate
 import java.time.LocalTime

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/SlotQuery.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/SlotQuery.kt
@@ -1,4 +1,4 @@
-package io.bluetape4k.clinic.appointment.service.model
+package io.bluetape4k.clinic.appointment.model.service
 
 import java.time.LocalDate
 

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/TimeRange.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/TimeRange.kt
@@ -1,4 +1,4 @@
-package io.bluetape4k.clinic.appointment.service.model
+package io.bluetape4k.clinic.appointment.model.service
 
 import java.time.Duration
 import java.time.LocalTime

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleService.kt
@@ -6,7 +6,7 @@ import io.bluetape4k.clinic.appointment.model.tables.AppointmentStateHistoryReco
 import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
 import io.bluetape4k.clinic.appointment.repository.AppointmentStateHistoryRepository
 import io.bluetape4k.clinic.appointment.repository.RescheduleCandidateRepository
-import io.bluetape4k.clinic.appointment.service.model.SlotQuery
+import io.bluetape4k.clinic.appointment.model.service.SlotQuery
 import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requireNotNull

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationService.kt
@@ -8,10 +8,10 @@ import io.bluetape4k.clinic.appointment.repository.ClinicRepository
 import io.bluetape4k.clinic.appointment.repository.DoctorRepository
 import io.bluetape4k.clinic.appointment.repository.HolidayRepository
 import io.bluetape4k.clinic.appointment.repository.TreatmentTypeRepository
-import io.bluetape4k.clinic.appointment.service.model.AvailableSlot
-import io.bluetape4k.clinic.appointment.service.model.SlotQuery
-import io.bluetape4k.clinic.appointment.service.model.TimeRange
-import io.bluetape4k.clinic.appointment.service.model.computeEffectiveRanges
+import io.bluetape4k.clinic.appointment.model.service.AvailableSlot
+import io.bluetape4k.clinic.appointment.model.service.SlotQuery
+import io.bluetape4k.clinic.appointment.model.service.TimeRange
+import io.bluetape4k.clinic.appointment.model.service.computeEffectiveRanges
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 /**

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/model/service/TimeRangeTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/model/service/TimeRangeTest.kt
@@ -1,4 +1,4 @@
-package io.bluetape4k.clinic.appointment.service.model
+package io.bluetape4k.clinic.appointment.model.service
 
 import org.amshove.kluent.shouldBeEqualTo
 import org.amshove.kluent.shouldBeFalse

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationServiceTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationServiceTest.kt
@@ -20,7 +20,7 @@ import io.bluetape4k.clinic.appointment.model.tables.ProviderType
 import io.bluetape4k.clinic.appointment.model.tables.TreatmentCategory
 import io.bluetape4k.clinic.appointment.model.tables.TreatmentEquipments
 import io.bluetape4k.clinic.appointment.model.tables.TreatmentTypes
-import io.bluetape4k.clinic.appointment.service.model.SlotQuery
+import io.bluetape4k.clinic.appointment.model.service.SlotQuery
 import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
 import org.amshove.kluent.shouldBeEmpty
 import org.amshove.kluent.shouldBeEqualTo

--- a/docs/requirements/architecture.md
+++ b/docs/requirements/architecture.md
@@ -96,6 +96,24 @@ if (bluetape4kProjectsDir.exists()) {
 
 ---
 
+### ADR-9: appointment-core 패키지 구조 — model/service 배치
+
+**결정**: 슬롯 계산 value type(`AvailableSlot`, `SlotQuery`, `TimeRange`)을 `service.model` 대신 `model.service`에 배치.
+
+**이유**: `model/` 하위에 DB 무관 데이터 타입을 일관성 있게 집중. `service.model`은 "서비스의 내부 구현 세부 사항"처럼 읽히고, `model.service`는 "서비스 계층용 도메인 모델"로 의도가 명확하다.
+
+**결과**:
+
+| 패키지 | 내용 |
+|--------|------|
+| `model.dto` | DB 조회 결과 Record DTO (16개 엔티티) |
+| `model.service` | 슬롯 계산 value type — `AvailableSlot`, `SlotQuery`, `TimeRange` |
+| `model.tables` | Exposed ORM 테이블 정의 |
+
+미래에 Exposed DAO 방식 Entity가 추가되면 `model.entities`에 배치. `model.entities`는 Exposed에 의존하므로 `appointment-domain` 모듈(예정)에 위치.
+
+---
+
 ### ADR-8: Flyway 마이그레이션 — 벤더별 SQL 분리
 
 **결정**: H2 / PostgreSQL / MySQL 각각 별도 SQL 파일 유지 + CI 매트릭스로 전 벤더 검증.

--- a/docs/requirements/domain-model.md
+++ b/docs/requirements/domain-model.md
@@ -92,6 +92,16 @@ Timefold Solver가 이동할 수 없는 고정 상태:
 | `RequestReschedule(reason)` | REQUESTED/CONFIRMED → PENDING_RESCHEDULE |
 | `ConfirmReschedule` | PENDING_RESCHEDULE → RESCHEDULED |
 
+## 슬롯 계산 모델 (`model.service`)
+
+DB에 직접 의존하지 않는 순수 value type.
+
+| 클래스 | 역할 |
+|--------|------|
+| `SlotQuery` | 슬롯 조회 파라미터 — clinicId, doctorId, treatmentTypeId, date, requestedDurationMinutes |
+| `AvailableSlot` | 가용 슬롯 결과 — date, startTime, endTime, doctorId, equipmentIds, remainingCapacity |
+| `TimeRange` | 시간 범위 (start inclusive, end exclusive) + `subtractRanges`, `computeEffectiveRanges` 헬퍼 |
+
 ## 서비스
 
 | 서비스 | 역할 |


### PR DESCRIPTION
## 변경 내용

`service/model/` 패키지를 `model/service/`로 이동합니다.

### 패키지 변경
```
before: io.bluetape4k.clinic.appointment.service.model
after:  io.bluetape4k.clinic.appointment.model.service
```

### 이유
`model/` 하위에 모든 값 타입을 일관성 있게 모으기 위함.
- `model/dto/` — DB 무관 Record DTO
- `model/service/` — 슬롯 계산용 value type (AvailableSlot, SlotQuery, TimeRange)

### 검증
- ✅ `appointment-core:build` 성공
- ✅ `appointment-api:build` 성공
- ✅ `appointment-core:test` 116개 전부 통과