### PR TITLE
feat: Epic #12 - Lettuce NearCache(Caffeine+Redis 2-tier) 마스터 데이터 캐시 모듈 적용

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,13 +28,13 @@
 
 ### 도입 예정 모듈
 
-| 모듈 | 용도 | 우선순위 |
-|------|------|----------|
-| `bluetape4k-cache-core` | Caffeine 기반 로컬 캐시 추상화 | **HIGH** |
-| `bluetape4k-exposed-jdbc-caffeine` | Exposed 쿼리 결과 Caffeine 캐싱 | **HIGH** |
-| `bluetape4k-jackson3` | Jackson 3 직렬화 유틸 | MEDIUM |
-| `bluetape4k-http` | HTTP 클라이언트 확장 (테스트 시) | LOW |
-| `bluetape4k-virtualthread-jdk25` | Virtual Thread 지원 | LOW |
+| 모듈 | 용도 | 우선순위 | 이슈 |
+|------|------|----------|------|
+| `bluetape4k-cache-core` | Caffeine 기반 로컬 캐시 추상화 | **HIGH** | [EPIC #12](https://github.com/bluetape4k/clinic-appointment/issues/12) |
+| `bluetape4k-exposed-jdbc-caffeine` | Exposed 쿼리 결과 Caffeine 캐싱 | **HIGH** | [#20](https://github.com/bluetape4k/clinic-appointment/issues/20) |
+| `bluetape4k-jackson3` | Jackson 3 직렬화 유틸 | MEDIUM | [#49](https://github.com/bluetape4k/clinic-appointment/issues/49) |
+| `bluetape4k-http` | HTTP 클라이언트 확장 (테스트 시) | LOW | — |
+| `bluetape4k-virtualthread-jdk25` | Virtual Thread 지원 | LOW | — |
 
 ### 활용 가이드라인
 
@@ -98,14 +98,14 @@ Angular 21 유지. 프레임워크 마이그레이션 **미채택**.
 - 마이그레이션 비용 32-48 영업일 — ROI 부적합
 - Angular는 헬스케어/규제 도메인에서 지배적 (opinionated 구조, 필수 TypeScript)
 
-### 할 일
+### 할 일 ([EPIC #13](https://github.com/bluetape4k/clinic-appointment/issues/13))
 
-- ⬜ Capacitor 프로젝트 초기화 (`@capacitor/core`, `@capacitor/ios`, `@capacitor/android`)
-- ⬜ iOS Safari WebView + Android WebView 통합 테스트
-- ⬜ PWA 지원 강화 (`@angular/pwa`, Service Worker, 오프라인 캐싱)
-- ⬜ 모바일 UX 최적화 (뷰포트, 터치 제스처, Safe Area, 키보드 처리)
+- ⬜ Capacitor 프로젝트 초기화 (`@capacitor/core`, `@capacitor/ios`, `@capacitor/android`) — [#23](https://github.com/bluetape4k/clinic-appointment/issues/23)
+- ⬜ iOS Safari WebView + Android WebView 통합 테스트 — [#24](https://github.com/bluetape4k/clinic-appointment/issues/24)
+- ⬜ PWA 지원 강화 (`@angular/pwa`, Service Worker, 오프라인 캐싱) — [#25](https://github.com/bluetape4k/clinic-appointment/issues/25)
+- ⬜ 모바일 UX 최적화 (뷰포트, 터치 제스처, Safe Area, 키보드 처리) — [#26](https://github.com/bluetape4k/clinic-appointment/issues/26)
 - ⬜ Lazy loading / code splitting 최적화 (라우트별 번들 분리)
-- ⬜ 네이티브 ↔ WebView 통신 계층 설계 (Deep link, postMessage)
+- ⬜ 네이티브 ↔ WebView 통신 계층 설계 (Deep link, postMessage) — [#27](https://github.com/bluetape4k/clinic-appointment/issues/27)
 
 ---
 
@@ -133,7 +133,7 @@ Angular 21 유지. 프레임워크 마이그레이션 **미채택**.
 - ✅ `ClinicListComponent` → `ClinicService.getAll()` 연결
 - ✅ 목 데이터(`MOCK_CLINICS`) 제거
 
-### 3.3 하드코딩 clinicId 해소 (MEDIUM)
+### 3.3 하드코딩 clinicId 해소 (MEDIUM) — [#46](https://github.com/bluetape4k/clinic-appointment/issues/46)
 
 8개 컴포넌트에서 `const CLINIC_ID = 1` 또는 `private readonly clinicId = 1` 하드코딩됨:
 
@@ -156,27 +156,27 @@ Angular 21 유지. 프레임워크 마이그레이션 **미채택**.
 - `/appointments/new`, `/appointments/:id/edit`은 guard 있음 ✅
 - `/management/**` 전체에 `canActivate: [roleGuard]` 필요 (ADMIN/STAFF만 접근)
 
-- ⬜ `management.routes.ts`에 상위 레벨 `canActivate` 추가
+- ⬜ `management.routes.ts`에 상위 레벨 `canActivate` 추가 — [#47](https://github.com/bluetape4k/clinic-appointment/issues/47)
 
-### 3.5 SSE 기반 일괄 재배정 진행 상황 표시 (HIGH)
+### 3.5 SSE 기반 일괄 재배정 진행 상황 표시 (HIGH) — [EPIC #14](https://github.com/bluetape4k/clinic-appointment/issues/14)
 
 건당 예약 취소/변경은 단순 spinner로 충분하지만, 휴진 일괄 재배정은 N건을 순차 처리하므로 실시간 진행 피드백이 필요.
 
 **백엔드:**
-- ⬜ `GET /api/reschedule/batch/stream` — `text/event-stream` SSE 엔드포인트
+- ⬜ `GET /api/reschedule/batch/stream` — `text/event-stream` SSE 엔드포인트 — [#29](https://github.com/bluetape4k/clinic-appointment/issues/29)
 - ⬜ 예약별 처리 결과를 이벤트로 스트리밍: `data: {"appointmentId": N, "status": "SUCCESS|FAILED", "newAppointmentId": M, "progress": "3/15"}`
 - ⬜ 완료 시 `event: complete` + 요약 데이터 전송
 
 **프론트엔드:**
-- ⬜ `RescheduleService`에 `EventSource` 기반 SSE 연결 메서드 추가
-- ⬜ `reschedule-list.component` — 일괄 재배정 시 progress bar + 개별 결과 실시간 테이블 갱신
+- ⬜ `RescheduleService`에 `EventSource` 기반 SSE 연결 메서드 추가 — [#30](https://github.com/bluetape4k/clinic-appointment/issues/30)
+- ⬜ `reschedule-list.component` — 일괄 재배정 시 progress bar + 개별 결과 실시간 테이블 갱신 — [#31](https://github.com/bluetape4k/clinic-appointment/issues/31)
 - ⬜ 연결 실패/타임아웃 시 fallback (polling 또는 에러 표시)
 
 **설계 포인트:**
 - 건당 예약 → spinner (현재 구현 완료)
 - 일괄 재배정 (관리자) → SSE 진행률 + 실시간 결과 스트리밍
 
-### 3.6 환경 설정 파일 (LOW)
+### 3.6 환경 설정 파일 (LOW) — [#48](https://github.com/bluetape4k/clinic-appointment/issues/48)
 
 현재 API baseUrl이 `/api/` 상대경로로 하드코딩. 프로덕션 배포 시 `environment.ts` 구성 필요:
 
@@ -237,7 +237,7 @@ Angular 21 유지. 프레임워크 마이그레이션 **미채택**.
 
 ---
 
-## 8. 의존성 관리 (LOW)
+## 8. 의존성 관리 (LOW) — [#49](https://github.com/bluetape4k/clinic-appointment/issues/49)
 
 - ⬜ bluetape4k BOM 버전 최신화 모니터링 (현재 1.6.2)
 - ⬜ Jackson 3 마이그레이션 완료 여부 확인
@@ -247,45 +247,45 @@ Angular 21 유지. 프레임워크 마이그레이션 **미채택**.
 
 ## 9. 백로그 — 미구현 요구사항 (`docs/requirements/README.md` 기준)
 
-### 9.1 환자 포털 (MEDIUM)
+### 9.1 환자 포털 (MEDIUM) — [EPIC #15](https://github.com/bluetape4k/clinic-appointment/issues/15)
 
 자가 예약 웹앱 — 환자가 직접 예약/확인/취소하는 별도 프론트엔드.
 
-- ⬜ `appointment-patient-portal` 모듈 신규 생성 (Angular 또는 별도 SPA)
-- ⬜ 환자 인증 (별도 JWT Role: `PATIENT`)
-- ⬜ 예약 생성/조회/취소 UI — 기존 `/api/appointments` 재사용
-- ⬜ 슬롯 선택 캘린더 UI
+- ⬜ `appointment-patient-portal` 모듈 신규 생성 (Angular 또는 별도 SPA) — [#32](https://github.com/bluetape4k/clinic-appointment/issues/32)
+- ⬜ 환자 인증 (별도 JWT Role: `PATIENT`) — [#33](https://github.com/bluetape4k/clinic-appointment/issues/33)
+- ⬜ 예약 생성/조회/취소 UI — 기존 `/api/appointments` 재사용 — [#34](https://github.com/bluetape4k/clinic-appointment/issues/34)
+- ⬜ 슬롯 선택 캘린더 UI — [#35](https://github.com/bluetape4k/clinic-appointment/issues/35)
 - ⬜ 예약 확인 알림 수신 (SSE 또는 polling)
 
-### 9.2 멀티테넌시 — 병원 그룹 데이터 격리 (MEDIUM)
+### 9.2 멀티테넌시 — 병원 그룹 데이터 격리 (MEDIUM) — [EPIC #16](https://github.com/bluetape4k/clinic-appointment/issues/16)
 
 현재 clinicId를 단순 FK로 관리. 병원 그룹(테넌트)별 데이터 격리 필요 시 별도 설계 필요.
 
-- ⬜ 테넌트 ID 전략 결정 (Row-level 격리 vs Schema 분리 vs DB 분리)
-- ⬜ `Clinic` → `TenantGroup` 상위 엔티티 도입 검토
-- ⬜ JWT 토큰에 `tenantId` 클레임 추가 + 스프링 시큐리티 필터 연동
-- ⬜ Exposed Row-level Security 또는 테넌트 필터 인터셉터 구현
-- ⬜ 기존 `clinicId` 하드코딩 해소(섹션 3.3) 이후 진행 권장
+- ⬜ 테넌트 ID 전략 결정 (Row-level 격리 vs Schema 분리 vs DB 분리) — [#36](https://github.com/bluetape4k/clinic-appointment/issues/36)
+- ⬜ `Clinic` → `TenantGroup` 상위 엔티티 도입 검토 — [#37](https://github.com/bluetape4k/clinic-appointment/issues/37)
+- ⬜ JWT 토큰에 `tenantId` 클레임 추가 + 스프링 시큐리티 필터 연동 — [#38](https://github.com/bluetape4k/clinic-appointment/issues/38)
+- ⬜ Exposed Row-level Security 또는 테넌트 필터 인터셉터 구현 — [#39](https://github.com/bluetape4k/clinic-appointment/issues/39)
+- ⬜ 기존 `clinicId` 하드코딩 해소(섹션 3.3, [#46](https://github.com/bluetape4k/clinic-appointment/issues/46)) 이후 진행 권장
 
-### 9.3 메시지 큐 — 비동기 이벤트 처리 (LOW)
+### 9.3 메시지 큐 — 비동기 이벤트 처리 (LOW) — [EPIC #17](https://github.com/bluetape4k/clinic-appointment/issues/17)
 
 현재 Spring `ApplicationEvent`로 동기 처리 중. 대용량/외부 시스템 연동 시 Kafka/RabbitMQ 필요.
 
-- ⬜ Kafka 또는 RabbitMQ 도입 검토 (bluetape4k 지원 여부 확인 선행)
-- ⬜ `appointment-messaging` 신규 모듈 생성
+- ⬜ Kafka 또는 RabbitMQ 도입 검토 (bluetape4k 지원 여부 확인 선행) — [#40](https://github.com/bluetape4k/clinic-appointment/issues/40)
+- ⬜ `appointment-messaging` 신규 모듈 생성 — [#41](https://github.com/bluetape4k/clinic-appointment/issues/41)
 - ⬜ 도메인 이벤트(Created/StatusChanged/Cancelled/Rescheduled) → 메시지 큐 발행
-- ⬜ 외부 시스템(알림, 통계) 구독 컨슈머 구현
+- ⬜ 외부 시스템(알림, 통계) 구독 컨슈머 구현 — [#42](https://github.com/bluetape4k/clinic-appointment/issues/42)
 - ⬜ 이벤트 스키마 버전 관리 (Avro/JSON Schema Registry)
 
-### 9.4 관리자 대시보드 — 통계/분석 (LOW)
+### 9.4 관리자 대시보드 — 통계/분석 (LOW) — [EPIC #18](https://github.com/bluetape4k/clinic-appointment/issues/18)
 
 예약 현황, 의사별 부하, 클리닉 운영 지표를 시각화하는 관리자 전용 뷰.
 
 - ⬜ `appointment-dashboard` 신규 모듈 또는 프론트엔드 `/admin` 라우트 확장
-- ⬜ 집계 쿼리 API 설계 — 일별/주별 예약 건수, 취소율, 의사 부하 분포
+- ⬜ 집계 쿼리 API 설계 — 일별/주별 예약 건수, 취소율, 의사 부하 분포 — [#44](https://github.com/bluetape4k/clinic-appointment/issues/44)
 - ⬜ Exposed `groupBy`/`sum`/`count` 집계 쿼리 구현
-- ⬜ 차트 라이브러리 도입 (Chart.js 또는 Recharts)
-- ⬜ 관리자 Role Guard 연동 (섹션 3.4 완료 선행)
+- ⬜ 차트 라이브러리 도입 (Chart.js 또는 Recharts) — [#45](https://github.com/bluetape4k/clinic-appointment/issues/45)
+- ⬜ 관리자 Role Guard 연동 (섹션 3.4 완료 선행, [#47](https://github.com/bluetape4k/clinic-appointment/issues/47))
 
 ---
 

--- a/appointment-api/build.gradle.kts
+++ b/appointment-api/build.gradle.kts
@@ -17,6 +17,9 @@ dependencies {
     implementation(libs.bluetape4k.cache.lettuce)
     implementation(libs.bluetape4k.lettuce)
     implementation(libs.lettuce.core)
+    // NearCache 기본 코덱(LZ4 + Fory)이 optional 의존성이므로 명시적 추가 필요
+    implementation(libs.lz4.java)
+    implementation(libs.fory.kotlin)
     // Spring MVC suspend 함수 지원에 reactor-core 필요 (CoroutinesUtils 의존)
     implementation(libs.kotlinx.coroutines.reactor)
     implementation(libs.exposed.jdbc)

--- a/appointment-api/build.gradle.kts
+++ b/appointment-api/build.gradle.kts
@@ -12,6 +12,11 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-security")
+
+    // Cache: Lettuce NearCache (Caffeine local + Redis remote)
+    implementation(libs.bluetape4k.cache.lettuce)
+    implementation(libs.bluetape4k.lettuce)
+    implementation(libs.lettuce.core)
     // Spring MVC suspend 함수 지원에 reactor-core 필요 (CoroutinesUtils 의존)
     implementation(libs.kotlinx.coroutines.reactor)
     implementation(libs.exposed.jdbc)

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/CacheConfig.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/CacheConfig.kt
@@ -1,0 +1,17 @@
+package io.bluetape4k.clinic.appointment.api.config
+
+import io.bluetape4k.logging.KLogging
+import io.lettuce.core.RedisClient
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration(proxyBeanMethods = false)
+class CacheConfig {
+    companion object : KLogging()
+
+    @Bean(destroyMethod = "shutdown")
+    fun redisClient(
+        @Value("\${spring.data.redis.url:redis://localhost:6379}") redisUrl: String,
+    ): RedisClient = RedisClient.create(redisUrl)
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.clinic.appointment.api.config
 
+import io.bluetape4k.cache.LettuceCaches
 import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
 import io.bluetape4k.clinic.appointment.repository.AppointmentStateHistoryRepository
 import io.bluetape4k.clinic.appointment.repository.ClinicRepository
@@ -14,8 +15,10 @@ import io.bluetape4k.clinic.appointment.service.EquipmentUnavailabilityService
 import io.bluetape4k.clinic.appointment.service.SlotCalculationService
 import io.bluetape4k.clinic.appointment.statemachine.AppointmentStateMachine
 import io.bluetape4k.clinic.appointment.timezone.ClinicTimezoneService
+import io.lettuce.core.RedisClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import java.time.Duration
 
 @Configuration(proxyBeanMethods = false)
 class ServiceConfig {
@@ -27,10 +30,26 @@ class ServiceConfig {
     fun clinicRepository(): ClinicRepository = ClinicRepository()
 
     @Bean
-    fun doctorRepository(): DoctorRepository = DoctorRepository()
+    fun doctorRepository(redisClient: RedisClient): DoctorRepository =
+        DoctorRepository(
+            clinicDoctorsCache = LettuceCaches.nearCache(redisClient) {
+                cacheName = "clinic-doctors"
+                maxLocalSize = 500
+                frontExpireAfterWrite = Duration.ofMinutes(10)
+                redisTtl = Duration.ofHours(1)
+            }
+        )
 
     @Bean
-    fun treatmentTypeRepository(): TreatmentTypeRepository = TreatmentTypeRepository()
+    fun treatmentTypeRepository(redisClient: RedisClient): TreatmentTypeRepository =
+        TreatmentTypeRepository(
+            clinicTreatmentTypesCache = LettuceCaches.nearCache(redisClient) {
+                cacheName = "clinic-treatment-types"
+                maxLocalSize = 500
+                frontExpireAfterWrite = Duration.ofMinutes(10)
+                redisTtl = Duration.ofHours(1)
+            }
+        )
 
     @Bean
     fun holidayRepository(): HolidayRepository = HolidayRepository()
@@ -77,7 +96,15 @@ class ServiceConfig {
         ClinicTimezoneService(clinicRepository)
 
     @Bean
-    fun equipmentRepository(): EquipmentRepository = EquipmentRepository()
+    fun equipmentRepository(redisClient: RedisClient): EquipmentRepository =
+        EquipmentRepository(
+            clinicEquipmentsCache = LettuceCaches.nearCache(redisClient) {
+                cacheName = "clinic-equipments"
+                maxLocalSize = 500
+                frontExpireAfterWrite = Duration.ofMinutes(10)
+                redisTtl = Duration.ofHours(1)
+            }
+        )
 
     @Bean
     fun equipmentUnavailabilityRepository(): EquipmentUnavailabilityRepository = EquipmentUnavailabilityRepository()

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
@@ -29,7 +29,7 @@ import java.time.Duration
 class ServiceConfig {
 
     companion object : KLogging() {
-        private const val MASTER_CACHE_LOCAL_SIZE = 500
+        private const val MASTER_CACHE_LOCAL_SIZE = 500L
         private val MASTER_CACHE_LOCAL_TTL: Duration = Duration.ofMinutes(10)
         private val MASTER_CACHE_REDIS_TTL: Duration = Duration.ofHours(1)
     }

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
@@ -1,6 +1,10 @@
 package io.bluetape4k.clinic.appointment.api.config
 
 import io.bluetape4k.cache.LettuceCaches
+import io.bluetape4k.cache.nearcache.NearCacheOperations
+import io.bluetape4k.clinic.appointment.model.dto.DoctorRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentRecord
+import io.bluetape4k.clinic.appointment.model.dto.TreatmentTypeRecord
 import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
 import io.bluetape4k.clinic.appointment.repository.AppointmentStateHistoryRepository
 import io.bluetape4k.clinic.appointment.repository.ClinicRepository
@@ -15,6 +19,7 @@ import io.bluetape4k.clinic.appointment.service.EquipmentUnavailabilityService
 import io.bluetape4k.clinic.appointment.service.SlotCalculationService
 import io.bluetape4k.clinic.appointment.statemachine.AppointmentStateMachine
 import io.bluetape4k.clinic.appointment.timezone.ClinicTimezoneService
+import io.bluetape4k.logging.KLogging
 import io.lettuce.core.RedisClient
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -23,6 +28,43 @@ import java.time.Duration
 @Configuration(proxyBeanMethods = false)
 class ServiceConfig {
 
+    companion object : KLogging() {
+        private const val MASTER_CACHE_LOCAL_SIZE = 500
+        private val MASTER_CACHE_LOCAL_TTL: Duration = Duration.ofMinutes(10)
+        private val MASTER_CACHE_REDIS_TTL: Duration = Duration.ofHours(1)
+    }
+
+    // --- 마스터 데이터 NearCache 빈 (destroyMethod 지정으로 리소스 해제 보장) ---
+
+    @Bean(destroyMethod = "close")
+    fun clinicDoctorsCache(redisClient: RedisClient): NearCacheOperations<List<DoctorRecord>> =
+        LettuceCaches.nearCache(redisClient) {
+            cacheName = "clinic-doctors"
+            maxLocalSize = MASTER_CACHE_LOCAL_SIZE
+            frontExpireAfterWrite = MASTER_CACHE_LOCAL_TTL
+            redisTtl = MASTER_CACHE_REDIS_TTL
+        }
+
+    @Bean(destroyMethod = "close")
+    fun clinicEquipmentsCache(redisClient: RedisClient): NearCacheOperations<List<EquipmentRecord>> =
+        LettuceCaches.nearCache(redisClient) {
+            cacheName = "clinic-equipments"
+            maxLocalSize = MASTER_CACHE_LOCAL_SIZE
+            frontExpireAfterWrite = MASTER_CACHE_LOCAL_TTL
+            redisTtl = MASTER_CACHE_REDIS_TTL
+        }
+
+    @Bean(destroyMethod = "close")
+    fun clinicTreatmentTypesCache(redisClient: RedisClient): NearCacheOperations<List<TreatmentTypeRecord>> =
+        LettuceCaches.nearCache(redisClient) {
+            cacheName = "clinic-treatment-types"
+            maxLocalSize = MASTER_CACHE_LOCAL_SIZE
+            frontExpireAfterWrite = MASTER_CACHE_LOCAL_TTL
+            redisTtl = MASTER_CACHE_REDIS_TTL
+        }
+
+    // --- Repository 빈 ---
+
     @Bean
     fun appointmentRepository(): AppointmentRepository = AppointmentRepository()
 
@@ -30,26 +72,19 @@ class ServiceConfig {
     fun clinicRepository(): ClinicRepository = ClinicRepository()
 
     @Bean
-    fun doctorRepository(redisClient: RedisClient): DoctorRepository =
-        DoctorRepository(
-            clinicDoctorsCache = LettuceCaches.nearCache(redisClient) {
-                cacheName = "clinic-doctors"
-                maxLocalSize = 500
-                frontExpireAfterWrite = Duration.ofMinutes(10)
-                redisTtl = Duration.ofHours(1)
-            }
-        )
+    fun doctorRepository(
+        clinicDoctorsCache: NearCacheOperations<List<DoctorRecord>>,
+    ): DoctorRepository = DoctorRepository(clinicDoctorsCache)
 
     @Bean
-    fun treatmentTypeRepository(redisClient: RedisClient): TreatmentTypeRepository =
-        TreatmentTypeRepository(
-            clinicTreatmentTypesCache = LettuceCaches.nearCache(redisClient) {
-                cacheName = "clinic-treatment-types"
-                maxLocalSize = 500
-                frontExpireAfterWrite = Duration.ofMinutes(10)
-                redisTtl = Duration.ofHours(1)
-            }
-        )
+    fun treatmentTypeRepository(
+        clinicTreatmentTypesCache: NearCacheOperations<List<TreatmentTypeRecord>>,
+    ): TreatmentTypeRepository = TreatmentTypeRepository(clinicTreatmentTypesCache)
+
+    @Bean
+    fun equipmentRepository(
+        clinicEquipmentsCache: NearCacheOperations<List<EquipmentRecord>>,
+    ): EquipmentRepository = EquipmentRepository(clinicEquipmentsCache)
 
     @Bean
     fun holidayRepository(): HolidayRepository = HolidayRepository()
@@ -59,6 +94,11 @@ class ServiceConfig {
 
     @Bean
     fun appointmentStateHistoryRepository(): AppointmentStateHistoryRepository = AppointmentStateHistoryRepository()
+
+    @Bean
+    fun equipmentUnavailabilityRepository(): EquipmentUnavailabilityRepository = EquipmentUnavailabilityRepository()
+
+    // --- Service 빈 ---
 
     @Bean
     fun slotCalculationService(
@@ -94,20 +134,6 @@ class ServiceConfig {
     @Bean
     fun clinicTimezoneService(clinicRepository: ClinicRepository): ClinicTimezoneService =
         ClinicTimezoneService(clinicRepository)
-
-    @Bean
-    fun equipmentRepository(redisClient: RedisClient): EquipmentRepository =
-        EquipmentRepository(
-            clinicEquipmentsCache = LettuceCaches.nearCache(redisClient) {
-                cacheName = "clinic-equipments"
-                maxLocalSize = 500
-                frontExpireAfterWrite = Duration.ofMinutes(10)
-                redisTtl = Duration.ofHours(1)
-            }
-        )
-
-    @Bean
-    fun equipmentUnavailabilityRepository(): EquipmentUnavailabilityRepository = EquipmentUnavailabilityRepository()
 
     @Bean
     fun equipmentUnavailabilityService(

--- a/appointment-api/src/main/resources/application.yml
+++ b/appointment-api/src/main/resources/application.yml
@@ -10,8 +10,6 @@ spring:
     flyway:
         enabled: false
         locations: classpath:db/migration/{vendor}
-
-spring:
     data:
         redis:
             url: redis://localhost:6379

--- a/appointment-api/src/main/resources/application.yml
+++ b/appointment-api/src/main/resources/application.yml
@@ -11,5 +11,10 @@ spring:
         enabled: false
         locations: classpath:db/migration/{vendor}
 
+spring:
+    data:
+        redis:
+            url: redis://localhost:6379
+
 server:
     port: 8080

--- a/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/test/AbstractApiIntegrationTest.kt
+++ b/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/test/AbstractApiIntegrationTest.kt
@@ -44,7 +44,9 @@ abstract class AbstractApiIntegrationTest {
 
         @JvmStatic
         @DynamicPropertySource
-        fun configureTestDatabase(registry: DynamicPropertyRegistry) {
+        fun configureTestContainers(registry: DynamicPropertyRegistry) {
+            registry.add("spring.data.redis.url") { Containers.Redis.url }
+
             val activeProfiles = System.getProperty("spring.profiles.active", "test")
             when {
                 activeProfiles.contains("test-postgresql") -> {

--- a/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/test/Containers.kt
+++ b/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/test/Containers.kt
@@ -3,12 +3,15 @@ package io.bluetape4k.clinic.appointment.api.test
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.testcontainers.database.MySQL8Server
 import io.bluetape4k.testcontainers.database.PostgreSQLServer
+import io.bluetape4k.testcontainers.storage.RedisServer
 import io.bluetape4k.utils.ShutdownQueue
 
 /**
- * API 통합 테스트용 DB 컨테이너.
+ * API 통합 테스트용 컨테이너.
  */
 object Containers : KLogging() {
+
+    val Redis: RedisServer by lazy { RedisServer.Launcher.redis }
 
     val Postgres: PostgreSQLServer by lazy { PostgreSQLServer.Launcher.postgres }
 

--- a/appointment-core/build.gradle.kts
+++ b/appointment-core/build.gradle.kts
@@ -7,6 +7,7 @@ dependencies {
     api(libs.exposed.java.time)
     api(libs.exposed.spring7.transaction)
 
+    api(libs.bluetape4k.cache.core)
     api(libs.bluetape4k.exposed.core)
     api(libs.bluetape4k.coroutines)
     api(libs.kotlinx.coroutines.core)
@@ -16,6 +17,12 @@ dependencies {
 
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.bluetape4k.testcontainers)
+    testImplementation(libs.bluetape4k.io)
+    testImplementation(libs.bluetape4k.cache.lettuce)
+    testImplementation(libs.bluetape4k.lettuce)
+    testImplementation(libs.lettuce.core)
+    testImplementation(libs.lz4.java)
+    testImplementation(libs.fory.kotlin)
     testImplementation(libs.bluetape4k.jdbc)
     testImplementation(libs.exposed.migration.jdbc)
     testImplementation(libs.h2.v2)

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/DoctorRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/DoctorRepository.kt
@@ -73,7 +73,7 @@ class DoctorRepository(
             .selectAll()
             .where { Doctors.clinicId eq clinicId }
             .map { it.toDoctorRecord() }
-            .also { clinicDoctorsCache?.put(cacheKey, it) }
+            .also { if (it.isNotEmpty()) clinicDoctorsCache?.put(cacheKey, it) }
     }
 
     fun findAllSchedules(doctorId: Long): List<DoctorScheduleRecord> =

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/DoctorRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/DoctorRepository.kt
@@ -64,8 +64,13 @@ class DoctorRepository(
     /**
      * 병원의 모든 의사를 조회합니다.
      *
+     * 결과는 NearCache(Caffeine + Redis)에 캐싱됩니다. 이 캐시는 **read-mostly** 마스터 데이터
+     * 전용이며, 의사 정보가 변경될 경우 캐시 무효화가 자동으로 수행되지 않습니다.
+     * 데이터 변경이 발생하면 캐시 TTL(기본 5분) 만료 후 자동 갱신되거나,
+     * [NearCacheOperations.evict]를 직접 호출하여 무효화해야 합니다.
+     *
      * @param clinicId 병원 ID
-     * @return 의사 목록
+     * @return 의사 목록 (빈 결과는 캐싱하지 않음)
      */
     fun findByClinicId(clinicId: Long): List<DoctorRecord> {
         val cacheKey = clinicId.toString()

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/DoctorRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/DoctorRepository.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.clinic.appointment.repository
 
+import io.bluetape4k.cache.nearcache.NearCacheOperations
 import io.bluetape4k.exposed.jdbc.repository.LongJdbcRepository
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requireNotNull
@@ -23,7 +24,9 @@ import java.time.LocalDate
  *
  * 의사의 기본 정보, 운영 스케줄, 휴무 정보를 조회합니다.
  */
-class DoctorRepository : LongJdbcRepository<DoctorRecord> {
+class DoctorRepository(
+    private val clinicDoctorsCache: NearCacheOperations<List<DoctorRecord>>? = null,
+) : LongJdbcRepository<DoctorRecord> {
     companion object : KLogging()
 
     override val table = Doctors
@@ -64,11 +67,14 @@ class DoctorRepository : LongJdbcRepository<DoctorRecord> {
      * @param clinicId 병원 ID
      * @return 의사 목록
      */
-    fun findByClinicId(clinicId: Long): List<DoctorRecord> =
-        Doctors
+    fun findByClinicId(clinicId: Long): List<DoctorRecord> {
+        val cacheKey = clinicId.toString()
+        return clinicDoctorsCache?.get(cacheKey) ?: Doctors
             .selectAll()
             .where { Doctors.clinicId eq clinicId }
             .map { it.toDoctorRecord() }
+            .also { clinicDoctorsCache?.put(cacheKey, it) }
+    }
 
     fun findAllSchedules(doctorId: Long): List<DoctorScheduleRecord> =
         DoctorSchedules

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentRepository.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.clinic.appointment.repository
 
+import io.bluetape4k.cache.nearcache.NearCacheOperations
 import io.bluetape4k.clinic.appointment.model.dto.EquipmentRecord
 import io.bluetape4k.clinic.appointment.model.tables.Equipments
 import io.bluetape4k.exposed.jdbc.repository.LongJdbcRepository
@@ -14,7 +15,9 @@ import org.jetbrains.exposed.v1.jdbc.selectAll
  *
  * 병원의 장비 목록 및 개별 장비 정보를 조회합니다.
  */
-class EquipmentRepository : LongJdbcRepository<EquipmentRecord> {
+class EquipmentRepository(
+    private val clinicEquipmentsCache: NearCacheOperations<List<EquipmentRecord>>? = null,
+) : LongJdbcRepository<EquipmentRecord> {
     companion object : KLogging()
 
     override val table = Equipments
@@ -27,9 +30,12 @@ class EquipmentRepository : LongJdbcRepository<EquipmentRecord> {
      * @param clinicId 병원 ID
      * @return 장비 목록
      */
-    fun findByClinicId(clinicId: Long): List<EquipmentRecord> =
-        Equipments
+    fun findByClinicId(clinicId: Long): List<EquipmentRecord> {
+        val cacheKey = clinicId.toString()
+        return clinicEquipmentsCache?.get(cacheKey) ?: Equipments
             .selectAll()
             .where { Equipments.clinicId eq clinicId }
             .map { it.toEquipmentRecord() }
+            .also { clinicEquipmentsCache?.put(cacheKey, it) }
+    }
 }

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentRepository.kt
@@ -27,8 +27,13 @@ class EquipmentRepository(
     /**
      * 병원의 장비 목록을 조회합니다.
      *
+     * 결과는 NearCache(Caffeine + Redis)에 캐싱됩니다. 이 캐시는 **read-mostly** 마스터 데이터
+     * 전용이며, 장비 정보가 변경될 경우 캐시 무효화가 자동으로 수행되지 않습니다.
+     * 데이터 변경이 발생하면 캐시 TTL(기본 5분) 만료 후 자동 갱신되거나,
+     * [NearCacheOperations.evict]를 직접 호출하여 무효화해야 합니다.
+     *
      * @param clinicId 병원 ID
-     * @return 장비 목록
+     * @return 장비 목록 (빈 결과는 캐싱하지 않음)
      */
     fun findByClinicId(clinicId: Long): List<EquipmentRecord> {
         val cacheKey = clinicId.toString()

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentRepository.kt
@@ -36,6 +36,6 @@ class EquipmentRepository(
             .selectAll()
             .where { Equipments.clinicId eq clinicId }
             .map { it.toEquipmentRecord() }
-            .also { clinicEquipmentsCache?.put(cacheKey, it) }
+            .also { if (it.isNotEmpty()) clinicEquipmentsCache?.put(cacheKey, it) }
     }
 }

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/TreatmentTypeRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/TreatmentTypeRepository.kt
@@ -1,20 +1,26 @@
 package io.bluetape4k.clinic.appointment.repository
 
 import io.bluetape4k.cache.nearcache.NearCacheOperations
-import io.bluetape4k.exposed.jdbc.repository.LongJdbcRepository
-import io.bluetape4k.logging.KLogging
-import io.bluetape4k.support.requireNotNull
 import io.bluetape4k.clinic.appointment.model.dto.EquipmentRecord
 import io.bluetape4k.clinic.appointment.model.dto.TreatmentEquipmentRecord
 import io.bluetape4k.clinic.appointment.model.dto.TreatmentTypeRecord
 import io.bluetape4k.clinic.appointment.model.tables.Equipments
 import io.bluetape4k.clinic.appointment.model.tables.TreatmentEquipments
 import io.bluetape4k.clinic.appointment.model.tables.TreatmentTypes
+import io.bluetape4k.exposed.jdbc.repository.LongJdbcRepository
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.support.requireNotNull
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.jdbc.selectAll
 
+/**
+ * 시술 유형(TreatmentType) 저장소.
+ *
+ * 병원의 시술 목록 조회, 시술별 필수 장비 ID 목록 조회, 장비 수량 조회를 담당합니다.
+ * 병원별 시술 목록은 [clinicTreatmentTypesCache]를 통해 NearCache(로컬 + Redis)로 캐싱됩니다.
+ */
 class TreatmentTypeRepository(
     private val clinicTreatmentTypesCache: NearCacheOperations<List<TreatmentTypeRecord>>? = null,
 ) : LongJdbcRepository<TreatmentTypeRecord> {
@@ -24,12 +30,24 @@ class TreatmentTypeRepository(
     override fun extractId(entity: TreatmentTypeRecord): Long = entity.id.requireNotNull("id")
     override fun ResultRow.toEntity(): TreatmentTypeRecord = toTreatmentTypeRecord()
 
+    /**
+     * 특정 시술 유형에 필요한 장비 ID 목록을 조회합니다.
+     *
+     * @param treatmentTypeId 시술 유형 ID
+     * @return 필수 장비 ID 목록
+     */
     fun findRequiredEquipmentIds(treatmentTypeId: Long): List<Long> =
         TreatmentEquipments
             .selectAll()
             .where { TreatmentEquipments.treatmentTypeId eq treatmentTypeId }
             .map { it[TreatmentEquipments.equipmentId].value }
 
+    /**
+     * 장비 ID 목록에 해당하는 장비별 수량을 조회합니다.
+     *
+     * @param equipmentIds 장비 ID 목록
+     * @return 장비 ID → 수량 매핑
+     */
     fun findEquipmentQuantities(equipmentIds: List<Long>): Map<Long, Int> =
         if (equipmentIds.isEmpty()) emptyMap()
         else Equipments
@@ -37,21 +55,41 @@ class TreatmentTypeRepository(
             .where { Equipments.id inList equipmentIds }
             .associate { it[Equipments.id].value to it[Equipments.quantity] }
 
+    /**
+     * 병원의 시술 유형 목록을 조회합니다. 결과는 NearCache에 캐싱됩니다.
+     *
+     * @param clinicId 병원 ID
+     * @return 시술 유형 목록 (빈 결과는 캐싱하지 않음)
+     */
     fun findByClinicId(clinicId: Long): List<TreatmentTypeRecord> {
         val cacheKey = clinicId.toString()
         return clinicTreatmentTypesCache?.get(cacheKey) ?: TreatmentTypes
             .selectAll()
             .where { TreatmentTypes.clinicId eq clinicId }
             .map { it.toTreatmentTypeRecord() }
-            .also { clinicTreatmentTypesCache?.put(cacheKey, it) }
+            .also { if (it.isNotEmpty()) clinicTreatmentTypesCache?.put(cacheKey, it) }
     }
 
+    /**
+     * 병원의 장비 목록을 조회합니다.
+     *
+     * @param clinicId 병원 ID
+     * @return 장비 목록
+     * @deprecated Equipment 도메인 책임은 [EquipmentRepository.findByClinicId]를 사용하세요.
+     */
+    @Deprecated("Equipment 도메인 책임은 EquipmentRepository.findByClinicId() 를 사용하세요.")
     fun findEquipmentsByClinicId(clinicId: Long): List<EquipmentRecord> =
         Equipments
             .selectAll()
             .where { Equipments.clinicId eq clinicId }
             .map { it.toEquipmentRecord() }
 
+    /**
+     * 병원 내 모든 시술-장비 연결 정보를 조회합니다.
+     *
+     * @param clinicId 병원 ID
+     * @return 시술-장비 연결 목록
+     */
     fun findAllTreatmentEquipments(clinicId: Long): List<TreatmentEquipmentRecord> {
         val treatmentIds = TreatmentTypes
             .selectAll()

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/TreatmentTypeRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/TreatmentTypeRepository.kt
@@ -56,7 +56,12 @@ class TreatmentTypeRepository(
             .associate { it[Equipments.id].value to it[Equipments.quantity] }
 
     /**
-     * 병원의 시술 유형 목록을 조회합니다. 결과는 NearCache에 캐싱됩니다.
+     * 병원의 시술 유형 목록을 조회합니다.
+     *
+     * 결과는 NearCache(Caffeine + Redis)에 캐싱됩니다. 이 캐시는 **read-mostly** 마스터 데이터
+     * 전용이며, 시술 유형 정보가 변경될 경우 캐시 무효화가 자동으로 수행되지 않습니다.
+     * 데이터 변경이 발생하면 캐시 TTL(기본 5분) 만료 후 자동 갱신되거나,
+     * [NearCacheOperations.evict]를 직접 호출하여 무효화해야 합니다.
      *
      * @param clinicId 병원 ID
      * @return 시술 유형 목록 (빈 결과는 캐싱하지 않음)

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/TreatmentTypeRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/TreatmentTypeRepository.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.clinic.appointment.repository
 
+import io.bluetape4k.cache.nearcache.NearCacheOperations
 import io.bluetape4k.exposed.jdbc.repository.LongJdbcRepository
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.support.requireNotNull
@@ -14,7 +15,9 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.jdbc.selectAll
 
-class TreatmentTypeRepository : LongJdbcRepository<TreatmentTypeRecord> {
+class TreatmentTypeRepository(
+    private val clinicTreatmentTypesCache: NearCacheOperations<List<TreatmentTypeRecord>>? = null,
+) : LongJdbcRepository<TreatmentTypeRecord> {
     companion object : KLogging()
 
     override val table = TreatmentTypes
@@ -34,11 +37,14 @@ class TreatmentTypeRepository : LongJdbcRepository<TreatmentTypeRecord> {
             .where { Equipments.id inList equipmentIds }
             .associate { it[Equipments.id].value to it[Equipments.quantity] }
 
-    fun findByClinicId(clinicId: Long): List<TreatmentTypeRecord> =
-        TreatmentTypes
+    fun findByClinicId(clinicId: Long): List<TreatmentTypeRecord> {
+        val cacheKey = clinicId.toString()
+        return clinicTreatmentTypesCache?.get(cacheKey) ?: TreatmentTypes
             .selectAll()
             .where { TreatmentTypes.clinicId eq clinicId }
             .map { it.toTreatmentTypeRecord() }
+            .also { clinicTreatmentTypesCache?.put(cacheKey, it) }
+    }
 
     fun findEquipmentsByClinicId(clinicId: Long): List<EquipmentRecord> =
         Equipments

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/DoctorRepositoryCacheTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/DoctorRepositoryCacheTest.kt
@@ -1,0 +1,155 @@
+package io.bluetape4k.clinic.appointment.repository
+
+import io.bluetape4k.cache.LettuceCaches
+import io.bluetape4k.cache.nearcache.NearCacheOperations
+import io.bluetape4k.clinic.appointment.model.dto.DoctorRecord
+import io.bluetape4k.clinic.appointment.model.tables.Clinics
+import io.bluetape4k.clinic.appointment.model.tables.Doctors
+import io.bluetape4k.clinic.appointment.test.AbstractExposedTest
+import io.bluetape4k.clinic.appointment.test.TestDB
+import io.bluetape4k.clinic.appointment.test.withTables
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.testcontainers.storage.RedisServer
+import io.bluetape4k.utils.ShutdownQueue
+import io.lettuce.core.RedisClient
+import org.amshove.kluent.shouldBeEqualTo
+import org.amshove.kluent.shouldHaveSize
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.time.Duration
+
+class DoctorRepositoryCacheTest : AbstractExposedTest() {
+
+    companion object : KLogging() {
+
+        private val redis: RedisServer by lazy { RedisServer.Launcher.redis }
+        private lateinit var redisClient: RedisClient
+
+        private val allTables = arrayOf(Clinics, Doctors)
+
+        @JvmStatic
+        @BeforeAll
+        fun setupRedis() {
+            redisClient = RedisClient.create(redis.url)
+            ShutdownQueue.register { redisClient.shutdown() }
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun teardownRedis() {
+            if (::redisClient.isInitialized) {
+                redisClient.shutdown()
+            }
+        }
+
+        private fun createCache(name: String): NearCacheOperations<List<DoctorRecord>> =
+            LettuceCaches.nearCache(redisClient) {
+                cacheName = name
+                maxLocalSize = 100
+                frontExpireAfterWrite = Duration.ofMinutes(1)
+                redisTtl = Duration.ofMinutes(5)
+            }
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `findByClinicId - DB 조회 결과를 캐시에 저장하고 재사용`(testDB: TestDB) {
+        val cache = createCache("test-doctors-01")
+        val repo = DoctorRepository(clinicDoctorsCache = cache)
+
+        withTables(testDB, *allTables) {
+            val clinicId = Clinics.insertAndGetId {
+                it[name] = "테스트 병원"
+                it[slotDurationMinutes] = 30
+                it[maxConcurrentPatients] = 3
+            }.value
+
+            Doctors.insertAndGetId {
+                it[Doctors.clinicId] = clinicId
+                it[name] = "김의사"
+                it[specialty] = "내과"
+                it[providerType] = "DOCTOR"
+            }
+
+            val result1 = repo.findByClinicId(clinicId)
+            result1 shouldHaveSize 1
+            result1[0].name shouldBeEqualTo "김의사"
+            result1[0].specialty shouldBeEqualTo "내과"
+
+            val result2 = repo.findByClinicId(clinicId)
+            result2 shouldHaveSize 1
+            result2[0].name shouldBeEqualTo result1[0].name
+        }
+
+        cache.close()
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `findByClinicId - 캐시 없이도 정상 동작`(testDB: TestDB) {
+        val repo = DoctorRepository(clinicDoctorsCache = null)
+
+        withTables(testDB, *allTables) {
+            val clinicId = Clinics.insertAndGetId {
+                it[name] = "캐시없는 병원"
+                it[slotDurationMinutes] = 30
+                it[maxConcurrentPatients] = 1
+            }.value
+
+            val empty = repo.findByClinicId(clinicId)
+            empty shouldHaveSize 0
+
+            Doctors.insertAndGetId {
+                it[Doctors.clinicId] = clinicId
+                it[name] = "박의사"
+                it[specialty] = "피부과"
+            }
+
+            val result = repo.findByClinicId(clinicId)
+            result shouldHaveSize 1
+            result[0].name shouldBeEqualTo "박의사"
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `findByClinicId - 다른 clinicId는 별도 캐시 키로 독립 관리`(testDB: TestDB) {
+        val cache = createCache("test-doctors-02")
+        val repo = DoctorRepository(clinicDoctorsCache = cache)
+
+        withTables(testDB, *allTables) {
+            val clinicId1 = Clinics.insertAndGetId {
+                it[name] = "병원 A"
+                it[slotDurationMinutes] = 30
+                it[maxConcurrentPatients] = 1
+            }.value
+
+            val clinicId2 = Clinics.insertAndGetId {
+                it[name] = "병원 B"
+                it[slotDurationMinutes] = 30
+                it[maxConcurrentPatients] = 1
+            }.value
+
+            Doctors.insertAndGetId {
+                it[Doctors.clinicId] = clinicId1
+                it[name] = "의사 A"
+            }
+            Doctors.insertAndGetId {
+                it[Doctors.clinicId] = clinicId2
+                it[name] = "의사 B1"
+            }
+            Doctors.insertAndGetId {
+                it[Doctors.clinicId] = clinicId2
+                it[name] = "의사 B2"
+            }
+
+            repo.findByClinicId(clinicId1) shouldHaveSize 1
+            repo.findByClinicId(clinicId2) shouldHaveSize 2
+        }
+
+        cache.close()
+    }
+}

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentRepositoryCacheTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/EquipmentRepositoryCacheTest.kt
@@ -2,9 +2,9 @@ package io.bluetape4k.clinic.appointment.repository
 
 import io.bluetape4k.cache.LettuceCaches
 import io.bluetape4k.cache.nearcache.NearCacheOperations
-import io.bluetape4k.clinic.appointment.model.dto.DoctorRecord
+import io.bluetape4k.clinic.appointment.model.dto.EquipmentRecord
 import io.bluetape4k.clinic.appointment.model.tables.Clinics
-import io.bluetape4k.clinic.appointment.model.tables.Doctors
+import io.bluetape4k.clinic.appointment.model.tables.Equipments
 import io.bluetape4k.clinic.appointment.test.AbstractExposedTest
 import io.bluetape4k.clinic.appointment.test.TestDB
 import io.bluetape4k.clinic.appointment.test.withTables
@@ -21,14 +21,14 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.time.Duration
 
-class DoctorRepositoryCacheTest : AbstractExposedTest() {
+class EquipmentRepositoryCacheTest : AbstractExposedTest() {
 
     companion object : KLogging() {
 
         private val redis: RedisServer by lazy { RedisServer.Launcher.redis }
         private lateinit var redisClient: RedisClient
 
-        private val allTables = arrayOf(Clinics, Doctors)
+        private val allTables = arrayOf(Clinics, Equipments)
 
         @JvmStatic
         @BeforeAll
@@ -44,7 +44,7 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
             }
         }
 
-        private fun createCache(name: String): NearCacheOperations<List<DoctorRecord>> =
+        private fun createCache(name: String): NearCacheOperations<List<EquipmentRecord>> =
             LettuceCaches.nearCache(redisClient) {
                 cacheName = name
                 maxLocalSize = 100
@@ -56,8 +56,8 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `findByClinicId - DB 조회 결과를 캐시에 저장하고 재사용`(testDB: TestDB) {
-        val cache = createCache("test-doctors-01-${testDB.name}")
-        val repo = DoctorRepository(clinicDoctorsCache = cache)
+        val cache = createCache("test-equipments-01-${testDB.name}")
+        val repo = EquipmentRepository(clinicEquipmentsCache = cache)
 
         withTables(testDB, *allTables) {
             val clinicId = Clinics.insertAndGetId {
@@ -66,17 +66,16 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
                 it[maxConcurrentPatients] = 3
             }.value
 
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId
-                it[name] = "김의사"
-                it[specialty] = "내과"
-                it[providerType] = "DOCTOR"
+            Equipments.insertAndGetId {
+                it[Equipments.clinicId] = clinicId
+                it[name] = "MRI 장비"
+                it[usageDurationMinutes] = 30
+                it[quantity] = 2
             }
 
             val result1 = repo.findByClinicId(clinicId)
             result1 shouldHaveSize 1
-            result1[0].name shouldBeEqualTo "김의사"
-            result1[0].specialty shouldBeEqualTo "내과"
+            result1[0].name shouldBeEqualTo "MRI 장비"
 
             // DB 조회 후 캐시에 실제로 저장됐는지 검증
             cache.get(clinicId.toString()).shouldNotBeNull() shouldHaveSize 1
@@ -92,7 +91,7 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `findByClinicId - 캐시 없이도 정상 동작`(testDB: TestDB) {
-        val repo = DoctorRepository(clinicDoctorsCache = null)
+        val repo = EquipmentRepository(clinicEquipmentsCache = null)
 
         withTables(testDB, *allTables) {
             val clinicId = Clinics.insertAndGetId {
@@ -104,40 +103,41 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
             val empty = repo.findByClinicId(clinicId)
             empty shouldHaveSize 0
 
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId
-                it[name] = "박의사"
-                it[specialty] = "피부과"
+            Equipments.insertAndGetId {
+                it[Equipments.clinicId] = clinicId
+                it[name] = "초음파 장비"
+                it[usageDurationMinutes] = 15
             }
 
             val result = repo.findByClinicId(clinicId)
             result shouldHaveSize 1
-            result[0].name shouldBeEqualTo "박의사"
+            result[0].name shouldBeEqualTo "초음파 장비"
         }
     }
 
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `findByClinicId - 빈 결과는 캐시에 저장하지 않음`(testDB: TestDB) {
-        val cache = createCache("test-doctors-03-${testDB.name}")
-        val repo = DoctorRepository(clinicDoctorsCache = cache)
+        val cache = createCache("test-equipments-03-${testDB.name}")
+        val repo = EquipmentRepository(clinicEquipmentsCache = cache)
 
         withTables(testDB, *allTables) {
             val clinicId = Clinics.insertAndGetId {
-                it[name] = "의사 없는 병원"
+                it[name] = "장비 없는 병원"
                 it[slotDurationMinutes] = 30
                 it[maxConcurrentPatients] = 1
             }.value
 
-            // 의사 없이 조회 — emptyList는 캐시 저장 안 됨
+            // 장비 없이 조회 — emptyList는 캐시 저장 안 됨
             val empty = repo.findByClinicId(clinicId)
             empty shouldHaveSize 0
             cache.get(clinicId.toString()) shouldBeEqualTo null
 
-            // 이후 의사 추가 시 캐시 스탈 없이 즉시 반영됨
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId
-                it[name] = "신규 의사"
+            // 이후 장비 추가 시 캐시 스탈 없이 즉시 반영됨
+            Equipments.insertAndGetId {
+                it[Equipments.clinicId] = clinicId
+                it[name] = "신규 장비"
+                it[usageDurationMinutes] = 20
             }
             val result = repo.findByClinicId(clinicId)
             result shouldHaveSize 1
@@ -149,8 +149,8 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `findByClinicId - 다른 clinicId는 별도 캐시 키로 독립 관리`(testDB: TestDB) {
-        val cache = createCache("test-doctors-02-${testDB.name}")
-        val repo = DoctorRepository(clinicDoctorsCache = cache)
+        val cache = createCache("test-equipments-02-${testDB.name}")
+        val repo = EquipmentRepository(clinicEquipmentsCache = cache)
 
         withTables(testDB, *allTables) {
             val clinicId1 = Clinics.insertAndGetId {
@@ -165,17 +165,20 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
                 it[maxConcurrentPatients] = 1
             }.value
 
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId1
-                it[name] = "의사 A"
+            Equipments.insertAndGetId {
+                it[Equipments.clinicId] = clinicId1
+                it[name] = "장비 A1"
+                it[usageDurationMinutes] = 20
             }
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId2
-                it[name] = "의사 B1"
+            Equipments.insertAndGetId {
+                it[Equipments.clinicId] = clinicId2
+                it[name] = "장비 B1"
+                it[usageDurationMinutes] = 30
             }
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId2
-                it[name] = "의사 B2"
+            Equipments.insertAndGetId {
+                it[Equipments.clinicId] = clinicId2
+                it[name] = "장비 B2"
+                it[usageDurationMinutes] = 45
             }
 
             repo.findByClinicId(clinicId1) shouldHaveSize 1

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/TreatmentTypeRepositoryCacheTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/TreatmentTypeRepositoryCacheTest.kt
@@ -2,9 +2,9 @@ package io.bluetape4k.clinic.appointment.repository
 
 import io.bluetape4k.cache.LettuceCaches
 import io.bluetape4k.cache.nearcache.NearCacheOperations
-import io.bluetape4k.clinic.appointment.model.dto.DoctorRecord
+import io.bluetape4k.clinic.appointment.model.dto.TreatmentTypeRecord
 import io.bluetape4k.clinic.appointment.model.tables.Clinics
-import io.bluetape4k.clinic.appointment.model.tables.Doctors
+import io.bluetape4k.clinic.appointment.model.tables.TreatmentTypes
 import io.bluetape4k.clinic.appointment.test.AbstractExposedTest
 import io.bluetape4k.clinic.appointment.test.TestDB
 import io.bluetape4k.clinic.appointment.test.withTables
@@ -21,14 +21,14 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import java.time.Duration
 
-class DoctorRepositoryCacheTest : AbstractExposedTest() {
+class TreatmentTypeRepositoryCacheTest : AbstractExposedTest() {
 
     companion object : KLogging() {
 
         private val redis: RedisServer by lazy { RedisServer.Launcher.redis }
         private lateinit var redisClient: RedisClient
 
-        private val allTables = arrayOf(Clinics, Doctors)
+        private val allTables = arrayOf(Clinics, TreatmentTypes)
 
         @JvmStatic
         @BeforeAll
@@ -44,7 +44,7 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
             }
         }
 
-        private fun createCache(name: String): NearCacheOperations<List<DoctorRecord>> =
+        private fun createCache(name: String): NearCacheOperations<List<TreatmentTypeRecord>> =
             LettuceCaches.nearCache(redisClient) {
                 cacheName = name
                 maxLocalSize = 100
@@ -56,8 +56,8 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `findByClinicId - DB 조회 결과를 캐시에 저장하고 재사용`(testDB: TestDB) {
-        val cache = createCache("test-doctors-01-${testDB.name}")
-        val repo = DoctorRepository(clinicDoctorsCache = cache)
+        val cache = createCache("test-treatment-types-01-${testDB.name}")
+        val repo = TreatmentTypeRepository(clinicTreatmentTypesCache = cache)
 
         withTables(testDB, *allTables) {
             val clinicId = Clinics.insertAndGetId {
@@ -66,17 +66,15 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
                 it[maxConcurrentPatients] = 3
             }.value
 
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId
-                it[name] = "김의사"
-                it[specialty] = "내과"
-                it[providerType] = "DOCTOR"
+            TreatmentTypes.insertAndGetId {
+                it[TreatmentTypes.clinicId] = clinicId
+                it[name] = "일반 진료"
+                it[defaultDurationMinutes] = 15
             }
 
             val result1 = repo.findByClinicId(clinicId)
             result1 shouldHaveSize 1
-            result1[0].name shouldBeEqualTo "김의사"
-            result1[0].specialty shouldBeEqualTo "내과"
+            result1[0].name shouldBeEqualTo "일반 진료"
 
             // DB 조회 후 캐시에 실제로 저장됐는지 검증
             cache.get(clinicId.toString()).shouldNotBeNull() shouldHaveSize 1
@@ -92,7 +90,7 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `findByClinicId - 캐시 없이도 정상 동작`(testDB: TestDB) {
-        val repo = DoctorRepository(clinicDoctorsCache = null)
+        val repo = TreatmentTypeRepository(clinicTreatmentTypesCache = null)
 
         withTables(testDB, *allTables) {
             val clinicId = Clinics.insertAndGetId {
@@ -104,40 +102,41 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
             val empty = repo.findByClinicId(clinicId)
             empty shouldHaveSize 0
 
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId
-                it[name] = "박의사"
-                it[specialty] = "피부과"
+            TreatmentTypes.insertAndGetId {
+                it[TreatmentTypes.clinicId] = clinicId
+                it[name] = "피부 시술"
+                it[defaultDurationMinutes] = 30
             }
 
             val result = repo.findByClinicId(clinicId)
             result shouldHaveSize 1
-            result[0].name shouldBeEqualTo "박의사"
+            result[0].name shouldBeEqualTo "피부 시술"
         }
     }
 
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `findByClinicId - 빈 결과는 캐시에 저장하지 않음`(testDB: TestDB) {
-        val cache = createCache("test-doctors-03-${testDB.name}")
-        val repo = DoctorRepository(clinicDoctorsCache = cache)
+        val cache = createCache("test-treatment-types-03-${testDB.name}")
+        val repo = TreatmentTypeRepository(clinicTreatmentTypesCache = cache)
 
         withTables(testDB, *allTables) {
             val clinicId = Clinics.insertAndGetId {
-                it[name] = "의사 없는 병원"
+                it[name] = "시술 없는 병원"
                 it[slotDurationMinutes] = 30
                 it[maxConcurrentPatients] = 1
             }.value
 
-            // 의사 없이 조회 — emptyList는 캐시 저장 안 됨
+            // 시술 유형 없이 조회 — emptyList는 캐시 저장 안 됨
             val empty = repo.findByClinicId(clinicId)
             empty shouldHaveSize 0
             cache.get(clinicId.toString()) shouldBeEqualTo null
 
-            // 이후 의사 추가 시 캐시 스탈 없이 즉시 반영됨
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId
-                it[name] = "신규 의사"
+            // 이후 시술 유형 추가 시 캐시 스탈 없이 즉시 반영됨
+            TreatmentTypes.insertAndGetId {
+                it[TreatmentTypes.clinicId] = clinicId
+                it[name] = "신규 시술"
+                it[defaultDurationMinutes] = 20
             }
             val result = repo.findByClinicId(clinicId)
             result shouldHaveSize 1
@@ -149,8 +148,8 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
     @ParameterizedTest
     @MethodSource(ENABLE_DIALECTS_METHOD)
     fun `findByClinicId - 다른 clinicId는 별도 캐시 키로 독립 관리`(testDB: TestDB) {
-        val cache = createCache("test-doctors-02-${testDB.name}")
-        val repo = DoctorRepository(clinicDoctorsCache = cache)
+        val cache = createCache("test-treatment-types-02-${testDB.name}")
+        val repo = TreatmentTypeRepository(clinicTreatmentTypesCache = cache)
 
         withTables(testDB, *allTables) {
             val clinicId1 = Clinics.insertAndGetId {
@@ -165,17 +164,20 @@ class DoctorRepositoryCacheTest : AbstractExposedTest() {
                 it[maxConcurrentPatients] = 1
             }.value
 
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId1
-                it[name] = "의사 A"
+            TreatmentTypes.insertAndGetId {
+                it[TreatmentTypes.clinicId] = clinicId1
+                it[name] = "시술 A1"
+                it[defaultDurationMinutes] = 15
             }
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId2
-                it[name] = "의사 B1"
+            TreatmentTypes.insertAndGetId {
+                it[TreatmentTypes.clinicId] = clinicId2
+                it[name] = "시술 B1"
+                it[defaultDurationMinutes] = 20
             }
-            Doctors.insertAndGetId {
-                it[Doctors.clinicId] = clinicId2
-                it[name] = "의사 B2"
+            TreatmentTypes.insertAndGetId {
+                it[TreatmentTypes.clinicId] = clinicId2
+                it[name] = "시술 B2"
+                it[defaultDurationMinutes] = 30
             }
 
             repo.findByClinicId(clinicId1) shouldHaveSize 1

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/service/SolverService.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/service/SolverService.kt
@@ -6,6 +6,7 @@ import io.bluetape4k.clinic.appointment.model.dto.AppointmentRecord
 import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
 import io.bluetape4k.clinic.appointment.repository.ClinicRepository
 import io.bluetape4k.clinic.appointment.repository.DoctorRepository
+import io.bluetape4k.clinic.appointment.repository.EquipmentRepository
 import io.bluetape4k.clinic.appointment.repository.HolidayRepository
 import io.bluetape4k.clinic.appointment.repository.TreatmentTypeRepository
 import io.bluetape4k.clinic.appointment.solver.converter.SolutionConverter
@@ -31,6 +32,7 @@ class SolverService(
     private val doctorRepository: DoctorRepository = DoctorRepository(),
     private val appointmentRepository: AppointmentRepository = AppointmentRepository(),
     private val treatmentTypeRepository: TreatmentTypeRepository = TreatmentTypeRepository(),
+    private val equipmentRepository: EquipmentRepository = EquipmentRepository(),
     private val holidayRepository: HolidayRepository = HolidayRepository(),
     private val solverFactory: SolverFactory<ScheduleSolution> = AppointmentSolverConfig.createFactory(),
 ) {
@@ -113,7 +115,7 @@ class SolverService(
             val doctors = doctorRepository.findByClinicId(clinicId)
             val appointments = appointmentRepository.findByClinicAndDateRange(clinicId, dateRange)
             val treatments = treatmentTypeRepository.findByClinicId(clinicId)
-            val equipments = treatmentTypeRepository.findEquipmentsByClinicId(clinicId)
+            val equipments = equipmentRepository.findByClinicId(clinicId)
             val operatingHours = clinicRepository.findAllOperatingHours(clinicId)
             val doctorSchedules = doctors.flatMap { doctorRepository.findAllSchedules(it.id!!) }
             val doctorAbsences = doctors.flatMap { doctorRepository.findAbsencesByDateRange(it.id!!, dateRange) }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,8 @@ jjwt = "0.13.0"
 
 lettuce = "6.8.2.RELEASE"
 exposed = "1.2.0"
+lz4-java = "1.8.0"
+fory = "0.15.0"
 
 slf4j = "2.0.17"
 logback = "1.5.32"
@@ -74,6 +76,9 @@ bluetape4k-jackson3 = { module = "io.github.bluetape4k:bluetape4k-jackson3" }
 bluetape4k-jdbc = { module = "io.github.bluetape4k:bluetape4k-jdbc" }
 bluetape4k-junit5 = { module = "io.github.bluetape4k:bluetape4k-junit5" }
 bluetape4k-leader = { module = "io.github.bluetape4k:bluetape4k-leader" }
+bluetape4k-cache-core = { module = "io.github.bluetape4k:bluetape4k-cache-core" }
+bluetape4k-cache-lettuce = { module = "io.github.bluetape4k:bluetape4k-cache-lettuce" }
+bluetape4k-io = { module = "io.github.bluetape4k:bluetape4k-io" }
 bluetape4k-lettuce = { module = "io.github.bluetape4k:bluetape4k-lettuce" }
 bluetape4k-logging = { module = "io.github.bluetape4k:bluetape4k-logging" }
 bluetape4k-resilience4j = { module = "io.github.bluetape4k:bluetape4k-resilience4j" }
@@ -108,6 +113,11 @@ logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 
 # Lettuce
 lettuce-core = { module = "io.lettuce:lettuce-core", version.ref = "lettuce" }
+
+# Compression / Serialization
+lz4-java = { module = "org.lz4:lz4-java", version.ref = "lz4-java" }
+fory-core = { module = "org.apache.fory:fory-core", version.ref = "fory" }
+fory-kotlin = { module = "org.apache.fory:fory-kotlin", version.ref = "fory" }
 
 # Exposed
 exposed-core = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }


### PR DESCRIPTION
## 개요

병원(Doctor/Equipment/TreatmentType) 마스터 데이터 조회에 Lettuce NearCache(Caffeine 로컬 + Redis 원격)를 적용합니다.
Solver 실행 시 반복되는 DB I/O를 줄이고, read-mostly 마스터 데이터의 응답 성능을 개선합니다.

Closes #12
Closes #19
Closes #20
Closes #21
Closes #22

## 변경 사항

### appointment-core

- `DoctorRepository` — `findByClinicId()` NearCache 적용
- `EquipmentRepository` (신규) — `findByClinicId()` NearCache 적용
- `TreatmentTypeRepository` — `findByClinicId()` NearCache 적용, `findEquipmentsByClinicId()` `@Deprecated` 처리
- `DoctorRepositoryCacheTest` — 4가지 캐시 시나리오 × 3 DB dialect 테스트 추가
- `EquipmentRepositoryCacheTest` — 동일 패턴 테스트 추가 (신규)
- `TreatmentTypeRepositoryCacheTest` — 동일 패턴 테스트 추가 (신규)
- `gradle/libs.versions.toml` — `bluetape4k-cache-core`, `bluetape4k-cache-lettuce`, `lz4-java`, `fory-kotlin` 추가

### appointment-api

- `CacheConfig` — `RedisClient` 빈 등록, `LettuceNearCache` 팩토리 메서드 추가
- `ServiceConfig` — Repository 빈에 캐시 주입 구성

### appointment-solver

- `SolverService` — `treatmentTypeRepository.findEquipmentsByClinicId()` → `equipmentRepository.findByClinicId()` 교체 (SRP 준수)

## 캐시 설계

| 캐시 | 로컬(Caffeine) TTL | Redis TTL |
|------|-------------------|-----------|
| clinic-doctors | 10분 | 1시간 |
| clinic-equipments | 10분 | 1시간 |
| clinic-treatment-types | 10분 | 1시간 |

- Redis key 형식: `{cacheName}:{clinicId}` (LettuceNearCache 내부 prefix 방식)
- 빈 결과(`emptyList()`)는 캐싱하지 않음 — negative caching 방지
- 마스터 데이터 쓰기 발생 시 `NearCacheOperations.evict()` 직접 호출로 무효화 (현재 read-mostly 가정)

## 테스트

```
appointment-core: 262 passing
appointment-solver: 27 passing
```

## 후속 이슈

- #52 — `@Cacheable`/`@CacheEvict` Spring Cache 어노테이션 방식으로 전환 (현재 manual cache → declarative cache)