### PR TITLE
모델 직렬화 계약과 KDoc 보강

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ dist/
 .worktrees/
 
 .profileconfig.json
+.omx/

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
@@ -23,6 +23,12 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.time.LocalDate
 
+/**
+ * 예약 REST 컨트롤러.
+ *
+ * @param appointmentService 예약 유스케이스 서비스
+ * @param timezoneService 병원 타임존 조회 서비스
+ */
 @RestController
 @RequestMapping("/api/appointments")
 class AppointmentController(

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/ClinicController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/ClinicController.kt
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.RestController
  * 클리닉(병원) 정보 조회 REST 컨트롤러.
  *
  * 병원 목록, 개별 병원 정보, 운영 시간, 휴식 시간 조회 API를 제공합니다.
+ *
+ * @param clinicRepository 병원 Repository
  */
 @RestController
 @RequestMapping("/api/clinics")

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/DoctorController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/DoctorController.kt
@@ -22,6 +22,8 @@ import java.time.LocalDate
  * 의사 정보 조회 REST 컨트롤러.
  *
  * 병원별 의사 목록, 개별 의사 정보, 운영 스케줄, 휴무 정보 조회 API를 제공합니다.
+ *
+ * @param doctorRepository 의사 Repository
  */
 @RestController
 @RequestMapping("/api")

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentController.kt
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController
  * 장비 정보 조회 REST 컨트롤러.
  *
  * 병원별 장비 목록 및 개별 장비 정보 조회 API를 제공합니다.
+ *
+ * @param equipmentRepository 장비 Repository
  */
 @RestController
 @RequestMapping("/api")

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentUnavailabilityController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentUnavailabilityController.kt
@@ -32,6 +32,8 @@ import java.time.LocalDate
  *
  * 장비의 사용불가 기간 등록, 조회, 수정, 삭제 API와
  * 예외 처리 및 충돌 예약 감지 API를 제공합니다.
+ *
+ * @param service 장비 사용불가 서비스
  */
 @RestController
 @RequestMapping("/api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities")

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleController.kt
@@ -26,6 +26,8 @@ import java.time.LocalDate
  *
  * 병원 휴진, 의사 임시휴진 시 영향받는 예약을 재배정하고
  * 관리자가 수동으로 재배정 후보를 선택할 수 있는 API를 제공합니다.
+ *
+ * @param closureRescheduleService 휴진 재배정 서비스
  */
 @RestController
 @RequestMapping("/api/appointments/{id}/reschedule")

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/SlotController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/SlotController.kt
@@ -21,6 +21,8 @@ import java.time.LocalDate
  *
  * 주어진 병원, 의사, 진료 유형, 날짜에 대해
  * 예약 가능한 시간대 목록을 반환합니다.
+ *
+ * @param slotCalculationService 가용 슬롯 계산 서비스
  */
 @RestController
 @RequestMapping("/api/clinics/{clinicId}/slots")

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/TreatmentTypeController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/TreatmentTypeController.kt
@@ -17,6 +17,8 @@ import org.springframework.web.bind.annotation.RestController
  * 진료 유형 조회 REST 컨트롤러.
  *
  * 병원별 진료 유형 목록, 개별 진료 유형 정보, 필요 장비 조회 API를 제공합니다.
+ *
+ * @param treatmentTypeRepository 진료 유형 Repository
  */
 @RestController
 @RequestMapping("/api")

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/JwtAuthenticationFilter.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/JwtAuthenticationFilter.kt
@@ -14,6 +14,8 @@ import org.springframework.web.filter.OncePerRequestFilter
  *
  * Authorization 헤더에서 Bearer 토큰을 추출하여 검증하고,
  * SecurityContext에 인증 정보를 설정합니다.
+ *
+ * @param jwtTokenParser JWT 토큰 검증 및 Claims 파서
  */
 class JwtAuthenticationFilter(
     private val jwtTokenParser: JwtTokenParser,

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/JwtSecurityProperties.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/JwtSecurityProperties.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.clinic.appointment.api.security
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import java.io.Serializable
 
 /**
  * JWT 보안 설정 프로퍼티.
@@ -13,10 +14,18 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *       secret: base64-encoded-secret-key-at-least-256-bits
  *       issuer: appointment-auth-service
  * ```
+ *
+ * @property enabled JWT 인증 활성화 여부
+ * @property secret JWT 서명 검증용 Base64 인코딩 비밀키
+ * @property issuer 허용할 JWT issuer
  */
 @ConfigurationProperties(prefix = "scheduling.security.jwt")
 data class JwtSecurityProperties(
     val enabled: Boolean = true,
     val secret: String = "",
     val issuer: String = "appointment-auth-service",
-)
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/JwtTokenParser.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/JwtTokenParser.kt
@@ -11,6 +11,8 @@ import java.util.Base64
  * JWT 토큰 파싱 및 검증.
  *
  * 외부 인증 서비스가 발급한 JWT를 검증하고 Claims를 추출합니다.
+ *
+ * @param properties JWT 보안 설정
  */
 class JwtTokenParser(
     private val properties: JwtSecurityProperties,

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/SchedulingUserPrincipal.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/SchedulingUserPrincipal.kt
@@ -3,15 +3,23 @@ package io.bluetape4k.clinic.appointment.api.security
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.userdetails.UserDetails
+import java.io.Serializable
 
 /**
  * JWT Claims에서 추출한 사용자 정보.
+ *
+ * @property userId 사용자 ID
+ * @property clinicId 사용자가 속한 병원 ID
+ * @property roles 사용자 역할 목록
  */
 data class SchedulingUserPrincipal(
     val userId: String,
     val clinicId: Long?,
     val roles: List<String>,
-) : UserDetails {
+) : UserDetails, Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
 
     override fun getAuthorities(): Collection<GrantedAuthority> =
         roles.map { SimpleGrantedAuthority("ROLE_$it") }

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/AppointmentService.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/AppointmentService.kt
@@ -16,6 +16,14 @@ import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
+/**
+ * 예약 API 유스케이스 서비스.
+ *
+ * @param appointmentRepository 예약 Repository
+ * @param stateMachine 예약 상태 전이 검증기
+ * @param eventPublisher 예약 도메인 이벤트 발행기
+ * @param stateHistoryRepository 예약 상태 이력 Repository
+ */
 @Service
 class AppointmentService(
     private val appointmentRepository: AppointmentRepository,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/AppointmentNoteRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/AppointmentNoteRecord.kt
@@ -3,6 +3,16 @@ package io.bluetape4k.clinic.appointment.model.dto
 import java.io.Serializable
 import java.time.Instant
 
+/**
+ * 예약 노트 레코드.
+ *
+ * @property id 예약 노트 ID
+ * @property appointmentId 예약 ID
+ * @property noteType 노트 유형
+ * @property content 노트 내용
+ * @property createdBy 작성자
+ * @property createdAt 작성 시각
+ */
 data class AppointmentNoteRecord(
     val id: Long? = null,
     val appointmentId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/AppointmentRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/AppointmentRecord.kt
@@ -6,6 +6,27 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 
+/**
+ * 예약 레코드.
+ *
+ * @property id 예약 ID
+ * @property clinicId 병원 ID
+ * @property doctorId 담당 의사 ID
+ * @property treatmentTypeId 진료 유형 ID
+ * @property equipmentId 사용 장비 ID
+ * @property consultationTopicId 상담 주제 ID
+ * @property consultationMethod 상담 방식
+ * @property rescheduleFromId 재배정 원본 예약 ID
+ * @property patientName 환자명
+ * @property patientPhone 환자 전화번호
+ * @property patientExternalId 외부 시스템 환자 ID
+ * @property appointmentDate 예약 날짜
+ * @property startTime 예약 시작 시간
+ * @property endTime 예약 종료 시간
+ * @property status 예약 상태
+ * @property createdAt 생성 시각
+ * @property updatedAt 수정 시각
+ */
 data class AppointmentRecord(
     val id: Long? = null,
     val clinicId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/BreakTimeRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/BreakTimeRecord.kt
@@ -4,6 +4,15 @@ import java.io.Serializable
 import java.time.DayOfWeek
 import java.time.LocalTime
 
+/**
+ * 병원 휴게 시간 레코드.
+ *
+ * @property id 휴게 시간 ID
+ * @property clinicId 병원 ID
+ * @property dayOfWeek 적용 요일
+ * @property startTime 휴게 시작 시간
+ * @property endTime 휴게 종료 시간
+ */
 data class BreakTimeRecord(
     val id: Long? = null,
     val clinicId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/ClinicClosureRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/ClinicClosureRecord.kt
@@ -4,6 +4,17 @@ import java.io.Serializable
 import java.time.LocalDate
 import java.time.LocalTime
 
+/**
+ * 병원 휴진 레코드.
+ *
+ * @property id 휴진 ID
+ * @property clinicId 병원 ID
+ * @property closureDate 휴진 날짜
+ * @property reason 휴진 사유
+ * @property isFullDay 종일 휴진 여부
+ * @property startTime 부분 휴진 시작 시간
+ * @property endTime 부분 휴진 종료 시간
+ */
 data class ClinicClosureRecord(
     val id: Long? = null,
     val clinicId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/ClinicDefaultBreakTimeRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/ClinicDefaultBreakTimeRecord.kt
@@ -3,6 +3,15 @@ package io.bluetape4k.clinic.appointment.model.dto
 import java.io.Serializable
 import java.time.LocalTime
 
+/**
+ * 병원 기본 휴게 시간 레코드.
+ *
+ * @property id 기본 휴게 시간 ID
+ * @property clinicId 병원 ID
+ * @property name 휴게 시간 이름
+ * @property startTime 휴게 시작 시간
+ * @property endTime 휴게 종료 시간
+ */
 data class ClinicDefaultBreakTimeRecord(
     val id: Long? = null,
     val clinicId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/ClinicRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/ClinicRecord.kt
@@ -2,6 +2,17 @@ package io.bluetape4k.clinic.appointment.model.dto
 
 import java.io.Serializable
 
+/**
+ * 병원 레코드.
+ *
+ * @property id 병원 ID
+ * @property name 병원 이름
+ * @property slotDurationMinutes 예약 슬롯 단위(분)
+ * @property timezone 병원 타임존 ID
+ * @property locale 병원 기본 locale
+ * @property maxConcurrentPatients 병원 기본 동시 진료 가능 환자 수
+ * @property openOnHolidays 공휴일 운영 여부
+ */
 data class ClinicRecord(
     val id: Long? = null,
     val name: String,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/ConsultationTopicRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/ConsultationTopicRecord.kt
@@ -2,6 +2,15 @@ package io.bluetape4k.clinic.appointment.model.dto
 
 import java.io.Serializable
 
+/**
+ * 상담 주제 레코드.
+ *
+ * @property id 상담 주제 ID
+ * @property clinicId 병원 ID
+ * @property name 상담 주제 이름
+ * @property description 상담 주제 설명
+ * @property defaultDurationMinutes 기본 상담 시간(분)
+ */
 data class ConsultationTopicRecord(
     val id: Long? = null,
     val clinicId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/DoctorAbsenceRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/DoctorAbsenceRecord.kt
@@ -4,6 +4,16 @@ import java.io.Serializable
 import java.time.LocalDate
 import java.time.LocalTime
 
+/**
+ * 의사 부재 레코드.
+ *
+ * @property id 부재 ID
+ * @property doctorId 의사 ID
+ * @property absenceDate 부재 날짜
+ * @property startTime 부재 시작 시간. null이면 종일 부재입니다.
+ * @property endTime 부재 종료 시간. null이면 종일 부재입니다.
+ * @property reason 부재 사유
+ */
 data class DoctorAbsenceRecord(
     val id: Long? = null,
     val doctorId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/DoctorRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/DoctorRecord.kt
@@ -2,6 +2,16 @@ package io.bluetape4k.clinic.appointment.model.dto
 
 import java.io.Serializable
 
+/**
+ * 의사 레코드.
+ *
+ * @property id 의사 ID
+ * @property clinicId 소속 병원 ID
+ * @property name 의사 이름
+ * @property specialty 전문 분야
+ * @property providerType 진료 제공자 유형
+ * @property maxConcurrentPatients 의사별 동시 진료 가능 환자 수
+ */
 data class DoctorRecord(
     val id: Long? = null,
     val clinicId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/DoctorScheduleRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/DoctorScheduleRecord.kt
@@ -4,6 +4,15 @@ import java.io.Serializable
 import java.time.DayOfWeek
 import java.time.LocalTime
 
+/**
+ * 의사 근무 시간 레코드.
+ *
+ * @property id 근무 시간 ID
+ * @property doctorId 의사 ID
+ * @property dayOfWeek 근무 요일
+ * @property startTime 근무 시작 시간
+ * @property endTime 근무 종료 시간
+ */
 data class DoctorScheduleRecord(
     val id: Long? = null,
     val doctorId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/EquipmentRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/EquipmentRecord.kt
@@ -2,6 +2,15 @@ package io.bluetape4k.clinic.appointment.model.dto
 
 import java.io.Serializable
 
+/**
+ * 장비 레코드.
+ *
+ * @property id 장비 ID
+ * @property clinicId 병원 ID
+ * @property name 장비 이름
+ * @property usageDurationMinutes 예약당 장비 점유 시간(분)
+ * @property quantity 동일 장비 수량
+ */
 data class EquipmentRecord(
     val id: Long? = null,
     val clinicId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/EquipmentUnavailabilityRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/EquipmentUnavailabilityRecord.kt
@@ -6,6 +6,21 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
 
+/**
+ * 장비 사용불가 스케줄 레코드.
+ *
+ * @property id 장비 사용불가 스케줄 ID
+ * @property equipmentId 장비 ID
+ * @property clinicId 병원 ID
+ * @property unavailableDate 단일 사용불가 날짜
+ * @property isRecurring 반복 스케줄 여부
+ * @property recurringDayOfWeek 반복 요일
+ * @property effectiveFrom 반복 스케줄 유효 시작일
+ * @property effectiveUntil 반복 스케줄 유효 종료일
+ * @property startTime 사용불가 시작 시간
+ * @property endTime 사용불가 종료 시간
+ * @property reason 사용불가 사유
+ */
 data class EquipmentUnavailabilityRecord(
     val id: Long,
     val equipmentId: Long,
@@ -24,6 +39,18 @@ data class EquipmentUnavailabilityRecord(
     }
 }
 
+/**
+ * 장비 사용불가 스케줄 예외 레코드.
+ *
+ * @property id 예외 ID
+ * @property unavailabilityId 원본 장비 사용불가 스케줄 ID
+ * @property originalDate 예외가 적용되는 원래 날짜
+ * @property exceptionType 예외 유형
+ * @property rescheduledDate 변경된 날짜
+ * @property rescheduledStartTime 변경된 시작 시간
+ * @property rescheduledEndTime 변경된 종료 시간
+ * @property reason 예외 사유
+ */
 data class EquipmentUnavailabilityExceptionRecord(
     val id: Long,
     val unavailabilityId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/HolidayRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/HolidayRecord.kt
@@ -3,6 +3,14 @@ package io.bluetape4k.clinic.appointment.model.dto
 import java.io.Serializable
 import java.time.LocalDate
 
+/**
+ * 휴일 레코드.
+ *
+ * @property id 휴일 ID
+ * @property holidayDate 휴일 날짜
+ * @property name 휴일 이름
+ * @property recurring 매년 반복 여부
+ */
 data class HolidayRecord(
     val id: Long? = null,
     val holidayDate: LocalDate,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/OperatingHoursRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/OperatingHoursRecord.kt
@@ -4,6 +4,16 @@ import java.io.Serializable
 import java.time.DayOfWeek
 import java.time.LocalTime
 
+/**
+ * 병원 운영 시간 레코드.
+ *
+ * @property id 운영 시간 ID
+ * @property clinicId 병원 ID
+ * @property dayOfWeek 운영 요일
+ * @property openTime 운영 시작 시간
+ * @property closeTime 운영 종료 시간
+ * @property isActive 활성 여부
+ */
 data class OperatingHoursRecord(
     val id: Long? = null,
     val clinicId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/RescheduleCandidateRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/RescheduleCandidateRecord.kt
@@ -5,6 +5,19 @@ import java.time.Instant
 import java.time.LocalDate
 import java.time.LocalTime
 
+/**
+ * 예약 재배정 후보 레코드.
+ *
+ * @property id 재배정 후보 ID
+ * @property originalAppointmentId 원본 예약 ID
+ * @property candidateDate 후보 예약 날짜
+ * @property startTime 후보 시작 시간
+ * @property endTime 후보 종료 시간
+ * @property doctorId 후보 의사 ID
+ * @property priority 후보 우선순위
+ * @property selected 선택 여부
+ * @property createdAt 생성 시각
+ */
 data class RescheduleCandidateRecord(
     val id: Long? = null,
     val originalAppointmentId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/TreatmentEquipmentRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/TreatmentEquipmentRecord.kt
@@ -2,6 +2,13 @@ package io.bluetape4k.clinic.appointment.model.dto
 
 import java.io.Serializable
 
+/**
+ * 진료 유형과 장비의 연결 레코드.
+ *
+ * @property id 연결 ID
+ * @property treatmentTypeId 진료 유형 ID
+ * @property equipmentId 장비 ID
+ */
 data class TreatmentEquipmentRecord(
     val id: Long? = null,
     val treatmentTypeId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/TreatmentTypeRecord.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/TreatmentTypeRecord.kt
@@ -2,6 +2,19 @@ package io.bluetape4k.clinic.appointment.model.dto
 
 import java.io.Serializable
 
+/**
+ * 진료 유형 레코드.
+ *
+ * @property id 진료 유형 ID
+ * @property clinicId 병원 ID
+ * @property name 진료 유형 이름
+ * @property category 진료 유형 분류
+ * @property defaultDurationMinutes 기본 진료 시간(분)
+ * @property requiredProviderType 필요한 진료 제공자 유형
+ * @property consultationMethod 상담 방식
+ * @property requiresEquipment 장비 필요 여부
+ * @property maxConcurrentPatients 진료 유형별 동시 진료 가능 환자 수
+ */
 data class TreatmentTypeRecord(
     val id: Long? = null,
     val clinicId: Long,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/UnavailablePeriod.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/dto/UnavailablePeriod.kt
@@ -4,7 +4,14 @@ import java.io.Serializable
 import java.time.LocalDate
 import java.time.LocalTime
 
-/** 반복 규칙에서 전개된 실제 사용불가 기간 */
+/**
+ * 반복 규칙에서 전개된 실제 사용불가 기간.
+ *
+ * @property equipmentId 장비 ID
+ * @property date 사용불가 날짜
+ * @property startTime 사용불가 시작 시간
+ * @property endTime 사용불가 종료 시간
+ */
 data class UnavailablePeriod(
     val equipmentId: Long,
     val date: LocalDate,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/AvailableSlot.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/AvailableSlot.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.clinic.appointment.model.service
 
+import java.io.Serializable
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -20,4 +21,8 @@ data class AvailableSlot(
     val doctorId: Long,
     val equipmentIds: List<Long> = emptyList(),
     val remainingCapacity: Int,
-)
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/SlotQuery.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/SlotQuery.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.clinic.appointment.model.service
 
+import java.io.Serializable
 import java.time.LocalDate
 
 /**
@@ -17,4 +18,8 @@ data class SlotQuery(
     val treatmentTypeId: Long,
     val date: LocalDate,
     val requestedDurationMinutes: Int? = null,
-)
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/TimeRange.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/service/TimeRange.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.clinic.appointment.model.service
 
+import java.io.Serializable
 import java.time.Duration
 import java.time.LocalTime
 
@@ -12,7 +13,11 @@ import java.time.LocalTime
 data class TimeRange(
     val start: LocalTime,
     val end: LocalTime,
-) {
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+
     init {
         require(start < end) { "start($start) must be before end($end)" }
     }

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/tables/AppointmentStateHistory.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/model/tables/AppointmentStateHistory.kt
@@ -32,6 +32,7 @@ object AppointmentStateHistory : LongIdTable("scheduling_appointment_state_histo
 /**
  * 예약 상태 변경 이력 레코드.
  *
+ * @property id 상태 변경 이력 ID
  * @property appointmentId 예약 ID
  * @property fromState 이전 상태
  * @property toState 변경된 새로운 상태

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleService.kt
@@ -19,6 +19,11 @@ import java.time.LocalDate
  * 1. 영향받는 예약을 PENDING_RESCHEDULE로 전환
  * 2. 각 예약에 대해 재배정 후보 슬롯 탐색
  * 3. 관리자가 후보를 선택하면 새 예약 생성 + 원래 예약 RESCHEDULED 처리
+ *
+ * @param slotCalculationService 재배정 후보 슬롯 계산 서비스
+ * @param appointmentRepository 예약 Repository
+ * @param rescheduleCandidateRepository 재배정 후보 Repository
+ * @param stateHistoryRepository 예약 상태 이력 Repository
  */
 class ClosureRescheduleService(
     private val slotCalculationService: SlotCalculationService,

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/EquipmentUnavailabilityService.kt
@@ -20,6 +20,9 @@ import java.time.LocalTime
  * 장비 사용불가 기간을 관리하는 서비스.
  *
  * JDBC Exposed 트랜잭션을 사용하며, Spring Bean이 아닌 일반 클래스입니다.
+ *
+ * @param repo 장비 사용불가 Repository
+ * @param appointmentRepository 충돌 예약 조회 Repository
  */
 class EquipmentUnavailabilityService(
     private val repo: EquipmentUnavailabilityRepository = EquipmentUnavailabilityRepository(),

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/SlotCalculationService.kt
@@ -18,6 +18,13 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
  * 예약 가능한 슬롯을 계산하는 서비스.
  *
  * JDBC Exposed 트랜잭션을 사용하며, Spring Bean이 아닌 일반 클래스입니다.
+ *
+ * @param clinicRepository 병원 운영 정보 Repository
+ * @param doctorRepository 의사 스케줄 Repository
+ * @param treatmentTypeRepository 진료 유형 Repository
+ * @param appointmentRepository 기존 예약 Repository
+ * @param holidayRepository 휴일 Repository
+ * @param equipmentUnavailabilityService 장비 사용불가 서비스
  */
 class SlotCalculationService(
     private val clinicRepository: ClinicRepository = ClinicRepository(),

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/statemachine/AppointmentEvent.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/statemachine/AppointmentEvent.kt
@@ -1,9 +1,15 @@
 package io.bluetape4k.clinic.appointment.statemachine
 
+import java.io.Serializable
+
 /**
  * 예약 상태 전이를 트리거하는 이벤트.
  */
-sealed class AppointmentEvent {
+sealed class AppointmentEvent : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+
     /** 예약 요청 (PENDING → REQUESTED) */
     data object Request : AppointmentEvent()
 
@@ -19,10 +25,18 @@ sealed class AppointmentEvent {
     /** 진료 완료 (IN_PROGRESS → COMPLETED) */
     data object Complete : AppointmentEvent()
 
-    /** 취소 (cancellable 상태 → CANCELLED) */
+    /**
+     * 취소 이벤트.
+     *
+     * @property reason 취소 사유
+     */
     data class Cancel(
         val reason: String,
-    ) : AppointmentEvent()
+    ) : AppointmentEvent(), Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 
     /** 미내원 처리 (CONFIRMED → NO_SHOW) */
     data object MarkNoShow : AppointmentEvent()
@@ -30,10 +44,18 @@ sealed class AppointmentEvent {
     /** 재예약 (CONFIRMED → PENDING) */
     data object Reschedule : AppointmentEvent()
 
-    /** 재배정 요청 — 임시휴진 등 (REQUESTED/CONFIRMED → PENDING_RESCHEDULE) */
+    /**
+     * 재배정 요청 이벤트.
+     *
+     * @property reason 재배정 요청 사유
+     */
     data class RequestReschedule(
         val reason: String,
-    ) : AppointmentEvent()
+    ) : AppointmentEvent(), Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 
     /** 재배정 확정 (PENDING_RESCHEDULE → RESCHEDULED) */
     data object ConfirmReschedule : AppointmentEvent()

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/statemachine/AppointmentState.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/statemachine/AppointmentState.kt
@@ -1,5 +1,7 @@
 package io.bluetape4k.clinic.appointment.statemachine
 
+import java.io.Serializable
+
 /**
  * 예약 상태를 나타내는 sealed class.
  *
@@ -21,11 +23,15 @@ package io.bluetape4k.clinic.appointment.statemachine
  *     → CANCELLED
  *   → CANCELLED
  * ```
+ *
+ * @property name DB와 API에서 사용하는 상태 이름
  */
 sealed class AppointmentState(
     val name: String,
-) {
+) : Serializable {
     companion object {
+        private const val serialVersionUID = 1L
+
         val ACTIVE_STATUSES: List<AppointmentState> by lazy { listOf(REQUESTED, CONFIRMED) }
         val ACTIVE_STATUS_NAMES: List<String> by lazy { ACTIVE_STATUSES.map { it.name } }
 

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/timezone/ClinicTimezoneService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/timezone/ClinicTimezoneService.kt
@@ -39,6 +39,8 @@ import java.util.Locale
  *     ↓  응답 시 Clinics.timezone 포함
  * Frontend (ZonedDateTime 복원 가능)
  * ```
+ *
+ * @param clinicRepository 병원 Repository
  */
 class ClinicTimezoneService(
     private val clinicRepository: ClinicRepository,

--- a/appointment-event/src/main/kotlin/io/bluetape4k/clinic/appointment/event/AppointmentDomainEvent.kt
+++ b/appointment-event/src/main/kotlin/io/bluetape4k/clinic/appointment/event/AppointmentDomainEvent.kt
@@ -1,34 +1,89 @@
 package io.bluetape4k.clinic.appointment.event
 
 import org.springframework.context.ApplicationEvent
+import java.io.Serializable
 import java.time.Instant
 
+/**
+ * 예약 도메인 이벤트의 공통 기반 클래스.
+ *
+ * @property occurredAt 이벤트 발생 시각
+ */
 sealed class AppointmentDomainEvent(
     source: Any,
     val occurredAt: Instant = Instant.now(),
-) : ApplicationEvent(source) {
+) : ApplicationEvent(source), Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+
+    /**
+     * 예약 생성 이벤트.
+     *
+     * @property appointmentId 생성된 예약 ID
+     * @property clinicId 예약이 속한 병원 ID
+     */
     data class Created(
         val appointmentId: Long,
         val clinicId: Long,
-    ) : AppointmentDomainEvent(appointmentId)
+    ) : AppointmentDomainEvent(appointmentId), Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 
+    /**
+     * 예약 상태 변경 이벤트.
+     *
+     * @property appointmentId 상태가 변경된 예약 ID
+     * @property clinicId 예약이 속한 병원 ID
+     * @property fromState 변경 전 상태
+     * @property toState 변경 후 상태
+     * @property reason 상태 변경 사유
+     */
     data class StatusChanged(
         val appointmentId: Long,
         val clinicId: Long,
         val fromState: String,
         val toState: String,
         val reason: String? = null,
-    ) : AppointmentDomainEvent(appointmentId)
+    ) : AppointmentDomainEvent(appointmentId), Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 
+    /**
+     * 예약 취소 이벤트.
+     *
+     * @property appointmentId 취소된 예약 ID
+     * @property clinicId 예약이 속한 병원 ID
+     * @property reason 취소 사유
+     */
     data class Cancelled(
         val appointmentId: Long,
         val clinicId: Long,
         val reason: String,
-    ) : AppointmentDomainEvent(appointmentId)
+    ) : AppointmentDomainEvent(appointmentId), Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 
+    /**
+     * 예약 재배정 이벤트.
+     *
+     * @property originalId 원본 예약 ID
+     * @property newId 재배정된 새 예약 ID
+     * @property clinicId 예약이 속한 병원 ID
+     */
     data class Rescheduled(
         val originalId: Long,
         val newId: Long,
         val clinicId: Long,
-    ) : AppointmentDomainEvent(originalId)
+    ) : AppointmentDomainEvent(originalId), Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 }

--- a/appointment-event/src/main/kotlin/io/bluetape4k/clinic/appointment/event/AppointmentEventLogRecord.kt
+++ b/appointment-event/src/main/kotlin/io/bluetape4k/clinic/appointment/event/AppointmentEventLogRecord.kt
@@ -3,6 +3,17 @@ package io.bluetape4k.clinic.appointment.event
 import java.io.Serializable
 import java.time.Instant
 
+/**
+ * 예약 이벤트 로그 레코드.
+ *
+ * @property id 이벤트 로그 ID
+ * @property eventType 이벤트 유형
+ * @property entityType 이벤트 대상 엔티티 유형
+ * @property entityId 이벤트 대상 엔티티 ID
+ * @property clinicId 병원 ID
+ * @property payloadJson 이벤트 페이로드 JSON
+ * @property createdAt 생성 시각
+ */
 data class AppointmentEventLogRecord(
     val id: Long? = null,
     val eventType: String,

--- a/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/AppointmentReminderScheduler.kt
+++ b/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/AppointmentReminderScheduler.kt
@@ -18,6 +18,12 @@ import java.time.LocalDate
  * 매시간 실행되어 내일/오늘 예약 중 CONFIRMED 상태인 예약에 리마인더를 발송합니다.
  * HA 환경에서는 [LettuceLeaderGroupElection]을 통해 리더로 선출된 인스턴스만 실행합니다.
  * 이미 발송한 리마인더는 중복 방지합니다.
+ *
+ * @param notificationChannel 알림 발송 채널
+ * @param appointmentRepository 예약 Repository
+ * @param historyRepository 알림 이력 Repository
+ * @param properties 알림 설정
+ * @param leaderElection Redis 기반 리더 선출기
  */
 @Component
 class AppointmentReminderScheduler(

--- a/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/DummyNotificationChannel.kt
+++ b/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/DummyNotificationChannel.kt
@@ -10,6 +10,8 @@ import org.jetbrains.exposed.v1.jdbc.transactions.transaction
  *
  * 로그 출력 + NotificationHistory 테이블에 이력 저장.
  * 운영 환경에서는 Feign 기반 외부 서비스 호출 구현체로 교체합니다.
+ *
+ * @param historyRepository 알림 이력 Repository
  */
 class DummyNotificationChannel(
     private val historyRepository: NotificationHistoryRepository,

--- a/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/NotificationEventListener.kt
+++ b/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/NotificationEventListener.kt
@@ -12,6 +12,10 @@ import org.springframework.stereotype.Component
  * 도메인 이벤트를 구독하여 알림을 발송하는 리스너.
  *
  * [NotificationProperties] 설정에 따라 이벤트별 on/off를 제어합니다.
+ *
+ * @param notificationChannel 알림 발송 채널
+ * @param appointmentRepository 예약 Repository
+ * @param properties 알림 설정
  */
 @Component
 class NotificationEventListener(

--- a/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/NotificationHistory.kt
+++ b/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/NotificationHistory.kt
@@ -44,6 +44,16 @@ object NotificationEventType {
 
 /**
  * 알림 발송 이력 레코드.
+ *
+ * @property id 알림 이력 ID
+ * @property appointmentId 예약 ID
+ * @property channelType 알림 채널 유형
+ * @property eventType 알림 이벤트 유형
+ * @property recipient 수신자
+ * @property payloadJson 알림 페이로드 JSON
+ * @property status 발송 상태
+ * @property errorMessage 실패 오류 메시지
+ * @property createdAt 생성 시각
  */
 data class NotificationHistoryRecord(
     val id: Long? = null,

--- a/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/NotificationProperties.kt
+++ b/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/NotificationProperties.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.clinic.appointment.notification
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import java.io.Serializable
 
 /**
  * 알림 설정 프로퍼티.
@@ -20,24 +21,56 @@ import org.springframework.boot.context.properties.ConfigurationProperties
  *       same-day: true
  *       same-day-hours-before: 2
  * ```
+ *
+ * @property enabled 알림 모듈 활성화 여부
+ * @property events 예약 이벤트별 알림 설정
+ * @property reminder 예약 리마인더 설정
  */
 @ConfigurationProperties(prefix = "clinic.notification")
 data class NotificationProperties(
     val enabled: Boolean = true,
     val events: EventProperties = EventProperties(),
     val reminder: ReminderProperties = ReminderProperties(),
-) {
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+
+    /**
+     * 예약 이벤트별 알림 설정.
+     *
+     * @property created 예약 생성 알림 활성화 여부
+     * @property confirmed 예약 확정 알림 활성화 여부
+     * @property cancelled 예약 취소 알림 활성화 여부
+     * @property rescheduled 예약 재배정 알림 활성화 여부
+     */
     data class EventProperties(
         val created: Boolean = true,
         val confirmed: Boolean = true,
         val cancelled: Boolean = true,
         val rescheduled: Boolean = true,
-    )
+    ) : Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 
+    /**
+     * 예약 리마인더 설정.
+     *
+     * @property enabled 리마인더 활성화 여부
+     * @property dayBefore 전일 리마인더 발송 여부
+     * @property sameDay 당일 리마인더 발송 여부
+     * @property sameDayHoursBefore 당일 리마인더 기준 시간(예약 전 N시간)
+     */
     data class ReminderProperties(
         val enabled: Boolean = true,
         val dayBefore: Boolean = true,
         val sameDay: Boolean = true,
         val sameDayHoursBefore: Int = 2,
-    )
+    ) : Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 }

--- a/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/NotificationResilienceProperties.kt
+++ b/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/NotificationResilienceProperties.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.clinic.appointment.notification
 
 import org.springframework.boot.context.properties.ConfigurationProperties
+import java.io.Serializable
 import java.time.Duration
 
 /**
@@ -23,28 +24,69 @@ import java.time.Duration
  *         max-concurrent-calls: 10
  *         max-wait-duration: 1s
  * ```
+ *
+ * @property circuitBreaker CircuitBreaker 설정
+ * @property retry Retry 설정
+ * @property bulkhead Bulkhead 설정
  */
 @ConfigurationProperties(prefix = "clinic.notification.resilience")
 data class NotificationResilienceProperties(
     val circuitBreaker: CircuitBreakerProperties = CircuitBreakerProperties(),
     val retry: RetryProperties = RetryProperties(),
     val bulkhead: BulkheadProperties = BulkheadProperties(),
-) {
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+
+    /**
+     * CircuitBreaker 설정.
+     *
+     * @property failureRateThreshold 실패율 임계값
+     * @property slowCallRateThreshold 느린 호출 비율 임계값
+     * @property waitDurationInOpenState OPEN 상태 유지 시간
+     * @property slidingWindowSize 집계 슬라이딩 윈도우 크기
+     * @property minimumNumberOfCalls 상태 전환 평가에 필요한 최소 호출 수
+     */
     data class CircuitBreakerProperties(
         val failureRateThreshold: Float = 50f,
         val slowCallRateThreshold: Float = 80f,
         val waitDurationInOpenState: Duration = Duration.ofSeconds(30),
         val slidingWindowSize: Int = 10,
         val minimumNumberOfCalls: Int = 5,
-    )
+    ) : Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 
+    /**
+     * Retry 설정.
+     *
+     * @property maxAttempts 최대 재시도 횟수
+     * @property waitDuration 재시도 간 대기 시간
+     */
     data class RetryProperties(
         val maxAttempts: Int = 3,
         val waitDuration: Duration = Duration.ofMillis(500),
-    )
+    ) : Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 
+    /**
+     * Bulkhead 설정.
+     *
+     * @property maxConcurrentCalls 최대 동시 호출 수
+     * @property maxWaitDuration bulkhead 진입 대기 시간
+     */
     data class BulkheadProperties(
         val maxConcurrentCalls: Int = 10,
         val maxWaitDuration: Duration = Duration.ofSeconds(1),
-    )
+    ) : Serializable {
+        companion object {
+            private const val serialVersionUID = 1L
+        }
+    }
 }

--- a/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/ResilientNotificationChannel.kt
+++ b/appointment-notification/src/main/kotlin/io/bluetape4k/clinic/appointment/notification/ResilientNotificationChannel.kt
@@ -19,6 +19,11 @@ import java.time.Duration
  * 실제 [NotificationChannel] 구현체를 감싸서
  * CircuitBreaker, Retry, Bulkhead를 적용합니다.
  * 외부 알림 서비스 호출 시 장애 격리를 보장합니다.
+ *
+ * @param delegate 실제 알림 채널 구현체
+ * @param circuitBreaker 알림 호출 CircuitBreaker
+ * @param retry 알림 호출 Retry
+ * @param bulkhead 알림 호출 Bulkhead
  */
 class ResilientNotificationChannel(
     private val delegate: NotificationChannel,

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/AppointmentPlanning.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/AppointmentPlanning.kt
@@ -14,6 +14,21 @@ import java.time.LocalTime
  * Solver가 최적 값을 탐색합니다.
  *
  * [pinned]가 true인 예약(CONFIRMED 등)은 Solver가 이동하지 않습니다.
+ *
+ * @property id 예약 ID
+ * @property clinicId 병원 ID
+ * @property treatmentTypeId 진료 유형 ID
+ * @property equipmentId 필요한 장비 ID
+ * @property patientName 환자명
+ * @property durationMinutes 예약 소요 시간(분)
+ * @property requiredProviderType 필요한 진료 제공자 유형
+ * @property requiresEquipment 장비 필요 여부
+ * @property originalDoctorId 원래 배정된 의사 ID
+ * @property requestedDate 환자가 요청한 예약 날짜
+ * @property pinned Solver 이동 금지 여부
+ * @property doctorId Solver가 배정하는 의사 ID
+ * @property appointmentDate Solver가 배정하는 예약 날짜
+ * @property startTime Solver가 배정하는 시작 시간
  */
 @PlanningEntity(comparatorClass = AppointmentDifficultyComparator::class)
 class AppointmentPlanning(

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/ClinicFact.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/ClinicFact.kt
@@ -1,11 +1,22 @@
 package io.bluetape4k.clinic.appointment.solver.domain
 
+import java.io.Serializable
+
 /**
  * 병원 정보 Problem Fact.
+ *
+ * @property id 병원 ID
+ * @property slotDurationMinutes 예약 슬롯 단위(분)
+ * @property maxConcurrentPatients 병원 기본 동시 진료 가능 환자 수
+ * @property openOnHolidays 공휴일 운영 여부
  */
 data class ClinicFact(
     val id: Long,
     val slotDurationMinutes: Int,
     val maxConcurrentPatients: Int,
     val openOnHolidays: Boolean,
-)
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/DoctorFact.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/DoctorFact.kt
@@ -1,11 +1,22 @@
 package io.bluetape4k.clinic.appointment.solver.domain
 
+import java.io.Serializable
+
 /**
  * 의사 정보 Problem Fact.
+ *
+ * @property id 의사 ID
+ * @property clinicId 소속 병원 ID
+ * @property providerType 진료 제공자 유형
+ * @property maxConcurrentPatients 의사별 동시 진료 가능 환자 수. null이면 병원 기본값을 사용합니다.
  */
 data class DoctorFact(
     val id: Long,
     val clinicId: Long,
     val providerType: String,
     val maxConcurrentPatients: Int?,
-)
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/EquipmentFact.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/EquipmentFact.kt
@@ -1,10 +1,20 @@
 package io.bluetape4k.clinic.appointment.solver.domain
 
+import java.io.Serializable
+
 /**
  * 장비 정보 Problem Fact.
+ *
+ * @property id 장비 ID
+ * @property usageDurationMinutes 장비 점유 시간(분)
+ * @property quantity 동일 장비 수량
  */
 data class EquipmentFact(
     val id: Long,
     val usageDurationMinutes: Int,
     val quantity: Int,
-)
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/EquipmentUnavailabilityFact.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/EquipmentUnavailabilityFact.kt
@@ -9,6 +9,11 @@ import java.time.LocalTime
  *
  * [ScheduleSolution]에 [ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty]로 등록되어
  * Hard Constraint H11에서 참조됩니다.
+ *
+ * @property equipmentId 장비 ID
+ * @property date 사용불가 날짜
+ * @property startTime 사용불가 시작 시간
+ * @property endTime 사용불가 종료 시간
  */
 data class EquipmentUnavailabilityFact(
     val equipmentId: Long,

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/ScheduleSolution.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/ScheduleSolution.kt
@@ -24,6 +24,25 @@ import java.time.LocalTime
  *
  * 전체 문제 정의(Problem Facts)와 Planning Entity 목록,
  * 그리고 Value Range Provider를 포함합니다.
+ *
+ * @property clinic Solver 대상 병원 정보
+ * @property doctors Solver 대상 의사 목록
+ * @property treatments Solver 대상 진료 유형 목록
+ * @property equipments Solver 대상 장비 목록
+ * @property operatingHours 병원 운영 시간 목록
+ * @property doctorSchedules 의사 근무 시간 목록
+ * @property doctorAbsences 의사 부재 목록
+ * @property breakTimes 병원 휴게 시간 목록
+ * @property defaultBreakTimes 병원 기본 휴게 시간 목록
+ * @property closures 병원 휴진 목록
+ * @property holidays 휴일 목록
+ * @property treatmentEquipments 진료 유형별 필요 장비 목록
+ * @property equipmentUnavailabilities 장비 사용불가 목록
+ * @property doctorIds 의사 ID Value Range
+ * @property dateRange 예약 날짜 Value Range
+ * @property timeSlots 예약 시작 시간 Value Range
+ * @property appointments Solver가 최적화할 예약 엔티티 목록
+ * @property score Solver 점수
  */
 @PlanningSolution
 class ScheduleSolution(

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/TreatmentFact.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/TreatmentFact.kt
@@ -1,7 +1,15 @@
 package io.bluetape4k.clinic.appointment.solver.domain
 
+import java.io.Serializable
+
 /**
  * 진료 유형 Problem Fact.
+ *
+ * @property id 진료 유형 ID
+ * @property defaultDurationMinutes 기본 진료 시간(분)
+ * @property requiredProviderType 필요한 진료 제공자 유형
+ * @property requiresEquipment 장비 필요 여부
+ * @property maxConcurrentPatients 동시 진료 가능 환자 수. null이면 병원 기본값을 사용합니다.
  */
 data class TreatmentFact(
     val id: Long,
@@ -9,4 +17,8 @@ data class TreatmentFact(
     val requiredProviderType: String,
     val requiresEquipment: Boolean,
     val maxConcurrentPatients: Int?,
-)
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/service/SolverResult.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/service/SolverResult.kt
@@ -2,16 +2,17 @@ package io.bluetape4k.clinic.appointment.solver.service
 
 import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore
 import io.bluetape4k.clinic.appointment.model.dto.AppointmentRecord
+import java.io.Serializable
 
 /**
  * Solver 실행 결과.
  *
- * @param score Solver가 계산한 최종 점수
- * @param appointments 최적화된 예약 목록
- * @param isFeasible Hard Constraint 위반이 없는지 여부
- * @param solveTimeMillis Solver 실행 시간 (밀리초)
- * @param entityCount 최적화 대상 엔티티 수
- * @param pinnedCount 고정(pinned) 엔티티 수
+ * @property score Solver가 계산한 최종 점수
+ * @property appointments 최적화된 예약 목록
+ * @property isFeasible Hard Constraint 위반이 없는지 여부
+ * @property solveTimeMillis Solver 실행 시간 (밀리초)
+ * @property entityCount 최적화 대상 엔티티 수
+ * @property pinnedCount 고정(pinned) 엔티티 수
  */
 data class SolverResult(
     val score: HardSoftScore,
@@ -20,4 +21,8 @@ data class SolverResult(
     val solveTimeMillis: Long = 0L,
     val entityCount: Int = 0,
     val pinnedCount: Int = 0,
-)
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/service/SolverService.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/service/SolverService.kt
@@ -18,6 +18,13 @@ import java.time.LocalDate
  * Solver 실행 진입점.
  *
  * Repository에서 데이터를 로딩하고 Solver를 실행하여 최적화된 예약 배치를 반환합니다.
+ *
+ * @param clinicRepository 병원 데이터 조회 Repository
+ * @param doctorRepository 의사 데이터 조회 Repository
+ * @param appointmentRepository 예약 데이터 조회 Repository
+ * @param treatmentTypeRepository 진료 유형 데이터 조회 Repository
+ * @param holidayRepository 휴일 데이터 조회 Repository
+ * @param solverFactory 기본 SolverFactory
  */
 class SolverService(
     private val clinicRepository: ClinicRepository = ClinicRepository(),


### PR DESCRIPTION
## Summary
- 프로덕션 data class에 Serializable 및 serialVersionUID 계약을 명시했습니다.
- 모델/DTO/설정/이벤트 data class 생성자 프로퍼티 KDoc을 한국어로 보강했습니다.
- 주요 class 생성자 의존성도 KDoc @param으로 설명했습니다.
- 로컬 OMX 상태가 커밋되지 않도록 .omx/를 .gitignore에 추가했습니다.

## Code Review
- 변경 범위는 직렬화 계약과 문서화에 한정되어 동작 경로 변경은 없습니다.
- 프로덕션 data class 선언과 KDoc property coverage를 스크립트로 대조했습니다.
- Blocking findings: none.

## Tests
- ./gradlew test
- ./gradlew check
- production data class Serializable/KDoc coverage script

Closes #28