### PR TITLE
fix: validate candidateId ownership in confirmReschedule (#91)

### DIFF
--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleController.kt
@@ -102,7 +102,7 @@ class RescheduleController(
         @PathVariable candidateId: Long,
     ): ResponseEntity<ApiResponse<Long>> {
         log.debug { "POST /api/appointments/$id/reschedule/confirm/$candidateId" }
-        val newAppointmentId = closureRescheduleService.confirmReschedule(candidateId)
+        val newAppointmentId = closureRescheduleService.confirmReschedule(candidateId, id)
         return ResponseEntity.ok(ApiResponse.ok(newAppointmentId))
     }
 

--- a/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleControllerTest.kt
+++ b/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleControllerTest.kt
@@ -23,6 +23,7 @@ import io.bluetape4k.clinic.appointment.api.test.AbstractApiIntegrationTest
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeNull
 import io.bluetape4k.assertions.shouldBePositive
 import io.bluetape4k.assertions.shouldBeTrue
@@ -221,6 +222,43 @@ class RescheduleControllerTest @Autowired constructor() : AbstractApiIntegration
         response.statusCode shouldBeEqualTo HttpStatus.OK
         response.jsonPath<Boolean>("$.success").shouldBeTrue()
         response.jsonPath<Int>("$.data").shouldNotBeNull().shouldBePositive()
+    }
+
+    @Test
+    fun `POST confirm - 다른 예약의 candidateId로 확정 시 400 반환`() {
+        val otherAppointmentId = transaction {
+            Appointments.insertAndGetId {
+                it[Appointments.clinicId] = this@RescheduleControllerTest.clinicId
+                it[Appointments.doctorId] = this@RescheduleControllerTest.doctorId
+                it[Appointments.treatmentTypeId] = this@RescheduleControllerTest.treatmentTypeId
+                it[patientName] = "Other Patient"
+                it[patientPhone] = "010-9999-8888"
+                it[appointmentDate] = LocalDate.of(2026, 4, 6)
+                it[startTime] = LocalTime.of(11, 0)
+                it[endTime] = LocalTime.of(11, 30)
+                it[Appointments.status] = AppointmentState.CONFIRMED
+            }.value
+        }
+
+        val candidateId = transaction {
+            RescheduleCandidates.insertAndGetId {
+                it[originalAppointmentId] = otherAppointmentId
+                it[candidateDate] = LocalDate.of(2026, 4, 7)
+                it[startTime] = LocalTime.of(10, 0)
+                it[endTime] = LocalTime.of(10, 30)
+                it[RescheduleCandidates.doctorId] = this@RescheduleControllerTest.doctorId
+                it[priority] = 1
+                it[selected] = false
+            }.value
+        }
+
+        val response = client.post()
+            .uri("$BASE_URL/{id}/reschedule/confirm/{candidateId}", appointmentId, candidateId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.BAD_REQUEST
+        response.jsonPath<Boolean>("$.success").shouldBeFalse()
     }
 
     @Test

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleService.kt
@@ -63,7 +63,7 @@ class ClosureRescheduleService(
             for (appointment in affected) {
                 stateHistoryRepository.save(
                     AppointmentStateHistoryRecord(
-                        appointmentId = appointment.id!!,
+                        appointmentId = appointment.id.requireNotNull("appointment.id"),
                         fromState = appointment.status,
                         toState = AppointmentState.PENDING_RESCHEDULE,
                         reason = "임시휴진으로 인한 재배정",
@@ -74,7 +74,7 @@ class ClosureRescheduleService(
             val result = mutableMapOf<Long, List<RescheduleCandidateRecord>>()
 
             for (appointment in affected) {
-                val appointmentId = appointment.id!!
+                val appointmentId = appointment.id.requireNotNull("appointment.id")
                 val candidates = mutableListOf<RescheduleCandidateRecord>()
                 var priority = 0
 
@@ -108,12 +108,17 @@ class ClosureRescheduleService(
      * 원래 예약은 RESCHEDULED로 전환하고, 새 예약을 생성합니다.
      *
      * @param candidateId 선택한 후보 ID
+     * @param originalAppointmentId 원본 예약 ID — 후보가 이 예약에 속하는지 검증
      * @return 새로 생성된 예약 ID
      */
-    fun confirmReschedule(candidateId: Long): Long =
+    fun confirmReschedule(candidateId: Long, originalAppointmentId: Long): Long =
         transaction {
             val candidate = rescheduleCandidateRepository.findByIdOrNull(candidateId)
                 ?: throw IllegalArgumentException("Reschedule candidate not found: $candidateId")
+
+            require(candidate.originalAppointmentId == originalAppointmentId) {
+                "Candidate $candidateId does not belong to appointment $originalAppointmentId"
+            }
 
             val original = appointmentRepository.findByIdOrNull(candidate.originalAppointmentId)
                 ?: throw IllegalArgumentException("Original appointment not found: ${candidate.originalAppointmentId}")
@@ -136,7 +141,7 @@ class ClosureRescheduleService(
             )
 
             val newAppointment = appointmentRepository.save(appointmentRecord)
-            appointmentRepository.updateStatus(original.id!!, AppointmentState.RESCHEDULED)
+            appointmentRepository.updateStatus(original.id.requireNotNull("original.id"), AppointmentState.RESCHEDULED)
             stateHistoryRepository.save(
                 AppointmentStateHistoryRecord(
                     appointmentId = original.id,
@@ -160,6 +165,6 @@ class ClosureRescheduleService(
         transaction {
             val best = rescheduleCandidateRepository.findBestCandidate(originalAppointmentId)
                 ?: return@transaction null
-            confirmReschedule(best.id!!)
+            confirmReschedule(best.id.requireNotNull("best.id"), originalAppointmentId)
         }
 }

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleServiceTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleServiceTest.kt
@@ -22,13 +22,14 @@ import io.bluetape4k.clinic.appointment.test.AbstractExposedTest
 import io.bluetape4k.clinic.appointment.test.TestDB
 import io.bluetape4k.clinic.appointment.test.withTables
 import io.bluetape4k.logging.KLogging
-import io.bluetape4k.support.requireNotNull
 import io.bluetape4k.assertions.shouldBeEmpty
 import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.assertFailsWith
 import io.bluetape4k.assertions.shouldBeFalse
 import io.bluetape4k.assertions.shouldBeTrue
 import io.bluetape4k.assertions.shouldHaveSize
 import io.bluetape4k.assertions.shouldNotBeNull
+import io.bluetape4k.support.requireNotNull
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
@@ -166,7 +167,10 @@ class ClosureRescheduleServiceTest : AbstractExposedTest() {
             val result = rescheduleService.processClosureReschedule(clinicId, MONDAY, searchDays = 1)
             val firstCandidate = result.values.first().first()
 
-            val newAppointmentId = rescheduleService.confirmReschedule(firstCandidate.id!!)
+            val newAppointmentId = rescheduleService.confirmReschedule(
+                firstCandidate.id.requireNotNull("firstCandidate.id"),
+                firstCandidate.originalAppointmentId,
+            )
 
             val originalAppointment = Appointments.selectAll()
                 .where { Appointments.status eq AppointmentState.RESCHEDULED }
@@ -265,6 +269,22 @@ class ClosureRescheduleServiceTest : AbstractExposedTest() {
 
             val result = rescheduleService.autoReschedule(appointmentId.value)
             (result == null).shouldBeTrue()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `7 - 다른 예약의 candidateId로 confirmReschedule 호출 시 예외 발생`(testDB: TestDB) {
+        withTables(testDB, *allTables) {
+            val (clinicId, _, _) = insertDataWithAppointment()
+            val result = rescheduleService.processClosureReschedule(clinicId, MONDAY, searchDays = 1)
+
+            val candidate = result.values.first().first()
+            val wrongAppointmentId = candidate.originalAppointmentId + 9999L
+
+            assertFailsWith<IllegalArgumentException> {
+                rescheduleService.confirmReschedule(candidate.id.requireNotNull("candidate.id"), wrongAppointmentId)
+            }
         }
     }
 }

--- a/docs/lessons/2026-05-18-issue-91-reschedule-auth.md
+++ b/docs/lessons/2026-05-18-issue-91-reschedule-auth.md
@@ -1,0 +1,56 @@
+# Issue #91 — confirmReschedule() Authorization Bypass Fix
+
+**Date**: 2026-05-18  
+**Branch**: `fix/issue-91-reschedule-auth`  
+**Scope**: `appointment-core`, `appointment-api`
+
+## Root Cause
+
+`RescheduleController.confirmReschedule()` accepted a `{candidateId}` path variable
+but the service layer (`ClosureRescheduleService.confirmReschedule()`) ignored the
+`originalAppointmentId` parameter entirely when querying the candidate.
+
+An attacker (or misconfigured client) could pass any `candidateId` belonging to a
+**different** appointment in the `{id}` URL slot and the system would process it without
+error — cross-appointment reschedule authorization bypass.
+
+## Decision
+
+Propagate the `originalAppointmentId` (from the controller's `{id}` path variable) all
+the way into the service, and add an ownership guard immediately after the candidate
+lookup:
+
+```kotlin
+require(candidate.originalAppointmentId == originalAppointmentId) {
+    "Candidate $candidateId does not belong to appointment $originalAppointmentId"
+}
+```
+
+`IllegalArgumentException` is the correct type here — `GlobalExceptionHandler` maps it
+to HTTP 400, which is the appropriate response for a bad/unauthorized request.
+
+## Outcome
+
+- `ClosureRescheduleService.confirmReschedule(candidateId, originalAppointmentId)` —
+  ownership check added inside the same `transaction {}` block (no TOCTOU window).
+- `RescheduleController.confirmReschedule()` — passes `id` path variable to service.
+- `autoReschedule()` — internal call updated to forward `originalAppointmentId`.
+- All `!!` occurrences replaced with `requireNotNull("param")` per project rules.
+
+## Verification
+
+- `ClosureRescheduleServiceTest` test 7: mismatch → `IllegalArgumentException` ✅
+- `RescheduleControllerTest` cross-appointment confirm: HTTP 400 ✅
+- 315 tests passing, 0 failures across `appointment-core` + `appointment-api`
+
+## Future Guidance
+
+- Whenever a REST path variable identifies a resource owner (`{appointmentId}`),
+  the service must validate that the secondary resource (candidate, note, etc.)
+  belongs to that owner before mutating state.
+- Prefer `require(child.parentId == parentId)` over a separate query — it is atomic
+  within the transaction and self-documenting.
+- Never leave `id` path variables unused in controller methods; if the variable exists,
+  it must be threaded through to the service.
+- Always use `requireNotNull("param")` from `io.bluetape4k.support` instead of `!!` — 
+  produces a clear error message and avoids NPE stack traces.


### PR DESCRIPTION
## Summary

Fixes #91 — authorization bypass in `confirmReschedule()`.

The `{id}` path variable in `POST /api/appointments/{id}/reschedule/confirm/{candidateId}` was completely ignored. Any `candidateId` — even one belonging to a **different** appointment — would be accepted and processed.

## Root Cause

`RescheduleController.confirmReschedule()` received `id` (the appointment owner) as a path variable but never passed it to `ClosureRescheduleService`. The service had no ownership check.

## Changes

### `appointment-core`
- `ClosureRescheduleService.confirmReschedule(candidateId, originalAppointmentId)`:
  - Added ownership guard inside the same `transaction {}` (no TOCTOU window)
  - Replaced all `!!` usages with `requireNotNull("param")` per project rules
- `autoReschedule()`: internal call now forwards `originalAppointmentId`

### `appointment-api`
- `RescheduleController.confirmReschedule()`: passes `id` path variable to service

### Tests
- `ClosureRescheduleServiceTest` test 7: cross-appointment mismatch → `IllegalArgumentException`
- `RescheduleControllerTest` new test: cross-appointment confirm → HTTP 400

## Verification

- `appointment-core`: BUILD SUCCESSFUL (315 tests, 0 failures)
- `appointment-api`: BUILD SUCCESSFUL (0 failures)

## DoD Checklist

| Item | Status |
|------|--------|
| All tests passing | ✅ |
| Tier 4 code review (P0/P1=0) | ✅ |
| `!!` → `requireNotNull` | ✅ |
| `assertThrows` → `io.bluetape4k.assertions.assertFailsWith` | ✅ |
| Lessons committed | ✅ `docs/lessons/2026-05-18-issue-91-reschedule-auth.md` |