### PR TITLE
fix: replace unsafe !! assertions with proper null handling in AppointmentService

### DIFF
--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/AppointmentService.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/AppointmentService.kt
@@ -2,6 +2,7 @@ package io.bluetape4k.clinic.appointment.api.service
 
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
+import io.bluetape4k.support.requireNotNull
 import io.bluetape4k.clinic.appointment.api.dto.CreateAppointmentRequest
 import io.bluetape4k.clinic.appointment.event.AppointmentDomainEvent
 import io.bluetape4k.clinic.appointment.model.dto.AppointmentRecord
@@ -61,7 +62,7 @@ class AppointmentService(
         val saved = transaction { appointmentRepository.save(record) }
         eventPublisher.publishEvent(
             AppointmentDomainEvent.Created(
-                appointmentId = saved.id!!,
+                appointmentId = saved.id.requireNotNull("saved.id"),
                 clinicId = saved.clinicId,
             )
         )
@@ -99,7 +100,8 @@ class AppointmentService(
             )
         )
 
-        return transaction { appointmentRepository.findByIdOrNull(id) }!!
+        return transaction { appointmentRepository.findByIdOrNull(id) }
+            ?: throw NoSuchElementException("Appointment not found after status update: $id")
     }
 
     suspend fun cancel(id: Long): AppointmentRecord {
@@ -130,7 +132,8 @@ class AppointmentService(
             )
         )
 
-        return transaction { appointmentRepository.findByIdOrNull(id) }!!
+        return transaction { appointmentRepository.findByIdOrNull(id) }
+            ?: throw NoSuchElementException("Appointment not found after cancel: $id")
     }
 }
 

--- a/docs/lessons/2026-05-18-issue-90-unsafe-assertion.md
+++ b/docs/lessons/2026-05-18-issue-90-unsafe-assertion.md
@@ -1,0 +1,29 @@
+# Issue #90: AppointmentService 의 unsafe `!!` assertion 제거
+
+## 근본 원인
+
+`AppointmentService`의 세 곳에서 `!!` (force-unwrap) 연산자를 사용하여
+null 발생 시 `KotlinNullPointerException`을 던짐. 이 예외는 `GlobalExceptionHandler`에
+매핑되지 않아 HTTP 500 Internal Server Error로 노출됨.
+
+## 수정 내용
+
+| 위치 | Before | After | 예외 타입 | HTTP |
+|------|--------|-------|----------|------|
+| `create()` — `saved.id` | `saved.id!!` | `saved.id.requireNotNull("saved.id")` | `IllegalArgumentException` | 400 |
+| `updateStatus()` — 후속 조회 | `findByIdOrNull(id)!!` | `?: throw NoSuchElementException(...)` | `NoSuchElementException` | 404 |
+| `cancel()` — 후속 조회 | `findByIdOrNull(id)!!` | `?: throw NoSuchElementException(...)` | `NoSuchElementException` | 404 |
+
+## 검증
+
+- appointment-api: 85 tests passing
+- appointment-core: 226 tests passing
+- 총 311 tests, 44초
+
+## 교훈
+
+1. `!!`는 항상 금지 — 어떤 상황에서도 적절한 예외 타입으로 대체해야 함
+2. `requireNotNull`은 반드시 `io.bluetape4k.support.requireNotNull` 사용 (stdlib 아님)
+3. "not found" 시나리오는 `NoSuchElementException` → HTTP 404 매핑 활용
+4. 의존성 해석 문제: Sonatype snapshot BOM이 릴리스 버전을 참조할 수 있음 —
+   로컬 테스트 시 `mavenLocal()` 추가로 우회 가능하나 커밋에 포함하면 안 됨


### PR DESCRIPTION
## Summary

Replace three instances of force-unwrap (`!!`) in `AppointmentService` with proper null handling that produces meaningful exception types aligned with `GlobalExceptionHandler` mappings.

## Changes

| Location | Before | After | Exception | HTTP |
|----------|--------|-------|-----------|------|
| `create()` — `saved.id` | `saved.id!!` | `saved.id.requireNotNull("saved.id")` | `IllegalArgumentException` | 400 |
| `updateStatus()` — post-query | `findByIdOrNull(id)!!` | `?: throw NoSuchElementException(...)` | `NoSuchElementException` | 404 |
| `cancel()` — post-query | `findByIdOrNull(id)!!` | `?: throw NoSuchElementException(...)` | `NoSuchElementException` | 404 |

## Test Results

- appointment-api: 85 tests passing
- appointment-core: 226 tests passing
- Total: 311 tests, 44s

## Verification

```bash
./gradlew :appointment-api:test :appointment-core:test --no-configuration-cache
```

Closes #90