### PR TITLE
fix: propagate caller-supplied reason to cancel() instead of hardcoding

### DIFF
--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
@@ -78,9 +78,12 @@ class AppointmentController(
     }
 
     @DeleteMapping("/{id}")
-    suspend fun cancel(@PathVariable id: Long): ResponseEntity<ApiResponse<AppointmentResponse>> {
-        log.debug { "DELETE /api/appointments/$id" }
-        val cancelled = appointmentService.cancel(id)
+    suspend fun cancel(
+        @PathVariable id: Long,
+        @RequestParam(required = false) reason: String?,
+    ): ResponseEntity<ApiResponse<AppointmentResponse>> {
+        log.debug { "DELETE /api/appointments/$id reason=$reason" }
+        val cancelled = appointmentService.cancel(id, reason)
         val (timezone, locale) = timezoneService.getTimezoneAndLocale(cancelled.clinicId)
         return ResponseEntity.ok(ApiResponse.ok(cancelled.toResponse(timezone, locale)))
     }

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/AppointmentService.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/AppointmentService.kt
@@ -104,13 +104,14 @@ class AppointmentService(
             ?: throw NoSuchElementException("Appointment not found after status update: $id")
     }
 
-    suspend fun cancel(id: Long): AppointmentRecord {
-        log.debug { "cancel: id=$id" }
+    suspend fun cancel(id: Long, reason: String? = null): AppointmentRecord {
+        log.debug { "cancel: id=$id, reason=$reason" }
         val record = transaction { appointmentRepository.findByIdOrNull(id) }
             ?: throw NoSuchElementException("Appointment not found: $id")
 
+        val effectiveReason = reason ?: "Cancelled by user"
         val currentState = record.status
-        stateMachine.transition(currentState, AppointmentEvent.Cancel(reason = "Cancelled by user"))
+        stateMachine.transition(currentState, AppointmentEvent.Cancel(reason = effectiveReason))
 
         transaction {
             appointmentRepository.updateStatus(id, AppointmentState.CANCELLED)
@@ -119,7 +120,7 @@ class AppointmentService(
                     appointmentId = id,
                     fromState = currentState,
                     toState = AppointmentState.CANCELLED,
-                    reason = "Cancelled by user",
+                    reason = effectiveReason,
                 )
             )
         }
@@ -128,7 +129,7 @@ class AppointmentService(
             AppointmentDomainEvent.Cancelled(
                 appointmentId = id,
                 clinicId = record.clinicId,
-                reason = "Cancelled by user",
+                reason = effectiveReason,
             )
         )
 

--- a/docs/lessons/2026-05-18-issue-96-cancel-reason.md
+++ b/docs/lessons/2026-05-18-issue-96-cancel-reason.md
@@ -1,0 +1,27 @@
+# Issue #96: cancel() 하드코딩된 reason 제거
+
+## 근본 원인
+
+`AppointmentService.cancel()`이 caller의 reason 파라미터를 받지 않고
+"Cancelled by user" 문자열을 3곳에 하드코딩. 감사 이력(state history)과
+도메인 이벤트에 실제 취소 사유가 기록되지 않음.
+
+## 수정 내용
+
+| 파일 | 변경 |
+|------|------|
+| `AppointmentController.kt` | `@RequestParam(required = false) reason: String?` 추가 |
+| `AppointmentService.kt` | `cancel(id, reason)` — `effectiveReason = reason ?: "Cancelled by user"` |
+
+3곳 모두 `effectiveReason` 사용: state machine event, history record, domain event.
+
+## 설계 결정
+
+- DELETE body 대신 query parameter 선택 — HTTP spec 상 DELETE body는 비표준
+- 기본값 유지 (`"Cancelled by user"`) — 하위호환성 보장
+- `effectiveReason` 로컬 val로 일관성 확보
+
+## 검증
+
+- appointment-api + appointment-core: 전체 테스트 통과 (1m 29s)
+- Tier 4 code review: PASS (0 blocking issues)


### PR DESCRIPTION
## Summary

`AppointmentService.cancel()` hardcoded `"Cancelled by user"` in three places, ignoring any reason supplied by the caller. This caused incorrect audit trail data.

## Changes

| File | Change |
|------|--------|
| `AppointmentController.kt` | Add `@RequestParam(required = false) reason: String?` to DELETE endpoint |
| `AppointmentService.kt` | Add `reason: String? = null` param; use `effectiveReason = reason ?: "Cancelled by user"` consistently |

## Design Decisions

- Query parameter (not body) for DELETE — DELETE body is non-standard per HTTP spec
- Default preserved (`"Cancelled by user"`) — backward compatible
- Single `effectiveReason` val used across state machine event, history record, and domain event

## Test Results

```bash
./gradlew :appointment-api:test :appointment-core:test --no-configuration-cache
# BUILD SUCCESSFUL in 1m 29s — all tests passing
```

Closes #96