### PR TITLE
chore: align dependency governance baseline

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,6 @@ updates:
       time: "06:00"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 8
-    assignees:
-      - "debop"
     groups:
       kotlin:
         patterns:
@@ -39,8 +37,6 @@ updates:
       time: "06:30"
       timezone: "Asia/Seoul"
     open-pull-requests-limit: 5
-    assignees:
-      - "debop"
     groups:
       github-actions:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,47 @@
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 8
+    assignees:
+      - "debop"
+    groups:
+      kotlin:
+        patterns:
+          - "org.jetbrains.kotlin*"
+          - "org.jetbrains.kotlinx*"
+      spring:
+        patterns:
+          - "org.springframework*"
+          - "io.spring*"
+      testcontainers:
+        patterns:
+          - "org.testcontainers*"
+      jackson:
+        patterns:
+          - "com.fasterxml.jackson*"
+          - "tools.jackson*"
+      bluetape4k:
+        patterns:
+          - "io.github.bluetape4k*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "develop"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:30"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 5
+    assignees:
+      - "debop"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ springdoc-openapi = "3.0.2"
 
 resilience4j = "2.4.0"
 
-jackson3 = "3.1.2"
+jackson3 = "3.1.3"
 jjwt = "0.13.0"
 
 lettuce = "6.8.2.RELEASE"
@@ -29,7 +29,7 @@ timefold-solver = "1.32.0"
 junit-jupiter = "6.0.3"
 junit-platform = "6.0.3"
 mockk = "1.14.9"
-testcontainers = "2.0.4"
+testcontainers = "2.0.5"
 assertj = "3.27.6"
 random-beans = "3.9.0"
 datafaker = "2.5.4"


### PR DESCRIPTION
## Summary
- Add valid Dependabot coverage for Gradle and GitHub Actions.
- Align governed Testcontainers/Jackson version catalog entries with the org baseline where this repository had drift.
- Connect this repository to bluetape4k/.github#9 dependency governance.

## Verification
- `./gradlew help --no-daemon`
- Dependabot YAML parsed with Ruby YAML.
- Central version drift report shows Testcontainers/Jackson aligned.

Refs bluetape4k/.github#9