### PR TITLE
docs: publish bilingual clinic README set

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,102 @@
+# clinic-appointment
+
+[English](README.md) | [한국어](README.ko.md)
+
+[![CI](https://github.com/bluetape4k/clinic-appointment/actions/workflows/ci.yml/badge.svg)](https://github.com/bluetape4k/clinic-appointment/actions/workflows/ci.yml)
+[![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org)
+[![Spring Boot](https://img.shields.io/badge/Spring_Boot-4.0.5-6DB33F?logo=springboot&logoColor=white)](https://spring.io/projects/spring-boot)
+[![Java](https://img.shields.io/badge/Java-25-ED8B00?logo=openjdk&logoColor=white)](https://openjdk.org/projects/jdk/25/)
+[![Coverage Status](https://coveralls.io/repos/github/bluetape4k/clinic-appointment/badge.svg?branch=main)](https://coveralls.io/github/bluetape4k/clinic-appointment?branch=main)
+[![Kover](https://img.shields.io/badge/coverage-Kover-7F52FF?logo=kotlin&logoColor=white)](https://github.com/Kotlin/kotlinx-kover)
+[![Last Commit](https://img.shields.io/github/last-commit/bluetape4k/clinic-appointment)](https://github.com/bluetape4k/clinic-appointment/commits/main)
+
+개인병원 환자 예약 관리 시스템 - Kotlin 2.3 + Spring Boot 4 + Timefold Solver AI 스케줄링
+
+## 주요 기능
+
+- **예약 상태 머신** - PENDING -> REQUESTED -> CONFIRMED -> CHECKED_IN -> IN_PROGRESS -> COMPLETED 전이, 취소/재배정 지원
+- **AI 최적 스케줄링** - Timefold Solver로 의사, 장비, 영업시간 10개 Hard + 2개 Soft 제약을 동시에 만족하는 최적 배치
+- **고가용성 알림** - Redis Leader Election으로 단일 노드 전송 보장, Resilience4j CircuitBreaker/Retry/Bulkhead 적용
+- **REST API** - Spring Boot 4 MVC, JWT 인증, Flyway 마이그레이션, Swagger UI 제공
+- **Angular 18 웹 UI** - 예약 조회/생성/상태 변경 인터페이스
+
+## 아키텍처
+
+```mermaid
+graph TD
+    core[appointment-core\n도메인/리포지토리/상태머신]
+    event[appointment-event\n도메인 이벤트]
+    solver[appointment-solver\nTimefold AI 스케줄러]
+    notification[appointment-notification\nHA 알림 스케줄러]
+    api[appointment-api\nSpring Boot REST API]
+    frontend[frontend/appointment-frontend\nAngular 18]
+
+    core --> event
+    core --> solver
+    core --> notification
+    event --> notification
+    core --> api
+    event --> api
+    solver --> api
+```
+
+## 모듈
+
+| 모듈 | 역할 | 개발자 문서 |
+|------|------|-----------|
+| `appointment-core` | 도메인 모델(16개 엔티티), Exposed ORM 테이블, 리포지토리, 예약 상태머신, 슬롯 계산 서비스 | [README](appointment-core/README.md) |
+| `appointment-event` | Spring ApplicationEvent 기반 도메인 이벤트 발행/구독, 이벤트 로그 저장 | [README](appointment-event/README.md) |
+| `appointment-solver` | Timefold Solver AI 최적화 - 10개 Hard + 2개 Soft 제약으로 대량 예약 최적 배치 | [README](appointment-solver/README.md) |
+| `appointment-notification` | Redis Leader Election + Resilience4j 기반 HA 알림 스케줄러, 리마인더 발송 | [README](appointment-notification/README.md) |
+| `appointment-api` | Spring Boot 4 REST API - 예약 CRUD, 슬롯 조회, 재배정, JWT 인증, Swagger | [README](appointment-api/README.md) |
+| `frontend/appointment-frontend` | Angular 18 웹 UI - 예약 관리 인터페이스 | [README](frontend/appointment-frontend/README.md) |
+
+## 빠른 시작
+
+> TODO: Docker Compose 환경 구성 후 업데이트 예정
+
+현재는 수동으로 PostgreSQL + Redis를 실행한 뒤 API를 기동합니다.
+
+```bash
+# API 서버 기동 (PostgreSQL + Redis 필요)
+./gradlew :appointment-api:bootRun
+# Swagger UI: http://localhost:8080/swagger-ui.html
+```
+
+## 빌드 & 테스트
+
+```bash
+# 전체 빌드 (frontend 제외)
+./gradlew build -x :frontend:appointment-frontend:build
+
+# 모듈별 빌드
+./gradlew :appointment-core:build
+./gradlew :appointment-solver:build
+./gradlew :appointment-api:build
+
+# 특정 테스트 실행
+./gradlew :appointment-core:test --tests "fully.qualified.ClassName.methodName"
+```
+
+### 사전 준비
+
+- JDK 25
+- Docker (Testcontainers - 테스트 시 자동 기동)
+- Node.js 22+ (frontend 빌드 시만 필요)
+
+## 문서
+
+### 요구사항 & 설계
+
+| 문서 | 내용 |
+|------|------|
+| [요구사항 인덱스](docs/requirements/README.md) | 전체 요구사항 목록 + 구현 상태 |
+| [아키텍처](docs/requirements/architecture.md) | 모듈 의존성, 주요 설계 결정 (ADR) |
+| [도메인 모델](docs/requirements/domain-model.md) | 16개 엔티티, 예약 상태머신, 테이블 관계 |
+| [AI 스케줄러](docs/requirements/solver.md) | Timefold Solver 제약조건 설계 |
+| [알림 모듈](docs/requirements/notification.md) | 알림 채널, HA 구성, Resilience4j |
+| [프론트엔드](docs/requirements/frontend.md) | Angular 구성, 페이지 구조 |
+
+### 변경 이력
+
+- [CHANGELOG.md](CHANGELOG.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # clinic-appointment
 
+[English](README.md) | [한국어](README.ko.md)
+
 [![CI](https://github.com/bluetape4k/clinic-appointment/actions/workflows/ci.yml/badge.svg)](https://github.com/bluetape4k/clinic-appointment/actions/workflows/ci.yml)
 [![Kotlin](https://img.shields.io/badge/Kotlin-2.3.20-7F52FF?logo=kotlin&logoColor=white)](https://kotlinlang.org)
 [![Spring Boot](https://img.shields.io/badge/Spring_Boot-4.0.5-6DB33F?logo=springboot&logoColor=white)](https://spring.io/projects/spring-boot)
@@ -8,24 +10,24 @@
 [![Kover](https://img.shields.io/badge/coverage-Kover-7F52FF?logo=kotlin&logoColor=white)](https://github.com/Kotlin/kotlinx-kover)
 [![Last Commit](https://img.shields.io/github/last-commit/bluetape4k/clinic-appointment)](https://github.com/bluetape4k/clinic-appointment/commits/main)
 
-개인병원 환자 예약 관리 시스템 — Kotlin 2.3 + Spring Boot 4 + Timefold Solver AI 스케줄링
+A private clinic appointment management system built with Kotlin 2.3, Spring Boot 4, and Timefold Solver AI scheduling.
 
-## 주요 기능
+## Key Features
 
-- **예약 상태 머신** — PENDING → REQUESTED → CONFIRMED → CHECKED_IN → IN_PROGRESS → COMPLETED 전이, 취소/재배정 지원
-- **AI 최적 스케줄링** — Timefold Solver로 의사·장비·영업시간 10개 Hard + 2개 Soft 제약을 동시에 만족하는 최적 배치
-- **고가용성 알림** — Redis Leader Election으로 단일 노드 전송 보장, Resilience4j CircuitBreaker/Retry/Bulkhead 적용
-- **REST API** — Spring Boot 4 MVC, JWT 인증, Flyway 마이그레이션, Swagger UI 제공
-- **Angular 18 웹 UI** — 예약 조회/생성/상태 변경 인터페이스
+- **Appointment state machine** - Supports PENDING -> REQUESTED -> CONFIRMED -> CHECKED_IN -> IN_PROGRESS -> COMPLETED transitions, cancellation, and reassignment.
+- **AI schedule optimization** - Uses Timefold Solver to assign appointments while satisfying doctor, equipment, business-hour, 10 hard, and 2 soft constraints.
+- **High-availability notifications** - Uses Redis Leader Election to guarantee single-node delivery, with Resilience4j CircuitBreaker/Retry/Bulkhead.
+- **REST API** - Provides Spring Boot 4 MVC APIs with JWT authentication, Flyway migrations, and Swagger UI.
+- **Angular 18 web UI** - Provides appointment search, creation, and status-change workflows.
 
-## 아키텍처
+## Architecture
 
 ```mermaid
 graph TD
-    core[appointment-core\n도메인·리포지토리·상태머신]
-    event[appointment-event\n도메인 이벤트]
-    solver[appointment-solver\nTimefold AI 스케줄러]
-    notification[appointment-notification\nHA 알림 스케줄러]
+    core[appointment-core\nDomain/Repositories/State Machine]
+    event[appointment-event\nDomain Events]
+    solver[appointment-solver\nTimefold AI Scheduler]
+    notification[appointment-notification\nHA Notification Scheduler]
     api[appointment-api\nSpring Boot REST API]
     frontend[frontend/appointment-frontend\nAngular 18]
 
@@ -38,63 +40,63 @@ graph TD
     solver --> api
 ```
 
-## 모듈
+## Modules
 
-| 모듈 | 역할 | 개발자 문서 |
+| Module | Role | Developer Docs |
 |------|------|-----------|
-| `appointment-core` | 도메인 모델(16개 엔티티), Exposed ORM 테이블, 리포지토리, 예약 상태머신, 슬롯 계산 서비스 | [README](appointment-core/README.md) |
-| `appointment-event` | Spring ApplicationEvent 기반 도메인 이벤트 발행/구독, 이벤트 로그 저장 | [README](appointment-event/README.md) |
-| `appointment-solver` | Timefold Solver AI 최적화 — 10개 Hard + 2개 Soft 제약으로 대량 예약 최적 배치 | [README](appointment-solver/README.md) |
-| `appointment-notification` | Redis Leader Election + Resilience4j 기반 HA 알림 스케줄러, 리마인더 발송 | [README](appointment-notification/README.md) |
-| `appointment-api` | Spring Boot 4 REST API — 예약 CRUD, 슬롯 조회, 재배정, JWT 인증, Swagger | [README](appointment-api/README.md) |
-| `frontend/appointment-frontend` | Angular 18 웹 UI — 예약 관리 인터페이스 | [README](frontend/appointment-frontend/README.md) |
+| `appointment-core` | Domain model with 16 entities, Exposed ORM tables, repositories, appointment state machine, and slot calculation services. | [README](appointment-core/README.md) |
+| `appointment-event` | Domain event publishing/subscription and event log persistence based on Spring ApplicationEvent. | [README](appointment-event/README.md) |
+| `appointment-solver` | Timefold Solver AI optimization for bulk appointment placement using 10 hard and 2 soft constraints. | [README](appointment-solver/README.md) |
+| `appointment-notification` | HA notification scheduler and reminder delivery using Redis Leader Election and Resilience4j. | [README](appointment-notification/README.md) |
+| `appointment-api` | Spring Boot 4 REST API for appointment CRUD, slot lookup, reassignment, JWT authentication, and Swagger. | [README](appointment-api/README.md) |
+| `frontend/appointment-frontend` | Angular 18 web UI for appointment management. | [README](frontend/appointment-frontend/README.md) |
 
-## 빠른 시작
+## Quick Start
 
-> TODO: Docker Compose 환경 구성 후 업데이트 예정
+> TODO: Update after the Docker Compose environment is added.
 
-현재는 수동으로 PostgreSQL + Redis를 실행한 뒤 API를 기동합니다.
+For now, start PostgreSQL and Redis manually, then run the API server.
 
 ```bash
-# API 서버 기동 (PostgreSQL + Redis 필요)
+# Start the API server (requires PostgreSQL + Redis)
 ./gradlew :appointment-api:bootRun
 # Swagger UI: http://localhost:8080/swagger-ui.html
 ```
 
-## 빌드 & 테스트
+## Build & Test
 
 ```bash
-# 전체 빌드 (frontend 제외)
+# Full build without frontend
 ./gradlew build -x :frontend:appointment-frontend:build
 
-# 모듈별 빌드
+# Module-scoped builds
 ./gradlew :appointment-core:build
 ./gradlew :appointment-solver:build
 ./gradlew :appointment-api:build
 
-# 특정 테스트 실행
+# Run a specific test
 ./gradlew :appointment-core:test --tests "fully.qualified.ClassName.methodName"
 ```
 
 ### Prerequisites
 
 - JDK 25
-- Docker (Testcontainers — 테스트 시 자동 기동)
-- Node.js 22+ (frontend 빌드 시만 필요)
+- Docker (Testcontainers starts dependencies automatically during tests)
+- Node.js 22+ (only needed for frontend builds)
 
-## 문서
+## Documentation
 
-### 요구사항 & 설계
+### Requirements & Design
 
-| 문서 | 내용 |
+| Document | Description |
 |------|------|
-| [요구사항 인덱스](docs/requirements/README.md) | 전체 요구사항 목록 + 구현 상태 |
-| [아키텍처](docs/requirements/architecture.md) | 모듈 의존성, 주요 설계 결정 (ADR) |
-| [도메인 모델](docs/requirements/domain-model.md) | 16개 엔티티, 예약 상태머신, 테이블 관계 |
-| [AI 스케줄러](docs/requirements/solver.md) | Timefold Solver 제약조건 설계 |
-| [알림 모듈](docs/requirements/notification.md) | 알림 채널, HA 구성, Resilience4j |
-| [프론트엔드](docs/requirements/frontend.md) | Angular 구성, 페이지 구조 |
+| [Requirements Index](docs/requirements/README.md) | Complete requirements list and implementation status. |
+| [Architecture](docs/requirements/architecture.md) | Module dependencies and key architecture decisions. |
+| [Domain Model](docs/requirements/domain-model.md) | 16 entities, appointment state machine, and table relationships. |
+| [AI Scheduler](docs/requirements/solver.md) | Timefold Solver constraint design. |
+| [Notification Module](docs/requirements/notification.md) | Notification channels, HA configuration, and Resilience4j. |
+| [Frontend](docs/requirements/frontend.md) | Angular structure and page design. |
 
-### 변경 이력
+### Change History
 
 - [CHANGELOG.md](CHANGELOG.md)

--- a/appointment-api/README.ko.md
+++ b/appointment-api/README.ko.md
@@ -1,5 +1,7 @@
 # appointment-api
 
+[English](README.md) | [한국어](README.ko.md)
+
 Spring Boot 4 REST API 서버 — JWT 인증, Flyway 마이그레이션, Swagger UI, Gatling 부하 테스트.
 
 ## 책임
@@ -13,18 +15,46 @@ Spring Boot 4 REST API 서버 — JWT 인증, Flyway 마이그레이션, Swagger
 |------|------|------|
 | 예약 | `GET /api/appointments` | 기간별 예약 목록 조회 |
 | 예약 | `POST /api/appointments` | 예약 생성 |
-| 예약 | `PATCH /api/appointments/{id}/status` | 상태 변경 |
+| 예약 | `PATCH /api/appointments/{id}/status` | 상태 변경 (Confirm, CheckIn, Complete 등) |
 | 예약 | `DELETE /api/appointments/{id}` | 예약 취소 |
-| 슬롯 | `GET /api/slots` | 가용 슬롯 조회 |
-| 재배정 | `POST /api/reschedule/closure` | 임시휴진 날짜 재배정 |
-| 재배정 | `GET /api/reschedule/candidates` | 재배정 후보 목록 |
-| 장비 사용불가 | `GET/POST/PUT/DELETE /api/equipment-unavailability` | 장비 사용불가 구간 CRUD |
+| 슬롯 | `GET /api/slots` | 가용 슬롯 조회 (의사/날짜/진료유형) |
+| 재배정 | `POST /api/reschedule/closure` | 임시휴진 날짜 재배정 실행 |
+| 재배정 | `GET /api/reschedule/candidates` | 재배정 후보 목록 조회 |
+| 장비 사용불가 | `GET /api/equipment-unavailability` | 목록 조회 |
+| 장비 사용불가 | `POST /api/equipment-unavailability` | 등록 |
+| 장비 사용불가 | `PUT /api/equipment-unavailability/{id}` | 수정 |
+| 장비 사용불가 | `DELETE /api/equipment-unavailability/{id}` | 삭제 |
 | 클리닉 | `GET /api/clinics`, `/{id}`, `/{id}/operating-hours`, `/{id}/break-times` | 클리닉 조회 |
-| 의사 | `GET /api/clinics/{id}/doctors`, `/doctors/{id}` | 의사 조회 |
-| 진료유형 | `GET /api/clinics/{id}/treatment-types` | 진료유형 조회 |
-| 장비 | `GET /api/clinics/{id}/equipments` | 장비 조회 |
+| 의사 | `GET /api/clinics/{id}/doctors`, `/doctors/{id}`, `/{id}/schedules`, `/{id}/absences` | 의사 조회 |
+| 진료유형 | `GET /api/clinics/{id}/treatment-types`, `/treatment-types/{id}` | 진료유형 조회 |
+| 장비 | `GET /api/clinics/{id}/equipments`, `/equipments/{id}` | 장비 조회 |
 
 **Swagger UI**: 서버 기동 후 `http://localhost:8080/swagger-ui.html`
+
+## 예약 생성 요청 흐름
+
+```mermaid
+sequenceDiagram
+    participant FE as Frontend
+    participant API as AppointmentController
+    participant SEC as JwtAuthFilter
+    participant SLOT as SlotCalculationService
+    participant DB as PostgreSQL
+    participant EVT as EventBus
+
+    FE->>API: POST /api/appointments (Bearer token)
+    API->>SEC: JWT 검증
+    SEC-->>API: SchedulingUserPrincipal
+    API->>SLOT: 슬롯 가용성 확인
+    SLOT->>DB: 영업시간·스케줄·충돌 조회
+    DB-->>SLOT: 데이터 반환
+    SLOT-->>API: isAvailable: true
+    API->>DB: INSERT appointments
+    API->>EVT: publishEvent(Created)
+    API-->>FE: AppointmentResponse (201)
+```
+
+→ 전체 데이터 흐름: [data-flow.md](../docs/requirements/data-flow.md)
 
 ## 인증
 
@@ -38,6 +68,61 @@ JWT Bearer Token:
 Flyway — `src/main/resources/db/migration/V*.sql`
 
 > **주의**: `scheduling_*` 테이블명은 Flyway 스크립트에 고정되어 있으므로 변경 금지.
+
+## 핵심 클래스
+
+| 클래스 | 역할 |
+|--------|------|
+| `AppointmentController` | 예약 CRUD + 상태 변경 |
+| `SlotController` | 가용 슬롯 조회 |
+| `RescheduleController` | 임시휴진 재배정 |
+| `EquipmentUnavailabilityController` | 장비 사용불가 구간 CRUD + 충돌 감지 |
+| `ClinicController` | 클리닉 조회 (영업시간, 휴식시간 포함) |
+| `DoctorController` | 의사 조회 (스케줄, 부재 포함) |
+| `TreatmentTypeController` | 진료유형 조회 |
+| `EquipmentController` | 장비 조회 |
+| `SecurityConfig` | JWT 기반 Spring Security 설정 |
+| `GlobalExceptionHandler` | 전역 예외 처리 → `ApiResponse` 반환 |
+| `TestDataSeeder` | 개발/테스트 초기 데이터 자동 삽입 |
+
+## 의존성
+
+- **내부**: `appointment-core`, `appointment-event`, `appointment-solver`
+- **외부**: Spring Boot 4 Web/Security, `jjwt`, Flyway, springdoc-openapi, `bluetape4k-exposed-jdbc`
+
+## 실행
+
+```bash
+# 기동 (PostgreSQL + Redis 필요)
+./gradlew :appointment-api:bootRun
+
+# 빌드
+./gradlew :appointment-api:build
+
+# Gatling 부하 테스트
+./gradlew :appointment-api:gatlingRun
+```
+
+## 타임존
+
+API 응답(`AppointmentResponse`)에는 항상 `timezone` 과 `locale` 필드가 포함됩니다.
+
+```json
+{
+  "appointmentDate": "2026-04-01",
+  "startTime": "09:00:00",
+  "endTime": "09:30:00",
+  "timezone": "Asia/Seoul",
+  "locale": "ko-KR"
+}
+```
+
+- `appointmentDate` / `startTime` / `endTime` 은 **클리닉 현지 시간** 기준입니다.
+- 프론트엔드는 `timezone` 필드를 이용해 `ZonedDateTime` 으로 복원할 수 있습니다.
+- UTC 변환은 서버에서 수행하지 않습니다 — 날짜 경계 문제 방지.
+- `locale` 은 날짜/시간 표시 형식 전용으로, timezone과 독립적입니다.
+
+상세 설계: [appointment-core 타임존 설계](../appointment-core/README.md#타임존-설계)
 
 ## 테스트 실행
 
@@ -62,19 +147,3 @@ Flyway — `src/main/resources/db/migration/V*.sql`
 - Spring Profile에 따라 DataSource를 동적으로 주입 (`@DynamicPropertySource`)
 - Controller 테스트는 `RestClient` 방식 사용. MockMvc 미사용
 - CI에서 H2 / PostgreSQL / MySQL8 세 환경을 병렬로 검증
-
-## 타임존
-
-API 응답에는 항상 `timezone` 과 `locale` 필드가 포함됩니다.
-
-- `appointmentDate` / `startTime` / `endTime` 은 클리닉 현지 시간 기준
-- UTC 변환은 서버에서 수행하지 않음 — 날짜 경계 문제 방지
-- `locale` 은 날짜/시간 표시 형식 전용
-
-## 실행
-
-```bash
-./gradlew :appointment-api:bootRun
-./gradlew :appointment-api:build
-./gradlew :appointment-api:gatlingRun
-```

--- a/appointment-api/README.md
+++ b/appointment-api/README.md
@@ -1,35 +1,37 @@
 # appointment-api
 
-Spring Boot 4 REST API 서버 — JWT 인증, Flyway 마이그레이션, Swagger UI, Gatling 부하 테스트.
+[English](README.md) | [한국어](README.ko.md)
 
-## 책임
+Spring Boot 4 REST API server with JWT authentication, Flyway migrations, Swagger UI, and Gatling load tests.
 
-- **하는 것**: HTTP API 제공, 인증/인가, DB 마이그레이션, 도메인 이벤트 발행
-- **하지 않는 것**: 알림 직접 발송 없음 (이벤트로 위임), Solver 직접 호출 가능
+## Responsibilities
 
-## API 엔드포인트
+- **Does**: exposes HTTP APIs, handles authentication/authorization, runs DB migrations, and publishes domain events.
+- **Does not**: send notifications directly. Notifications are delegated through events. It may call Solver for scheduling workflows.
 
-| 그룹 | 경로 | 설명 |
+## API Endpoints
+
+| Group | Path | Description |
 |------|------|------|
-| 예약 | `GET /api/appointments` | 기간별 예약 목록 조회 |
-| 예약 | `POST /api/appointments` | 예약 생성 |
-| 예약 | `PATCH /api/appointments/{id}/status` | 상태 변경 (Confirm, CheckIn, Complete 등) |
-| 예약 | `DELETE /api/appointments/{id}` | 예약 취소 |
-| 슬롯 | `GET /api/slots` | 가용 슬롯 조회 (의사/날짜/진료유형) |
-| 재배정 | `POST /api/reschedule/closure` | 임시휴진 날짜 재배정 실행 |
-| 재배정 | `GET /api/reschedule/candidates` | 재배정 후보 목록 조회 |
-| 장비 사용불가 | `GET /api/equipment-unavailability` | 목록 조회 |
-| 장비 사용불가 | `POST /api/equipment-unavailability` | 등록 |
-| 장비 사용불가 | `PUT /api/equipment-unavailability/{id}` | 수정 |
-| 장비 사용불가 | `DELETE /api/equipment-unavailability/{id}` | 삭제 |
-| 클리닉 | `GET /api/clinics`, `/{id}`, `/{id}/operating-hours`, `/{id}/break-times` | 클리닉 조회 |
-| 의사 | `GET /api/clinics/{id}/doctors`, `/doctors/{id}`, `/{id}/schedules`, `/{id}/absences` | 의사 조회 |
-| 진료유형 | `GET /api/clinics/{id}/treatment-types`, `/treatment-types/{id}` | 진료유형 조회 |
-| 장비 | `GET /api/clinics/{id}/equipments`, `/equipments/{id}` | 장비 조회 |
+| Appointments | `GET /api/appointments` | List appointments by period. |
+| Appointments | `POST /api/appointments` | Create an appointment. |
+| Appointments | `PATCH /api/appointments/{id}/status` | Change status, such as Confirm, CheckIn, Complete. |
+| Appointments | `DELETE /api/appointments/{id}` | Cancel an appointment. |
+| Slots | `GET /api/slots` | Query available slots by doctor, date, and treatment type. |
+| Reschedule | `POST /api/reschedule/closure` | Reschedule appointments affected by a temporary clinic closure. |
+| Reschedule | `GET /api/reschedule/candidates` | List reschedule candidates. |
+| Equipment unavailability | `GET /api/equipment-unavailability` | List equipment unavailability windows. |
+| Equipment unavailability | `POST /api/equipment-unavailability` | Register an unavailability window. |
+| Equipment unavailability | `PUT /api/equipment-unavailability/{id}` | Update an unavailability window. |
+| Equipment unavailability | `DELETE /api/equipment-unavailability/{id}` | Delete an unavailability window. |
+| Clinics | `GET /api/clinics`, `/{id}`, `/{id}/operating-hours`, `/{id}/break-times` | Query clinic information. |
+| Doctors | `GET /api/clinics/{id}/doctors`, `/doctors/{id}`, `/{id}/schedules`, `/{id}/absences` | Query doctor information. |
+| Treatment types | `GET /api/clinics/{id}/treatment-types`, `/treatment-types/{id}` | Query treatment types. |
+| Equipment | `GET /api/clinics/{id}/equipments`, `/equipments/{id}` | Query equipment. |
 
-**Swagger UI**: 서버 기동 후 `http://localhost:8080/swagger-ui.html`
+**Swagger UI**: `http://localhost:8080/swagger-ui.html` after the server starts.
 
-## 예약 생성 요청 흐름
+## Appointment Creation Flow
 
 ```mermaid
 sequenceDiagram
@@ -41,69 +43,70 @@ sequenceDiagram
     participant EVT as EventBus
 
     FE->>API: POST /api/appointments (Bearer token)
-    API->>SEC: JWT 검증
+    API->>SEC: Validate JWT
     SEC-->>API: SchedulingUserPrincipal
-    API->>SLOT: 슬롯 가용성 확인
-    SLOT->>DB: 영업시간·스케줄·충돌 조회
-    DB-->>SLOT: 데이터 반환
+    API->>SLOT: Check slot availability
+    SLOT->>DB: Query hours, schedules, conflicts
+    DB-->>SLOT: Data
     SLOT-->>API: isAvailable: true
     API->>DB: INSERT appointments
     API->>EVT: publishEvent(Created)
     API-->>FE: AppointmentResponse (201)
 ```
 
-→ 전체 데이터 흐름: [data-flow.md](../docs/requirements/data-flow.md)
+Full data flow: [data-flow.md](../docs/requirements/data-flow.md)
 
-## 인증
+## Authentication
 
 JWT Bearer Token:
-- 헤더: `Authorization: Bearer <token>`
-- 설정: `JwtSecurityProperties` (`scheduling.security.jwt.*`)
-- 필터: `JwtAuthenticationFilter` → `SchedulingUserPrincipal`
 
-## DB 마이그레이션
+- Header: `Authorization: Bearer <token>`
+- Properties: `JwtSecurityProperties` (`scheduling.security.jwt.*`)
+- Filter: `JwtAuthenticationFilter` -> `SchedulingUserPrincipal`
 
-Flyway — `src/main/resources/db/migration/V*.sql`
+## DB Migration
 
-> **주의**: `scheduling_*` 테이블명은 Flyway 스크립트에 고정되어 있으므로 변경 금지.
+Flyway migration scripts live under `src/main/resources/db/migration/V*.sql`.
 
-## 핵심 클래스
+> **Important**: `scheduling_*` table names are fixed in Flyway scripts. Do not rename them.
 
-| 클래스 | 역할 |
+## Core Classes
+
+| Class | Role |
 |--------|------|
-| `AppointmentController` | 예약 CRUD + 상태 변경 |
-| `SlotController` | 가용 슬롯 조회 |
-| `RescheduleController` | 임시휴진 재배정 |
-| `EquipmentUnavailabilityController` | 장비 사용불가 구간 CRUD + 충돌 감지 |
-| `ClinicController` | 클리닉 조회 (영업시간, 휴식시간 포함) |
-| `DoctorController` | 의사 조회 (스케줄, 부재 포함) |
-| `TreatmentTypeController` | 진료유형 조회 |
-| `EquipmentController` | 장비 조회 |
-| `SecurityConfig` | JWT 기반 Spring Security 설정 |
-| `GlobalExceptionHandler` | 전역 예외 처리 → `ApiResponse` 반환 |
-| `TestDataSeeder` | 개발/테스트 초기 데이터 자동 삽입 |
+| `AppointmentController` | Appointment CRUD and status changes. |
+| `SlotController` | Available slot lookup. |
+| `RescheduleController` | Temporary clinic closure rescheduling. |
+| `EquipmentUnavailabilityController` | Equipment unavailability CRUD and conflict detection. |
+| `ClinicController` | Clinic lookup, including operating hours and break times. |
+| `DoctorController` | Doctor lookup, including schedules and absences. |
+| `TreatmentTypeController` | Treatment type lookup. |
+| `EquipmentController` | Equipment lookup. |
+| `SecurityConfig` | JWT-based Spring Security configuration. |
+| `GlobalExceptionHandler` | Global exception handling that returns `ApiResponse`. |
+| `TestDataSeeder` | Automatic development/test seed data insertion. |
 
-## 의존성
+## Dependencies
 
-- **내부**: `appointment-core`, `appointment-event`, `appointment-solver`
-- **외부**: Spring Boot 4 Web/Security, `jjwt`, Flyway, springdoc-openapi, `bluetape4k-exposed-jdbc`
+- **Internal**: `appointment-core`, `appointment-event`, `appointment-solver`
+- **External**: Spring Boot 4 Web/Security, `jjwt`, Flyway, springdoc-openapi, `bluetape4k-exposed-jdbc`
 
-## 실행
+## Run
 
 ```bash
-# 기동 (PostgreSQL + Redis 필요)
+# Start the server (requires PostgreSQL + Redis)
 ./gradlew :appointment-api:bootRun
 
-# 빌드
+# Build
 ./gradlew :appointment-api:build
 
-# Gatling 부하 테스트
+# Gatling load tests
 ./gradlew :appointment-api:gatlingRun
 ```
 
-## 타임존
+## Timezone Model
 
-API 응답(`AppointmentResponse`)에는 항상 `timezone` 과 `locale` 필드가 포함됩니다.
+API responses such as `AppointmentResponse` always include `timezone` and `locale`.
 
 ```json
 {
@@ -115,17 +118,17 @@ API 응답(`AppointmentResponse`)에는 항상 `timezone` 과 `locale` 필드가
 }
 ```
 
-- `appointmentDate` / `startTime` / `endTime` 은 **클리닉 현지 시간** 기준입니다.
-- 프론트엔드는 `timezone` 필드를 이용해 `ZonedDateTime` 으로 복원할 수 있습니다.
-- UTC 변환은 서버에서 수행하지 않습니다 — 날짜 경계 문제 방지.
-- `locale` 은 날짜/시간 표시 형식 전용으로, timezone과 독립적입니다.
+- `appointmentDate`, `startTime`, and `endTime` are based on the clinic's local time.
+- The frontend can reconstruct `ZonedDateTime` using the `timezone` field.
+- The server does not convert appointment dates/times to UTC, which avoids date-boundary bugs.
+- `locale` is for date/time display formatting and is independent from timezone.
 
-상세 설계: [appointment-core 타임존 설계](../appointment-core/README.md#타임존-설계)
+Detailed design: [appointment-core timezone design](../appointment-core/README.md#timezone-design)
 
-## 테스트 실행
+## Tests
 
 ```bash
-# H2 in-memory (기본)
+# H2 in-memory, default
 ./gradlew :appointment-api:test
 
 # PostgreSQL Testcontainer
@@ -135,13 +138,13 @@ API 응답(`AppointmentResponse`)에는 항상 `timezone` 과 `locale` 필드가
 ./gradlew :appointment-api:test -Dspring.profiles.active=test,test-mysql
 ```
 
-### 테스트 구조
+### Test Structure
 
-| 클래스 | 역할 |
+| Class | Role |
 |--------|------|
-| `AbstractApiIntegrationTest` | `@SpringBootTest(RANDOM_PORT)` + `@DynamicPropertySource` 기반 추상 클래스 |
-| `Containers` | PostgreSQL / MySQL8 Testcontainer singleton |
+| `AbstractApiIntegrationTest` | Abstract class based on `@SpringBootTest(RANDOM_PORT)` and `@DynamicPropertySource`. |
+| `Containers` | PostgreSQL / MySQL8 Testcontainer singleton. |
 
-- Spring Profile에 따라 DataSource를 동적으로 주입 (`@DynamicPropertySource`)
-- Controller 테스트는 `RestClient` 방식 사용. MockMvc 미사용
-- CI에서 H2 / PostgreSQL / MySQL8 세 환경을 병렬로 검증
+- DataSource is injected dynamically by Spring profile with `@DynamicPropertySource`.
+- Controller tests use `RestClient`, not MockMvc.
+- CI verifies H2, PostgreSQL, and MySQL8 in parallel.

--- a/appointment-core/README.ko.md
+++ b/appointment-core/README.ko.md
@@ -1,0 +1,190 @@
+# appointment-core
+
+[English](README.md) | [한국어](README.ko.md)
+
+도메인 모델, Exposed ORM 테이블, 리포지토리, 예약 상태머신, 슬롯 계산 서비스.
+모든 다른 모듈의 기반이 되는 leaf 모듈.
+
+## 책임
+
+- **하는 것**: 도메인 엔티티 정의, DB 테이블 스키마, 리포지토리 CRUD, 상태머신 전이 검증, 가용 슬롯 계산
+- **하지 않는 것**: Spring Context 의존성 없음, HTTP 없음, 알림 없음, 이벤트 발행 없음
+
+## 핵심 클래스
+
+### 도메인 엔티티 (Record)
+
+| 클래스 | 역할 |
+|--------|------|
+| `AppointmentRecord` | 예약 — clinicId, doctorId, treatmentTypeId, appointmentDate, startTime, endTime, status |
+| `ClinicRecord` | 병원 — slotDurationMinutes, maxConcurrentPatients, openOnHolidays |
+| `DoctorRecord` | 의사 — clinicId, providerType, maxConcurrentPatients |
+| `TreatmentTypeRecord` | 진료유형 — defaultDurationMinutes, requiredProviderType, requiresEquipment |
+| `EquipmentRecord` | 장비 — usageDurationMinutes, quantity |
+| `OperatingHoursRecord` | 영업시간 — dayOfWeek, openTime, closeTime, isActive |
+| `DoctorScheduleRecord` | 의사 근무 — dayOfWeek, startTime, endTime |
+| `DoctorAbsenceRecord` | 의사 부재 — absenceDate, startTime?(null=전일), endTime? |
+| `ClinicClosureRecord` | 임시휴진 — closureDate, isFullDay, startTime?, endTime? |
+| `HolidayRecord` | 공휴일 — holidayDate, recurring |
+| `EquipmentUnavailabilityRecord` | 장비 사용불가 구간 — equipmentId, startDate, endDate, recurrenceRule, exceptions |
+
+### 상태머신
+
+```kotlin
+// 상태 전이 예시
+val machine = AppointmentStateMachine()
+val newState = machine.transition(
+    current = AppointmentState.REQUESTED,
+    event = AppointmentEvent.Confirm
+)   // → AppointmentState.CONFIRMED
+```
+
+상태 전이 전체 목록: [도메인 모델 문서](../docs/requirements/domain-model.md#상태-전이도)
+
+### 리포지토리
+
+| 클래스 | 주요 메서드 |
+|--------|-----------|
+| `AppointmentRepository` | `findByDateRange()`, `findByStatus()`, `save()`, `updateStatus()` |
+| `ClinicRepository` | `findById()`, `findAll()` |
+| `DoctorRepository` | `findByClinic()`, `findByProviderType()` |
+| `TreatmentTypeRepository` | `findAll()`, `findById()` |
+| `HolidayRepository` | `isHoliday(date)`, `findByYear()` |
+| `RescheduleCandidateRepository` | `findPendingByClinic()`, `save()` |
+| `EquipmentUnavailabilityRepository` | `findByEquipment()`, `findOverlapping()`, `save()`, `delete()` |
+
+> **중요**: 모든 리포지토리 호출은 `transaction { }` 블록 안에서 실행해야 함.
+
+### 서비스 value type (`model/service/`)
+
+| 클래스 | 역할 |
+|--------|------|
+| `SlotQuery` | 슬롯 조회 파라미터 (clinicId, doctorId, treatmentTypeId, date) |
+| `AvailableSlot` | 계산된 가용 슬롯 결과 (date, startTime, endTime, doctorId, remainingCapacity) |
+| `TimeRange` | 시간 범위 value type + `subtractRanges`, `computeEffectiveRanges` top-level 함수 |
+
+### 서비스
+
+| 클래스 | 역할 |
+|--------|------|
+| `SlotCalculationService` | 의사/날짜/진료유형 조합의 빈 슬롯 목록 반환 (실시간 단건) |
+| `ClosureRescheduleService` | 임시휴진 날짜의 영향받는 예약을 첫 번째 가용 슬롯으로 재배정 |
+| `ConcurrencyResolver` | 동시 예약 충돌 해결 |
+| `ClinicTimezoneService` | 병원 타임존 변환 |
+| `EquipmentUnavailabilityService` | 장비 사용불가 구간 CRUD + `UnavailabilityExpander` 기반 반복 규칙 전개 |
+
+## 의존성
+
+- **내부**: 없음 (leaf 모듈)
+- **외부**: `bluetape4k-exposed-core`, `bluetape4k-exposed-jdbc`, `bluetape4k-coroutines`, Exposed ORM
+
+## 테스트 실행
+
+```bash
+./gradlew :appointment-core:test
+
+# 특정 테스트
+./gradlew :appointment-core:test --tests "*.SlotCalculationServiceTest"
+```
+
+> 테스트에서 DB 초기화: `@BeforeEach` — `SchemaUtils.createMissingTablesAndColumns(Table)` + `Table.deleteAll()`
+> Testcontainers: `@Testcontainers` 어노테이션 없이 bluetape4k singleton 패턴 사용
+
+## 주요 엔티티 관계도
+
+```mermaid
+erDiagram
+    Clinics ||--o{ Doctors : "employs"
+    Clinics ||--o{ TreatmentTypes : "offers"
+    Clinics ||--o{ Equipments : "owns"
+    Clinics ||--o{ Appointments : "receives"
+    Clinics ||--o{ OperatingHoursTable : "hours"
+    Clinics ||--o{ ClinicClosures : "closures"
+
+    Doctors ||--o{ DoctorSchedules : "schedules"
+    Doctors ||--o{ DoctorAbsences : "absences"
+    Doctors ||--o{ Appointments : "treats"
+
+    TreatmentTypes ||--o{ TreatmentEquipments : "requires"
+    TreatmentTypes ||--o{ Appointments : "applied in"
+
+    Equipments ||--o{ TreatmentEquipments : "used by"
+    Equipments ||--o{ EquipmentUnavailabilities : "unavailable"
+    Equipments |o--o{ Appointments : "used in"
+
+    Appointments ||--o{ AppointmentNotes : "notes"
+    Appointments ||--o{ RescheduleCandidates : "reschedule"
+```
+
+→ 전체 ERD: [erd.md](../docs/requirements/erd.md)
+
+## 예약 상태머신
+
+```mermaid
+stateDiagram-v2
+    [*] --> REQUESTED : 예약 요청
+    REQUESTED --> CONFIRMED : Confirm
+    REQUESTED --> CANCELLED : Cancel
+    CONFIRMED --> CHECKED_IN : CheckIn
+    CONFIRMED --> NO_SHOW : MarkNoShow
+    CONFIRMED --> PENDING_RESCHEDULE : RequestReschedule
+    CHECKED_IN --> IN_PROGRESS : StartTreatment
+    IN_PROGRESS --> COMPLETED : Complete
+    PENDING_RESCHEDULE --> RESCHEDULED : ConfirmReschedule
+    PENDING_RESCHEDULE --> CANCELLED : Cancel
+    COMPLETED --> [*]
+    RESCHEDULED --> [*]
+    CANCELLED --> [*]
+    NO_SHOW --> [*]
+```
+
+→ 상태 전이 전체 목록: [domain-model.md](../docs/requirements/domain-model.md#상태-전이도)
+
+## 타임존 설계
+
+### 저장 원칙
+
+| 컬럼 | 타입 | 기준 |
+|------|------|------|
+| `appointment_date` | `LocalDate` | 클리닉 현지 날짜 |
+| `start_time` / `end_time` | `LocalTime` | 클리닉 현지 시간 |
+| `created_at` / `updated_at` | `Instant` (UTC) | 시스템 감사 타임스탬프 |
+
+**예약 시간은 UTC 변환 없이 클리닉 현지 시간으로 저장합니다.**
+
+UTC로 변환하지 않는 이유:
+- 예약은 본질적으로 현지 이벤트 — "서울 클리닉 23:00" 를 UTC로 변환하면 날짜가 바뀜
+- `WHERE appointment_date = '2026-04-01'` 같은 날짜 기반 쿼리가 timezone에 무관하게 정확
+- 슬롯 계산, 영업시간 비교가 동일 timezone 안에서 단순하게 유지됨
+
+### 다국가 SaaS 지원
+
+각 클리닉은 `Clinics.timezone` 컬럼으로 ZoneId를 보유합니다 (예: `"Asia/Seoul"`, `"America/New_York"`).
+`Clinics.locale` 은 날짜/시간 **표시 형식**과 언어 용도로만 사용합니다 — 타임존과는 별개입니다
+(교민 병원처럼 `locale="ko-KR"` 이지만 timezone이 `"America/Los_Angeles"` 일 수 있음).
+
+### API 흐름
+
+```
+Frontend  →  LocalDate + LocalTime (클리닉 현지)
+               ↓  변환 없이 저장
+DB        →  LocalDate + LocalTime (클리닉 현지)
+               ↓  응답 시 Clinics.timezone / locale 포함
+Frontend  →  ZonedDateTime 복원 가능 (appointmentDate + startTime + timezone)
+```
+
+### ClinicTimezoneService
+
+`ClinicTimezoneService` 는 API 경계에서 timezone 정보를 조합할 때 사용합니다:
+
+```kotlin
+// 응답에 timezone/locale 포함 (단일 DB 조회)
+val (timezone, locale) = timezoneService.getTimezoneAndLocale(clinicId)
+
+// 크로스-클리닉 비교 시 ZonedDateTime 변환
+val zoned: ZonedDateTime = timezoneService.toClinicTime(clinicId, date, time)
+```
+
+## 설계 문서
+
+- [도메인 모델 전체](../docs/requirements/domain-model.md)

--- a/appointment-core/README.md
+++ b/appointment-core/README.md
@@ -1,47 +1,48 @@
 # appointment-core
 
-도메인 모델, Exposed ORM 테이블, 리포지토리, 예약 상태머신, 슬롯 계산 서비스.
-모든 다른 모듈의 기반이 되는 leaf 모듈.
+[English](README.md) | [한국어](README.ko.md)
 
-## 책임
+Domain model, Exposed ORM tables, repositories, appointment state machine, and slot calculation services.
+This is the leaf module that all other modules build on.
 
-- **하는 것**: 도메인 엔티티 정의, DB 테이블 스키마, 리포지토리 CRUD, 상태머신 전이 검증, 가용 슬롯 계산
-- **하지 않는 것**: Spring Context 의존성 없음, HTTP 없음, 알림 없음, 이벤트 발행 없음
+## Responsibilities
 
-## 핵심 클래스
+- **Does**: defines domain entities, database table schemas, repository CRUD operations, state-machine transition validation, and available-slot calculation.
+- **Does not**: depend on Spring Context, expose HTTP APIs, send notifications, or publish events.
 
-### 도메인 엔티티 (Record)
+## Core Classes
 
-| 클래스 | 역할 |
+### Domain Entities (Record)
+
+| Class | Role |
 |--------|------|
-| `AppointmentRecord` | 예약 — clinicId, doctorId, treatmentTypeId, appointmentDate, startTime, endTime, status |
-| `ClinicRecord` | 병원 — slotDurationMinutes, maxConcurrentPatients, openOnHolidays |
-| `DoctorRecord` | 의사 — clinicId, providerType, maxConcurrentPatients |
-| `TreatmentTypeRecord` | 진료유형 — defaultDurationMinutes, requiredProviderType, requiresEquipment |
-| `EquipmentRecord` | 장비 — usageDurationMinutes, quantity |
-| `OperatingHoursRecord` | 영업시간 — dayOfWeek, openTime, closeTime, isActive |
-| `DoctorScheduleRecord` | 의사 근무 — dayOfWeek, startTime, endTime |
-| `DoctorAbsenceRecord` | 의사 부재 — absenceDate, startTime?(null=전일), endTime? |
-| `ClinicClosureRecord` | 임시휴진 — closureDate, isFullDay, startTime?, endTime? |
-| `HolidayRecord` | 공휴일 — holidayDate, recurring |
-| `EquipmentUnavailabilityRecord` | 장비 사용불가 구간 — equipmentId, startDate, endDate, recurrenceRule, exceptions |
+| `AppointmentRecord` | Appointment with clinicId, doctorId, treatmentTypeId, appointmentDate, startTime, endTime, and status. |
+| `ClinicRecord` | Clinic settings such as slotDurationMinutes, maxConcurrentPatients, and openOnHolidays. |
+| `DoctorRecord` | Doctor information such as clinicId, providerType, and maxConcurrentPatients. |
+| `TreatmentTypeRecord` | Treatment type with defaultDurationMinutes, requiredProviderType, and requiresEquipment. |
+| `EquipmentRecord` | Equipment with usageDurationMinutes and quantity. |
+| `OperatingHoursRecord` | Operating hours with dayOfWeek, openTime, closeTime, and isActive. |
+| `DoctorScheduleRecord` | Doctor working schedule with dayOfWeek, startTime, and endTime. |
+| `DoctorAbsenceRecord` | Doctor absence with absenceDate, optional startTime, and optional endTime. |
+| `ClinicClosureRecord` | Temporary clinic closure with closureDate, isFullDay, optional startTime, and optional endTime. |
+| `HolidayRecord` | Holiday with holidayDate and recurring flag. |
+| `EquipmentUnavailabilityRecord` | Equipment unavailability window with recurrence rule and exceptions. |
 
-### 상태머신
+### State Machine
 
 ```kotlin
-// 상태 전이 예시
 val machine = AppointmentStateMachine()
 val newState = machine.transition(
     current = AppointmentState.REQUESTED,
-    event = AppointmentEvent.Confirm
-)   // → AppointmentState.CONFIRMED
+    event = AppointmentEvent.Confirm,
+)   // AppointmentState.CONFIRMED
 ```
 
-상태 전이 전체 목록: [도메인 모델 문서](../docs/requirements/domain-model.md#상태-전이도)
+Full transition list: [domain model document](../docs/requirements/domain-model.md#상태-전이도)
 
-### 리포지토리
+### Repositories
 
-| 클래스 | 주요 메서드 |
+| Class | Main Methods |
 |--------|-----------|
 | `AppointmentRepository` | `findByDateRange()`, `findByStatus()`, `save()`, `updateStatus()` |
 | `ClinicRepository` | `findById()`, `findAll()` |
@@ -51,44 +52,44 @@ val newState = machine.transition(
 | `RescheduleCandidateRepository` | `findPendingByClinic()`, `save()` |
 | `EquipmentUnavailabilityRepository` | `findByEquipment()`, `findOverlapping()`, `save()`, `delete()` |
 
-> **중요**: 모든 리포지토리 호출은 `transaction { }` 블록 안에서 실행해야 함.
+> **Important**: every repository call must run inside a `transaction { }` block.
 
-### 서비스 value type (`model/service/`)
+### Service Value Types (`model/service/`)
 
-| 클래스 | 역할 |
+| Class | Role |
 |--------|------|
-| `SlotQuery` | 슬롯 조회 파라미터 (clinicId, doctorId, treatmentTypeId, date) |
-| `AvailableSlot` | 계산된 가용 슬롯 결과 (date, startTime, endTime, doctorId, remainingCapacity) |
-| `TimeRange` | 시간 범위 value type + `subtractRanges`, `computeEffectiveRanges` top-level 함수 |
+| `SlotQuery` | Slot query parameters: clinicId, doctorId, treatmentTypeId, date. |
+| `AvailableSlot` | Calculated available slot result: date, startTime, endTime, doctorId, remainingCapacity. |
+| `TimeRange` | Time range value type plus top-level `subtractRanges` and `computeEffectiveRanges` functions. |
 
-### 서비스
+### Services
 
-| 클래스 | 역할 |
+| Class | Role |
 |--------|------|
-| `SlotCalculationService` | 의사/날짜/진료유형 조합의 빈 슬롯 목록 반환 (실시간 단건) |
-| `ClosureRescheduleService` | 임시휴진 날짜의 영향받는 예약을 첫 번째 가용 슬롯으로 재배정 |
-| `ConcurrencyResolver` | 동시 예약 충돌 해결 |
-| `ClinicTimezoneService` | 병원 타임존 변환 |
-| `EquipmentUnavailabilityService` | 장비 사용불가 구간 CRUD + `UnavailabilityExpander` 기반 반복 규칙 전개 |
+| `SlotCalculationService` | Returns available slots for a doctor/date/treatment-type combination. |
+| `ClosureRescheduleService` | Reassigns appointments affected by a temporary closure to the first available slot. |
+| `ConcurrencyResolver` | Resolves concurrent appointment conflicts. |
+| `ClinicTimezoneService` | Converts and combines clinic timezone data at API boundaries. |
+| `EquipmentUnavailabilityService` | CRUD for equipment unavailability windows and recurrence expansion with `UnavailabilityExpander`. |
 
-## 의존성
+## Dependencies
 
-- **내부**: 없음 (leaf 모듈)
-- **외부**: `bluetape4k-exposed-core`, `bluetape4k-exposed-jdbc`, `bluetape4k-coroutines`, Exposed ORM
+- **Internal**: none. This is a leaf module.
+- **External**: `bluetape4k-exposed-core`, `bluetape4k-exposed-jdbc`, `bluetape4k-coroutines`, Exposed ORM.
 
-## 테스트 실행
+## Tests
 
 ```bash
 ./gradlew :appointment-core:test
 
-# 특정 테스트
+# Specific test
 ./gradlew :appointment-core:test --tests "*.SlotCalculationServiceTest"
 ```
 
-> 테스트에서 DB 초기화: `@BeforeEach` — `SchemaUtils.createMissingTablesAndColumns(Table)` + `Table.deleteAll()`
-> Testcontainers: `@Testcontainers` 어노테이션 없이 bluetape4k singleton 패턴 사용
+> Test DB setup: `@BeforeEach` with `SchemaUtils.createMissingTablesAndColumns(Table)` and `Table.deleteAll()`.
+> Testcontainers: use the bluetape4k singleton pattern without `@Testcontainers`.
 
-## 주요 엔티티 관계도
+## Entity Relationship Overview
 
 ```mermaid
 erDiagram
@@ -114,13 +115,13 @@ erDiagram
     Appointments ||--o{ RescheduleCandidates : "reschedule"
 ```
 
-→ 전체 ERD: [erd.md](../docs/requirements/erd.md)
+Full ERD: [erd.md](../docs/requirements/erd.md)
 
-## 예약 상태머신
+## Appointment State Machine
 
 ```mermaid
 stateDiagram-v2
-    [*] --> REQUESTED : 예약 요청
+    [*] --> REQUESTED : Request
     REQUESTED --> CONFIRMED : Confirm
     REQUESTED --> CANCELLED : Cancel
     CONFIRMED --> CHECKED_IN : CheckIn
@@ -136,53 +137,55 @@ stateDiagram-v2
     NO_SHOW --> [*]
 ```
 
-→ 상태 전이 전체 목록: [domain-model.md](../docs/requirements/domain-model.md#상태-전이도)
+Full transition list: [domain-model.md](../docs/requirements/domain-model.md#상태-전이도)
 
-## 타임존 설계
+## Timezone Design
 
-### 저장 원칙
+### Storage Rules
 
-| 컬럼 | 타입 | 기준 |
+| Column | Type | Reference |
 |------|------|------|
-| `appointment_date` | `LocalDate` | 클리닉 현지 날짜 |
-| `start_time` / `end_time` | `LocalTime` | 클리닉 현지 시간 |
-| `created_at` / `updated_at` | `Instant` (UTC) | 시스템 감사 타임스탬프 |
+| `appointment_date` | `LocalDate` | Clinic-local date. |
+| `start_time` / `end_time` | `LocalTime` | Clinic-local time. |
+| `created_at` / `updated_at` | `Instant` (UTC) | System audit timestamp. |
 
-**예약 시간은 UTC 변환 없이 클리닉 현지 시간으로 저장합니다.**
+Appointment times are stored as clinic-local date and time without UTC conversion.
 
-UTC로 변환하지 않는 이유:
-- 예약은 본질적으로 현지 이벤트 — "서울 클리닉 23:00" 를 UTC로 변환하면 날짜가 바뀜
-- `WHERE appointment_date = '2026-04-01'` 같은 날짜 기반 쿼리가 timezone에 무관하게 정확
-- 슬롯 계산, 영업시간 비교가 동일 timezone 안에서 단순하게 유지됨
+Reasons:
 
-### 다국가 SaaS 지원
+- Appointments are local events. Converting "Seoul clinic 23:00" to UTC can shift the date.
+- Date-based queries such as `WHERE appointment_date = '2026-04-01'` stay correct regardless of timezone.
+- Slot calculation and business-hour comparison remain simple inside the same timezone.
 
-각 클리닉은 `Clinics.timezone` 컬럼으로 ZoneId를 보유합니다 (예: `"Asia/Seoul"`, `"America/New_York"`).
-`Clinics.locale` 은 날짜/시간 **표시 형식**과 언어 용도로만 사용합니다 — 타임존과는 별개입니다
-(교민 병원처럼 `locale="ko-KR"` 이지만 timezone이 `"America/Los_Angeles"` 일 수 있음).
+### Multi-Country SaaS Support
 
-### API 흐름
+Each clinic stores a ZoneId in `Clinics.timezone`, such as `"Asia/Seoul"` or `"America/New_York"`.
+`Clinics.locale` is used only for display format and language. It is independent from timezone.
 
-```
-Frontend  →  LocalDate + LocalTime (클리닉 현지)
-               ↓  변환 없이 저장
-DB        →  LocalDate + LocalTime (클리닉 현지)
-               ↓  응답 시 Clinics.timezone / locale 포함
-Frontend  →  ZonedDateTime 복원 가능 (appointmentDate + startTime + timezone)
+For example, a Korean expatriate clinic can use `locale = "ko-KR"` with `timezone = "America/Los_Angeles"`.
+
+### API Flow
+
+```text
+Frontend  ->  LocalDate + LocalTime (clinic local)
+               stored without conversion
+DB        ->  LocalDate + LocalTime (clinic local)
+               response includes Clinics.timezone / locale
+Frontend  ->  can reconstruct ZonedDateTime from appointmentDate + startTime + timezone
 ```
 
 ### ClinicTimezoneService
 
-`ClinicTimezoneService` 는 API 경계에서 timezone 정보를 조합할 때 사용합니다:
+`ClinicTimezoneService` is used at API boundaries when timezone information must be combined:
 
 ```kotlin
-// 응답에 timezone/locale 포함 (단일 DB 조회)
+// Include timezone/locale in a response with one DB lookup.
 val (timezone, locale) = timezoneService.getTimezoneAndLocale(clinicId)
 
-// 크로스-클리닉 비교 시 ZonedDateTime 변환
+// Convert to ZonedDateTime for cross-clinic comparison.
 val zoned: ZonedDateTime = timezoneService.toClinicTime(clinicId, date, time)
 ```
 
-## 설계 문서
+## Design Documents
 
-- [도메인 모델 전체](../docs/requirements/domain-model.md)
+- [Full Domain Model](../docs/requirements/domain-model.md)

--- a/appointment-event/README.ko.md
+++ b/appointment-event/README.ko.md
@@ -1,0 +1,72 @@
+# appointment-event
+
+[English](README.md) | [한국어](README.ko.md)
+
+Spring `ApplicationEvent` 기반 도메인 이벤트 발행/구독 + 이벤트 로그 DB 저장.
+
+## 책임
+
+- **하는 것**: 도메인 이벤트 타입 정의, 이벤트 발행, 이벤트 로그 Exposed 테이블 저장
+- **하지 않는 것**: 알림 발송 없음 (알림은 `appointment-notification`이 이벤트 구독)
+
+## 이벤트 타입
+
+```kotlin
+sealed class AppointmentDomainEvent : ApplicationEvent {
+    data class Created(val appointmentId: Long, val clinicId: Long)
+    data class StatusChanged(val appointmentId: Long, val clinicId: Long,
+                             val fromState: String, val toState: String, val reason: String?)
+    data class Cancelled(val appointmentId: Long, val clinicId: Long, val reason: String)
+    data class Rescheduled(val originalId: Long, val newId: Long, val clinicId: Long)
+}
+```
+
+## 발행 패턴
+
+```kotlin
+// 발행 (appointment-api, appointment-core에서 사용)
+eventPublisher.publishEvent(AppointmentDomainEvent.Created(id, clinicId))
+
+// 구독
+@EventListener
+fun on(event: AppointmentDomainEvent.Created) { ... }
+```
+
+## 핵심 클래스
+
+| 클래스 | 역할 |
+|--------|------|
+| `AppointmentDomainEvent` | 이벤트 sealed class — Created, StatusChanged, Cancelled, Rescheduled |
+| `AppointmentEventLogger` | `@EventListener` — 모든 이벤트를 `AppointmentEventLogs` 테이블에 저장 |
+| `AppointmentEventLogRecord` | 이벤트 로그 DTO |
+| `AppointmentEventLogs` | Exposed 테이블 — event_type, appointment_id, payload_json, occurred_at |
+
+## 이벤트 발행/구독 흐름
+
+```mermaid
+flowchart LR
+    API["appointment-api\n(상태 변경 후)"] -->|"publishEvent()"| BUS["Spring\nApplicationEventPublisher"]
+
+    BUS -->|"@EventListener"| LOG["AppointmentEventLogger\n→ AppointmentEventLogs 테이블"]
+    BUS -->|"@EventListener"| NOTIF["appointment-notification\nNotificationEventListener"]
+
+    subgraph Events["AppointmentDomainEvent"]
+        E1["Created"] 
+        E2["StatusChanged"]
+        E3["Cancelled"]
+        E4["Rescheduled"]
+    end
+
+    API --> Events --> BUS
+```
+
+## 의존성
+
+- **내부**: `appointment-core`
+- **외부**: Spring Context
+
+## 테스트 실행
+
+```bash
+./gradlew :appointment-event:test
+```

--- a/appointment-event/README.md
+++ b/appointment-event/README.md
@@ -1,55 +1,62 @@
 # appointment-event
 
-Spring `ApplicationEvent` 기반 도메인 이벤트 발행/구독 + 이벤트 로그 DB 저장.
+[English](README.md) | [한국어](README.ko.md)
 
-## 책임
+Domain event publishing, subscription, and event-log persistence based on Spring `ApplicationEvent`.
 
-- **하는 것**: 도메인 이벤트 타입 정의, 이벤트 발행, 이벤트 로그 Exposed 테이블 저장
-- **하지 않는 것**: 알림 발송 없음 (알림은 `appointment-notification`이 이벤트 구독)
+## Responsibilities
 
-## 이벤트 타입
+- **Does**: defines domain event types, publishes events, and persists event logs with Exposed tables.
+- **Does not**: send notifications directly. Notification delivery is handled by `appointment-notification`, which subscribes to events.
+
+## Event Types
 
 ```kotlin
 sealed class AppointmentDomainEvent : ApplicationEvent {
     data class Created(val appointmentId: Long, val clinicId: Long)
-    data class StatusChanged(val appointmentId: Long, val clinicId: Long,
-                             val fromState: String, val toState: String, val reason: String?)
+    data class StatusChanged(
+        val appointmentId: Long,
+        val clinicId: Long,
+        val fromState: String,
+        val toState: String,
+        val reason: String?,
+    )
     data class Cancelled(val appointmentId: Long, val clinicId: Long, val reason: String)
     data class Rescheduled(val originalId: Long, val newId: Long, val clinicId: Long)
 }
 ```
 
-## 발행 패턴
+## Publishing Pattern
 
 ```kotlin
-// 발행 (appointment-api, appointment-core에서 사용)
+// Publish from appointment-api or appointment-core integration code.
 eventPublisher.publishEvent(AppointmentDomainEvent.Created(id, clinicId))
 
-// 구독
+// Subscribe from application modules.
 @EventListener
 fun on(event: AppointmentDomainEvent.Created) { ... }
 ```
 
-## 핵심 클래스
+## Core Classes
 
-| 클래스 | 역할 |
+| Class | Role |
 |--------|------|
-| `AppointmentDomainEvent` | 이벤트 sealed class — Created, StatusChanged, Cancelled, Rescheduled |
-| `AppointmentEventLogger` | `@EventListener` — 모든 이벤트를 `AppointmentEventLogs` 테이블에 저장 |
-| `AppointmentEventLogRecord` | 이벤트 로그 DTO |
-| `AppointmentEventLogs` | Exposed 테이블 — event_type, appointment_id, payload_json, occurred_at |
+| `AppointmentDomainEvent` | Sealed event hierarchy: Created, StatusChanged, Cancelled, Rescheduled. |
+| `AppointmentEventLogger` | `@EventListener` that stores every event in `AppointmentEventLogs`. |
+| `AppointmentEventLogRecord` | Event log DTO. |
+| `AppointmentEventLogs` | Exposed table with event_type, appointment_id, payload_json, and occurred_at. |
 
-## 이벤트 발행/구독 흐름
+## Event Flow
 
 ```mermaid
 flowchart LR
-    API["appointment-api\n(상태 변경 후)"] -->|"publishEvent()"| BUS["Spring\nApplicationEventPublisher"]
+    API["appointment-api\n(after state change)"] -->|"publishEvent()"| BUS["Spring\nApplicationEventPublisher"]
 
-    BUS -->|"@EventListener"| LOG["AppointmentEventLogger\n→ AppointmentEventLogs 테이블"]
+    BUS -->|"@EventListener"| LOG["AppointmentEventLogger\nAppointmentEventLogs table"]
     BUS -->|"@EventListener"| NOTIF["appointment-notification\nNotificationEventListener"]
 
     subgraph Events["AppointmentDomainEvent"]
-        E1["Created"] 
+        E1["Created"]
         E2["StatusChanged"]
         E3["Cancelled"]
         E4["Rescheduled"]
@@ -58,12 +65,12 @@ flowchart LR
     API --> Events --> BUS
 ```
 
-## 의존성
+## Dependencies
 
-- **내부**: `appointment-core`
-- **외부**: Spring Context
+- **Internal**: `appointment-core`
+- **External**: Spring Context
 
-## 테스트 실행
+## Tests
 
 ```bash
 ./gradlew :appointment-event:test

--- a/appointment-notification/README.ko.md
+++ b/appointment-notification/README.ko.md
@@ -1,0 +1,97 @@
+# appointment-notification
+
+[English](README.md) | [한국어](README.ko.md)
+
+Redis Leader Election + Resilience4j 기반 고가용성(HA) 알림 스케줄러.
+도메인 이벤트 구독으로 예약 상태 변경 알림 발송, 전날/당일 리마인더 지원.
+
+## 책임
+
+- **하는 것**: 도메인 이벤트 → 알림 발송, 리마인더 스케줄링, 알림 이력 DB 저장, Resilience4j 장애 격리
+- **하지 않는 것**: `appointment-api`에 의존하지 않음, 직접 예약 CRUD 없음
+
+## 핵심 클래스
+
+| 클래스 | 역할 |
+|--------|------|
+| `NotificationChannel` | 알림 채널 인터페이스 — channelType, sendCreated/Confirmed/Cancelled/Rescheduled/Reminder |
+| `DummyNotificationChannel` | 기본 구현 — 로그 출력 + DB 이력 저장, 항상 SUCCESS |
+| `ResilientNotificationChannel` | Resilience4j CircuitBreaker/Retry/Bulkhead 래핑 |
+| `NotificationEventListener` | `@EventListener` — AppointmentDomainEvent 구독 → NotificationChannel 호출 |
+| `AppointmentReminderScheduler` | `@Scheduled(1시간)` — 내일/오늘 CONFIRMED 예약 리마인더, 중복 방지 |
+| `NotificationHistoryRepository` | 알림 이력 조회/저장 |
+| `NotificationAutoConfiguration` | Spring `@Configuration` — 자동 빈 등록 |
+
+## 알림 처리 흐름
+
+```mermaid
+flowchart LR
+    EVT["AppointmentDomainEvent"] --> LISTEN["NotificationEventListener\n@EventListener"]
+    LISTEN --> CB["CircuitBreaker\n(Resilience4j)"]
+    CB --> RETRY["Retry · Bulkhead"]
+    RETRY --> CH["DummyNotificationChannel\n로그 + DB 이력"]
+
+    subgraph HA["HA 리마인더 (1h 주기)"]
+        LEADER{"Redis Leader?"}
+        LEADER -->|"Yes"| REMIND["내일/오늘 예약\n리마인더 발송"]
+        LEADER -->|"No"| SKIP["SKIP"]
+    end
+```
+
+→ 전체 시나리오: [user-scenarios.md S5](../docs/requirements/user-scenarios.md#s5-ha-알림-리마인더-발송-스케줄러)
+
+## HA 구성
+
+다중 인스턴스에서 단일 노드만 스케줄러 실행:
+
+```kotlin
+@Scheduled(fixedRate = 3_600_000)
+fun sendReminders() {
+    if (!leaderElection.isLeader()) return
+    // 이하 발송 로직
+}
+```
+
+Redis SETNX 기반 `bluetape4k-leader` 라이브러리 사용.
+
+## 설정 예시
+
+```yaml
+scheduling:
+  notification:
+    enabled: true
+    events:
+      created: true
+      confirmed: true
+      cancelled: true
+      rescheduled: true
+    reminder:
+      enabled: true
+      day-before: true
+      same-day: true
+      same-day-hours-before: 2
+    resilience:
+      circuit-breaker:
+        failure-rate-threshold: 50
+        wait-duration-in-open-state: 30s
+      retry:
+        max-attempts: 3
+        wait-duration: 1s
+      bulkhead:
+        max-concurrent-calls: 10
+```
+
+## 의존성
+
+- **내부**: `appointment-core`, `appointment-event`
+- **외부**: `bluetape4k-leader`, `bluetape4k-lettuce`, `bluetape4k-resilience4j`, `bluetape4k-exposed-jdbc`
+
+## 테스트 실행
+
+```bash
+./gradlew :appointment-notification:test
+```
+
+## 설계 문서
+
+- [알림 모듈 설계 전체](../docs/requirements/notification.md)

--- a/appointment-notification/README.md
+++ b/appointment-notification/README.md
@@ -1,58 +1,60 @@
 # appointment-notification
 
-Redis Leader Election + Resilience4j 기반 고가용성(HA) 알림 스케줄러.
-도메인 이벤트 구독으로 예약 상태 변경 알림 발송, 전날/당일 리마인더 지원.
+[English](README.md) | [한국어](README.ko.md)
 
-## 책임
+High-availability notification scheduler built on Redis Leader Election and Resilience4j.
+It subscribes to domain events, sends appointment status notifications, and supports day-before and same-day reminders.
 
-- **하는 것**: 도메인 이벤트 → 알림 발송, 리마인더 스케줄링, 알림 이력 DB 저장, Resilience4j 장애 격리
-- **하지 않는 것**: `appointment-api`에 의존하지 않음, 직접 예약 CRUD 없음
+## Responsibilities
 
-## 핵심 클래스
+- **Does**: converts domain events to notifications, schedules reminders, stores notification history, and isolates failures with Resilience4j.
+- **Does not**: depend on `appointment-api` or perform appointment CRUD directly.
 
-| 클래스 | 역할 |
+## Core Classes
+
+| Class | Role |
 |--------|------|
-| `NotificationChannel` | 알림 채널 인터페이스 — channelType, sendCreated/Confirmed/Cancelled/Rescheduled/Reminder |
-| `DummyNotificationChannel` | 기본 구현 — 로그 출력 + DB 이력 저장, 항상 SUCCESS |
-| `ResilientNotificationChannel` | Resilience4j CircuitBreaker/Retry/Bulkhead 래핑 |
-| `NotificationEventListener` | `@EventListener` — AppointmentDomainEvent 구독 → NotificationChannel 호출 |
-| `AppointmentReminderScheduler` | `@Scheduled(1시간)` — 내일/오늘 CONFIRMED 예약 리마인더, 중복 방지 |
-| `NotificationHistoryRepository` | 알림 이력 조회/저장 |
-| `NotificationAutoConfiguration` | Spring `@Configuration` — 자동 빈 등록 |
+| `NotificationChannel` | Notification channel interface with channelType and sendCreated/Confirmed/Cancelled/Rescheduled/Reminder operations. |
+| `DummyNotificationChannel` | Default implementation that logs output, stores DB history, and always returns SUCCESS. |
+| `ResilientNotificationChannel` | Wraps a channel with Resilience4j CircuitBreaker, Retry, and Bulkhead. |
+| `NotificationEventListener` | `@EventListener` that subscribes to AppointmentDomainEvent and calls NotificationChannel. |
+| `AppointmentReminderScheduler` | Hourly `@Scheduled` reminder sender for tomorrow/today CONFIRMED appointments, with duplicate prevention. |
+| `NotificationHistoryRepository` | Reads and writes notification history. |
+| `NotificationAutoConfiguration` | Spring `@Configuration` that registers notification beans. |
 
-## 알림 처리 흐름
+## Notification Flow
 
 ```mermaid
 flowchart LR
     EVT["AppointmentDomainEvent"] --> LISTEN["NotificationEventListener\n@EventListener"]
-    LISTEN --> CB["CircuitBreaker\n(Resilience4j)"]
-    CB --> RETRY["Retry · Bulkhead"]
-    RETRY --> CH["DummyNotificationChannel\n로그 + DB 이력"]
+    LISTEN --> CB["CircuitBreaker\nResilience4j"]
+    CB --> RETRY["Retry / Bulkhead"]
+    RETRY --> CH["DummyNotificationChannel\nlog + DB history"]
 
-    subgraph HA["HA 리마인더 (1h 주기)"]
+    subgraph HA["HA reminders, every 1h"]
         LEADER{"Redis Leader?"}
-        LEADER -->|"Yes"| REMIND["내일/오늘 예약\n리마인더 발송"]
+        LEADER -->|"Yes"| REMIND["Tomorrow/today\nreminder delivery"]
         LEADER -->|"No"| SKIP["SKIP"]
     end
 ```
 
-→ 전체 시나리오: [user-scenarios.md S5](../docs/requirements/user-scenarios.md#s5-ha-알림-리마인더-발송-스케줄러)
+Scenario details: [user-scenarios.md S5](../docs/requirements/user-scenarios.md#s5-ha-알림-리마인더-발송-스케줄러)
 
-## HA 구성
+## HA Configuration
 
-다중 인스턴스에서 단일 노드만 스케줄러 실행:
+Only one node runs the scheduler in a multi-instance deployment:
 
 ```kotlin
 @Scheduled(fixedRate = 3_600_000)
 fun sendReminders() {
     if (!leaderElection.isLeader()) return
-    // 이하 발송 로직
+    // send reminders
 }
 ```
 
-Redis SETNX 기반 `bluetape4k-leader` 라이브러리 사용.
+This module uses the Redis SETNX based `bluetape4k-leader` library.
 
-## 설정 예시
+## Configuration Example
 
 ```yaml
 scheduling:
@@ -79,17 +81,17 @@ scheduling:
         max-concurrent-calls: 10
 ```
 
-## 의존성
+## Dependencies
 
-- **내부**: `appointment-core`, `appointment-event`
-- **외부**: `bluetape4k-leader`, `bluetape4k-lettuce`, `bluetape4k-resilience4j`, `bluetape4k-exposed-jdbc`
+- **Internal**: `appointment-core`, `appointment-event`
+- **External**: `bluetape4k-leader`, `bluetape4k-lettuce`, `bluetape4k-resilience4j`, `bluetape4k-exposed-jdbc`
 
-## 테스트 실행
+## Tests
 
 ```bash
 ./gradlew :appointment-notification:test
 ```
 
-## 설계 문서
+## Design Documents
 
-- [알림 모듈 설계 전체](../docs/requirements/notification.md)
+- [Full Notification Module Design](../docs/requirements/notification.md)

--- a/appointment-solver/README.ko.md
+++ b/appointment-solver/README.ko.md
@@ -1,0 +1,97 @@
+# appointment-solver
+
+[English](README.md) | [한국어](README.ko.md)
+
+Timefold Solver 기반 AI 예약 최적화 스케줄러.
+대량 예약을 동시에 고려하여 11개 Hard + 2개 Soft 제약을 만족하는 전역 최적 배치를 수행.
+
+## 책임
+
+- **하는 것**: Planning Variable(의사, 날짜, 시작시간) 최적 배정, Hard 제약 전부 충족, Soft 제약 최소화
+- **하지 않는 것**: 실시간 단건 슬롯 조회 (→ `SlotCalculationService`), DB 직접 쓰기 (→ `SolverService`가 결과 반환 후 호출자가 저장)
+
+## 제약조건 요약
+
+Hard (11개): 영업시간, 의사 스케줄, 의사 부재, 요일 휴식, 기본 휴식, 임시휴진, 공휴일, 동시 환자 수, 장비 가용성, 진료유형-의사 매칭, 장비 사용불가 구간
+
+Soft (2개): 의사 부하 분산(가중치 100), 스케줄 갭 최소화(가중치 10)
+
+→ 전체 제약조건 상세: [solver.md](../docs/requirements/solver.md)
+
+## 핵심 클래스
+
+| 클래스 | 역할 |
+|--------|------|
+| `AppointmentPlanning` | `@PlanningEntity` — doctorId, appointmentDate, startTime이 결정 변수. status가 Pinned 상태면 고정 |
+| `ScheduleSolution` | `@PlanningSolution` — AppointmentPlanning 목록 + Problem Facts |
+| `SolverService` | 진입점 — DB에서 데이터 로드 → SolverConfig 실행 → 결과 반환 |
+| `SolverConfig` | Timefold SolverFactory 설정 (termination, moveFilters) |
+| `SolutionConverter` | DB Record ↔ Planning Domain 변환 |
+| `AppointmentConstraintProvider` | 모든 제약 등록 (H1~H11, S1~S2) |
+| `EquipmentUnavailabilityFact` | Problem Fact — 장비 사용불가 구간 데이터 (H11 제약용) |
+
+## Solver 데이터 흐름
+
+```mermaid
+flowchart TD
+    API["SolverService.solve()"] --> LOAD["SolutionConverter\nDB → Planning Domain"]
+
+    subgraph Facts["Problem Facts (고정 데이터)"]
+        direction LR
+        F1["Doctor"] --- F2["Schedule"] --- F3["Absence"]
+        F4["Closure"] --- F5["Holiday"] --- F6["EquipmentUnavailability"]
+    end
+
+    subgraph Planning["Planning Entities"]
+        PE["AppointmentPlanning\ndoctorId · date · startTime\n[Pinned: CONFIRMED+]"]
+    end
+
+    LOAD --> Facts
+    LOAD --> Planning
+    Facts & Planning --> SOLVE["Timefold Solver\nH1~H11 + S1~S2"]
+    SOLVE --> RESULT["SolverResult\nappointmentId → Assignment"]
+```
+
+→ 전체 흐름: [data-flow.md](../docs/requirements/data-flow.md#6-solver-데이터-흐름)
+
+## Pinned 예약
+
+`@PlanningPin` — 아래 상태의 예약은 Solver가 이동 불가:
+- **고정**: `CONFIRMED`, `CHECKED_IN`, `IN_PROGRESS`, `COMPLETED`
+- **이동 가능**: `REQUESTED`, `PENDING_RESCHEDULE`
+
+## Solver 실행 예시
+
+```kotlin
+val result: SolverResult = solverService.solve(
+    clinicId = 1L,
+    appointmentIds = listOf(10L, 11L, 12L),
+    dateRange = LocalDate.now()..LocalDate.now().plusDays(7)
+)
+// result.assignments: Map<Long, Assignment> — appointmentId → (doctorId, date, startTime)
+```
+
+## 의존성
+
+- **내부**: `appointment-core`
+- **외부**: `ai.timefold.solver:timefold-solver-core`, `bluetape4k-exposed-jdbc`
+
+## 테스트 실행
+
+```bash
+./gradlew :appointment-solver:test
+```
+
+## 벤치마크
+
+```bash
+./gradlew :appointment-solver:test --tests "*.SolverBenchmarkTest"
+```
+
+결과는 `build/reports/solver-benchmark/` 에 HTML 리포트로 생성됩니다.
+
+→ 상세: [solver-benchmark-report.md](../docs/requirements/solver.md#벤치마크)
+
+## 설계 문서
+
+- [Solver 설계 전체](../docs/requirements/solver.md)

--- a/appointment-solver/README.md
+++ b/appointment-solver/README.md
@@ -1,95 +1,114 @@
 # appointment-solver
 
-Timefold Solver 기반 AI 예약 최적화 스케줄러.
-대량 예약을 동시에 고려하여 11개 Hard + 2개 Soft 제약을 만족하는 전역 최적 배치를 수행.
+[English](README.md) | [한국어](README.ko.md)
 
-## 책임
+Timefold Solver based AI appointment scheduler.
+It optimizes bulk appointment placement across the global schedule while satisfying 11 hard constraints and 2 soft constraints.
 
-- **하는 것**: Planning Variable(의사, 날짜, 시작시간) 최적 배정, Hard 제약 전부 충족, Soft 제약 최소화
-- **하지 않는 것**: 실시간 단건 슬롯 조회 (→ `SlotCalculationService`), DB 직접 쓰기 (→ `SolverService`가 결과 반환 후 호출자가 저장)
+## Responsibilities
 
-## 제약조건 요약
+- **Does**: assigns planning variables such as doctor, date, and start time; satisfies all hard constraints; minimizes soft-constraint penalties.
+- **Does not**: provide real-time single-slot lookup, which belongs to `SlotCalculationService`; write results directly to the database, because `SolverService` returns results to its caller.
 
-Hard (11개): 영업시간, 의사 스케줄, 의사 부재, 요일 휴식, 기본 휴식, 임시휴진, 공휴일, 동시 환자 수, 장비 가용성, 진료유형-의사 매칭, 장비 사용불가 구간
+## Constraint Summary
 
-Soft (2개): 의사 부하 분산(가중치 100), 스케줄 갭 최소화(가중치 10)
+Hard constraints (11):
 
-→ 전체 제약조건 상세: [solver.md](../docs/requirements/solver.md)
+- business hours
+- doctor schedule
+- doctor absence
+- day-of-week rest
+- default break time
+- temporary clinic closure
+- holiday
+- concurrent patient capacity
+- equipment availability
+- treatment-type and doctor matching
+- equipment unavailability windows
 
-## 핵심 클래스
+Soft constraints (2):
 
-| 클래스 | 역할 |
+- doctor load balancing, weight 100
+- schedule gap minimization, weight 10
+
+Full details: [solver.md](../docs/requirements/solver.md)
+
+## Core Classes
+
+| Class | Role |
 |--------|------|
-| `AppointmentPlanning` | `@PlanningEntity` — doctorId, appointmentDate, startTime이 결정 변수. status가 Pinned 상태면 고정 |
-| `ScheduleSolution` | `@PlanningSolution` — AppointmentPlanning 목록 + Problem Facts |
-| `SolverService` | 진입점 — DB에서 데이터 로드 → SolverConfig 실행 → 결과 반환 |
-| `SolverConfig` | Timefold SolverFactory 설정 (termination, moveFilters) |
-| `SolutionConverter` | DB Record ↔ Planning Domain 변환 |
-| `AppointmentConstraintProvider` | 모든 제약 등록 (H1~H11, S1~S2) |
-| `EquipmentUnavailabilityFact` | Problem Fact — 장비 사용불가 구간 데이터 (H11 제약용) |
+| `AppointmentPlanning` | `@PlanningEntity`; doctorId, appointmentDate, and startTime are planning variables. Pinned statuses are fixed. |
+| `ScheduleSolution` | `@PlanningSolution`; contains AppointmentPlanning entries and problem facts. |
+| `SolverService` | Entry point; loads data from the database, runs SolverConfig, and returns the result. |
+| `SolverConfig` | Timefold SolverFactory configuration, including termination and move filters. |
+| `SolutionConverter` | Converts between DB records and the planning domain. |
+| `AppointmentConstraintProvider` | Registers all constraints, H1-H11 and S1-S2. |
+| `EquipmentUnavailabilityFact` | Problem fact for equipment unavailability windows used by H11. |
 
-## Solver 데이터 흐름
+## Solver Data Flow
 
 ```mermaid
 flowchart TD
-    API["SolverService.solve()"] --> LOAD["SolutionConverter\nDB → Planning Domain"]
+    API["SolverService.solve()"] --> LOAD["SolutionConverter\nDB to Planning Domain"]
 
-    subgraph Facts["Problem Facts (고정 데이터)"]
+    subgraph Facts["Problem Facts"]
         direction LR
         F1["Doctor"] --- F2["Schedule"] --- F3["Absence"]
         F4["Closure"] --- F5["Holiday"] --- F6["EquipmentUnavailability"]
     end
 
     subgraph Planning["Planning Entities"]
-        PE["AppointmentPlanning\ndoctorId · date · startTime\n[Pinned: CONFIRMED+]"]
+        PE["AppointmentPlanning\ndoctorId / date / startTime\nPinned: CONFIRMED+"]
     end
 
     LOAD --> Facts
     LOAD --> Planning
-    Facts & Planning --> SOLVE["Timefold Solver\nH1~H11 + S1~S2"]
-    SOLVE --> RESULT["SolverResult\nappointmentId → Assignment"]
+    Facts & Planning --> SOLVE["Timefold Solver\nH1-H11 + S1-S2"]
+    SOLVE --> RESULT["SolverResult\nappointmentId to Assignment"]
 ```
 
-→ 전체 흐름: [data-flow.md](../docs/requirements/data-flow.md#6-solver-데이터-흐름)
+Full flow: [data-flow.md](../docs/requirements/data-flow.md#6-solver-데이터-흐름)
 
-## Pinned 예약
+## Pinned Appointments
 
-`@PlanningPin` — 아래 상태의 예약은 Solver가 이동 불가:
-- **고정**: `CONFIRMED`, `CHECKED_IN`, `IN_PROGRESS`, `COMPLETED`
-- **이동 가능**: `REQUESTED`, `PENDING_RESCHEDULE`
+`@PlanningPin` prevents Solver from moving appointments in the following states:
 
-## Solver 실행 예시
+- **Pinned**: `CONFIRMED`, `CHECKED_IN`, `IN_PROGRESS`, `COMPLETED`
+- **Movable**: `REQUESTED`, `PENDING_RESCHEDULE`
+
+## Usage Example
 
 ```kotlin
 val result: SolverResult = solverService.solve(
     clinicId = 1L,
     appointmentIds = listOf(10L, 11L, 12L),
-    dateRange = LocalDate.now()..LocalDate.now().plusDays(7)
+    dateRange = LocalDate.now()..LocalDate.now().plusDays(7),
 )
-// result.assignments: Map<Long, Assignment> — appointmentId → (doctorId, date, startTime)
+// result.assignments: Map<Long, Assignment>
+// appointmentId -> (doctorId, date, startTime)
 ```
 
-## 의존성
+## Dependencies
 
-- **내부**: `appointment-core`
-- **외부**: `ai.timefold.solver:timefold-solver-core`, `bluetape4k-exposed-jdbc`
+- **Internal**: `appointment-core`
+- **External**: `ai.timefold.solver:timefold-solver-core`, `bluetape4k-exposed-jdbc`
 
-## 테스트 실행
+## Tests
 
 ```bash
 ./gradlew :appointment-solver:test
 ```
 
-## 벤치마크
+## Benchmarks
 
 ```bash
 ./gradlew :appointment-solver:test --tests "*.SolverBenchmarkTest"
 ```
 
-결과는 `build/reports/solver-benchmark/` 에 HTML 리포트로 생성됩니다.
+HTML reports are generated under `build/reports/solver-benchmark/`.
 
-→ 상세: [solver-benchmark-report.md](../docs/requirements/solver.md#벤치마크)
+Details: [solver-benchmark-report.md](../docs/requirements/solver.md#벤치마크)
 
-## 설계 문서
+## Design Documents
 
-- [Solver 설계 전체](../docs/requirements/solver.md)
+- [Full Solver Design](../docs/requirements/solver.md)

--- a/frontend/appointment-frontend/README.ko.md
+++ b/frontend/appointment-frontend/README.ko.md
@@ -1,0 +1,35 @@
+# appointment-frontend
+
+[English](README.md) | [한국어](README.ko.md)
+
+Angular 18 기반 병원 예약 관리 웹 UI.
+
+## 개발 서버 실행
+
+```bash
+cd frontend/appointment-frontend
+npm install
+npm start   # http://localhost:4200
+```
+
+API 서버(`http://localhost:8080`)가 먼저 실행되어 있어야 합니다.
+
+## 빌드
+
+```bash
+# Angular CLI 직접
+npm run build   # dist/ 생성
+
+# Gradle 통합 빌드
+./gradlew :frontend:appointment-frontend:build
+```
+
+## 테스트
+
+```bash
+npm test   # Karma 단위 테스트
+```
+
+## 설계 문서
+
+- [프론트엔드 설계](../../docs/requirements/frontend.md)

--- a/frontend/appointment-frontend/README.md
+++ b/frontend/appointment-frontend/README.md
@@ -1,8 +1,10 @@
 # appointment-frontend
 
-Angular 18 기반 병원 예약 관리 웹 UI.
+[English](README.md) | [한국어](README.ko.md)
 
-## 개발 서버 실행
+Angular 18 web UI for clinic appointment management.
+
+## Development Server
 
 ```bash
 cd frontend/appointment-frontend
@@ -10,24 +12,24 @@ npm install
 npm start   # http://localhost:4200
 ```
 
-API 서버(`http://localhost:8080`)가 먼저 실행되어 있어야 합니다.
+The API server at `http://localhost:8080` must be running first.
 
-## 빌드
+## Build
 
 ```bash
-# Angular CLI 직접
-npm run build   # dist/ 생성
+# Direct Angular CLI build
+npm run build   # creates dist/
 
-# Gradle 통합 빌드
+# Gradle-integrated build
 ./gradlew :frontend:appointment-frontend:build
 ```
 
-## 테스트
+## Tests
 
 ```bash
-npm test   # Karma 단위 테스트
+npm test   # Karma unit tests
 ```
 
-## 설계 문서
+## Design Documents
 
-- [프론트엔드 설계](../../docs/requirements/frontend.md)
+- [Frontend Design](../../docs/requirements/frontend.md)


### PR DESCRIPTION
## Summary
- Add Korean README.ko.md counterparts for the root project and module README files.
- Convert README.md files to English defaults with language-switch links.
- Keep API, core, event, solver, notification, and frontend documentation aligned with the bilingual pattern.

## Verification
- git diff --check
- verified language switch links across root and module README files
- verified referenced documentation paths exist

## Notes
- Documentation-only change; Gradle build was not run.