### PR TITLE
Use governed dependency snapshot

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Gradle Version Catalog — migrated from buildSrc/src/main/kotlin/Libs.kt
 
 [versions]
-bluetape4k-dependencies = "1.0.0"
+bluetape4k-dependencies = "1.0.1-SNAPSHOT"
 
 kotlin = "2.3.21"
 kotlinx-coroutines = "1.11.0"


### PR DESCRIPTION
## Summary
- move clinic-appointment to bluetape4k-dependencies 1.0.1-SNAPSHOT
- keep dependency alignment centralized instead of leaf library bumps

## Verification
- ./gradlew :appointment-api:compileKotlin --no-build-cache

## Notes
- This follows the policy to close leaf Dependabot library PRs and handle shared versions through bluetape4k-dependencies.