### PR TITLE
fix: Spring Boot 4.x FlywayAutoConfiguration 누락으로 인한 PostgreSQL/MySQL API 테스트 실패 수정

### DIFF
--- a/appointment-api/build.gradle.kts
+++ b/appointment-api/build.gradle.kts
@@ -31,7 +31,8 @@ dependencies {
     // OpenAPI / Swagger
     implementation(Libs.springdoc_openapi_starter_webmvc_ui)
 
-    // Flyway
+    // Flyway (spring-boot-flyway: Spring Boot 4.x에서 FlywayAutoConfiguration이 별도 모듈로 분리됨)
+    implementation(Libs.springBoot("flyway"))
     implementation(Libs.flyway_core)
     runtimeOnly(Libs.flyway_database_postgresql)
     runtimeOnly(Libs.flyway_mysql)

--- a/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/test/AbstractApiIntegrationTest.kt
+++ b/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/test/AbstractApiIntegrationTest.kt
@@ -3,8 +3,25 @@ package io.bluetape4k.clinic.appointment.api.test
 import io.bluetape4k.logging.KLogging
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.ActiveProfilesResolver
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+
+/**
+ * `spring.profiles.active` 시스템 프로퍼티에 따라 DB 프로파일을 동적으로 활성화한다.
+ *
+ * 기본은 `test` 프로파일(H2)이며, `test-postgresql` 또는 `test-mysql` 포함 시 해당 프로파일을 추가한다.
+ */
+class DatabaseProfileResolver : ActiveProfilesResolver {
+    override fun resolve(testClass: Class<*>): Array<String> {
+        val sysProfiles = System.getProperty("spring.profiles.active", "")
+        return buildList {
+            add("test")
+            if ("test-postgresql" in sysProfiles) add("test-postgresql")
+            if ("test-mysql" in sysProfiles) add("test-mysql")
+        }.toTypedArray()
+    }
+}
 
 /**
  * API 통합 테스트 기반 클래스.
@@ -20,7 +37,7 @@ import org.springframework.test.context.DynamicPropertySource
  * ```
  */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
+@ActiveProfiles(resolver = DatabaseProfileResolver::class)
 abstract class AbstractApiIntegrationTest {
 
     companion object : KLogging() {
@@ -35,6 +52,7 @@ abstract class AbstractApiIntegrationTest {
                     registry.add("spring.datasource.url") { pg.jdbcUrl!! }
                     registry.add("spring.datasource.username") { pg.username ?: "test" }
                     registry.add("spring.datasource.password") { pg.password ?: "" }
+                    registry.add("spring.flyway.enabled") { "true" }
                 }
 
                 activeProfiles.contains("test-mysql") -> {
@@ -42,6 +60,7 @@ abstract class AbstractApiIntegrationTest {
                     registry.add("spring.datasource.url") { mysql.jdbcUrl!! }
                     registry.add("spring.datasource.username") { mysql.username ?: "test" }
                     registry.add("spring.datasource.password") { mysql.password ?: "" }
+                    registry.add("spring.flyway.enabled") { "true" }
                 }
             }
         }


### PR DESCRIPTION
## 문제

GitHub Actions CI에서 `Test / API (PostgreSQL)`와 `Test / API (MySQL)` 잡만 실패.

```
Caused by: org.postgresql.util.PSQLException: ERROR: relation "scheduling_clinics" does not exist
```

Flyway가 스키마를 생성하지 않아 `TestDataSeeder`가 테이블을 찾지 못함.

## 근본 원인

**Spring Boot 4.x에서 `FlywayAutoConfiguration`이 `spring-boot-autoconfigure`에서 `spring-boot-flyway` 별도 모듈로 분리됨.**

- Spring Boot 3.x: `spring-boot-autoconfigure` 내 포함
- Spring Boot 4.x: `org.springframework.boot:spring-boot-flyway` 별도 모듈

`org.flywaydb:flyway-core`만 있고 `org.springframework.boot:spring-boot-flyway`가 없으면 `FlywayAutoConfiguration`이 클래스패스에 등록되지 않음.

## 수정 내용

### `appointment-api/build.gradle.kts`
```kotlin
// spring-boot-flyway 추가 (Spring Boot 4.x FlywayAutoConfiguration)
implementation(Libs.springBoot("flyway"))
implementation(Libs.flyway_core)
runtimeOnly(Libs.flyway_database_postgresql)
runtimeOnly(Libs.flyway_mysql)
```

### `AbstractApiIntegrationTest.kt`
- `DatabaseProfileResolver`: `spring.profiles.active` 기반 동적 프로파일 활성화
- `@DynamicPropertySource`: PostgreSQL/MySQL 시 `spring.flyway.enabled=true` 설정

## 테스트 결과

| 프로파일 | 결과 |
|---------|------|
| H2 (기본) | ✅ 7 passing |
| PostgreSQL | ✅ 7 passing |
| MySQL | ✅ 7 passing |