### PR TITLE
fix: add @Valid and Bean Validation constraints to all @RequestBody DTOs

### DIFF
--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/GlobalExceptionHandler.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/GlobalExceptionHandler.kt
@@ -5,6 +5,8 @@ import io.bluetape4k.logging.warn
 import io.bluetape4k.clinic.appointment.api.dto.ApiResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 
@@ -12,6 +14,21 @@ import org.springframework.web.bind.annotation.RestControllerAdvice
 class GlobalExceptionHandler {
 
     companion object : KLogging()
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidation(ex: MethodArgumentNotValidException): ResponseEntity<ApiResponse<Nothing>> {
+        val message = ex.bindingResult.fieldErrors.joinToString("; ") { "${it.field}: ${it.defaultMessage}" }
+        log.warn(ex) { "Validation failed: $message" }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(message.ifBlank { "Validation failed" }))
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleMessageNotReadable(ex: HttpMessageNotReadableException): ResponseEntity<ApiResponse<Nothing>> {
+        log.warn(ex) { "Malformed request body: ${ex.mostSpecificCause.message}" }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error("Invalid request body"))
+    }
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgument(ex: IllegalArgumentException): ResponseEntity<ApiResponse<Nothing>> {

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
@@ -12,6 +12,7 @@ import io.bluetape4k.clinic.appointment.timezone.ClinicTimezoneService
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
+import jakarta.validation.Valid
 import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PatchMapping
@@ -58,7 +59,7 @@ class AppointmentController(
     }
 
     @PostMapping
-    fun create(@RequestBody request: CreateAppointmentRequest): ResponseEntity<ApiResponse<AppointmentResponse>> {
+    fun create(@Valid @RequestBody request: CreateAppointmentRequest): ResponseEntity<ApiResponse<AppointmentResponse>> {
         log.debug { "POST /api/appointments - patient=${request.patientName}" }
         val saved = appointmentService.create(request)
         val (timezone, locale) = timezoneService.getTimezoneAndLocale(saved.clinicId)
@@ -69,7 +70,7 @@ class AppointmentController(
     @PatchMapping("/{id}/status")
     suspend fun updateStatus(
         @PathVariable id: Long,
-        @RequestBody request: UpdateStatusRequest,
+        @Valid @RequestBody request: UpdateStatusRequest,
     ): ResponseEntity<ApiResponse<AppointmentResponse>> {
         log.debug { "PATCH /api/appointments/$id/status - target=${request.status}" }
         val updated = appointmentService.updateStatus(id, request.status, request.reason)

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentUnavailabilityController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentUnavailabilityController.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.clinic.appointment.api.controller
 
+import jakarta.validation.Valid
 import io.bluetape4k.clinic.appointment.api.dto.ApiResponse
 import io.bluetape4k.clinic.appointment.api.dto.ConflictingAppointmentResponse
 import io.bluetape4k.clinic.appointment.api.dto.CreateEquipmentUnavailabilityRequest
@@ -77,7 +78,7 @@ class EquipmentUnavailabilityController(
     fun create(
         @PathVariable clinicId: Long,
         @PathVariable equipmentId: Long,
-        @RequestBody request: CreateEquipmentUnavailabilityRequest,
+        @Valid @RequestBody request: CreateEquipmentUnavailabilityRequest,
     ): ResponseEntity<ApiResponse<EquipmentUnavailabilityRecord>> {
         clinicId.requirePositiveNumber("clinicId")
         equipmentId.requirePositiveNumber("equipmentId")
@@ -113,7 +114,7 @@ class EquipmentUnavailabilityController(
         @PathVariable clinicId: Long,
         @PathVariable equipmentId: Long,
         @PathVariable id: Long,
-        @RequestBody request: UpdateEquipmentUnavailabilityRequest,
+        @Valid @RequestBody request: UpdateEquipmentUnavailabilityRequest,
     ): ResponseEntity<ApiResponse<EquipmentUnavailabilityRecord>> {
         clinicId.requirePositiveNumber("clinicId")
         equipmentId.requirePositiveNumber("equipmentId")
@@ -172,7 +173,7 @@ class EquipmentUnavailabilityController(
         @PathVariable clinicId: Long,
         @PathVariable equipmentId: Long,
         @PathVariable id: Long,
-        @RequestBody request: UnavailabilityExceptionRequest,
+        @Valid @RequestBody request: UnavailabilityExceptionRequest,
     ): ResponseEntity<ApiResponse<EquipmentUnavailabilityExceptionRecord>> {
         clinicId.requirePositiveNumber("clinicId")
         equipmentId.requirePositiveNumber("equipmentId")
@@ -250,7 +251,7 @@ class EquipmentUnavailabilityController(
     fun previewConflicts(
         @PathVariable clinicId: Long,
         @PathVariable equipmentId: Long,
-        @RequestBody request: CreateEquipmentUnavailabilityRequest,
+        @Valid @RequestBody request: CreateEquipmentUnavailabilityRequest,
     ): ResponseEntity<ApiResponse<UnavailabilityConflictResponse>> {
         clinicId.requirePositiveNumber("clinicId")
         equipmentId.requirePositiveNumber("equipmentId")

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/CreateAppointmentRequest.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/CreateAppointmentRequest.kt
@@ -1,5 +1,9 @@
 package io.bluetape4k.clinic.appointment.api.dto
 
+import jakarta.validation.constraints.FutureOrPresent
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
+import jakarta.validation.constraints.Positive
 import java.io.Serializable
 import java.time.LocalDate
 import java.time.LocalTime
@@ -18,14 +22,22 @@ import java.time.LocalTime
  * @property endTime 예약 종료 시간
  */
 data class CreateAppointmentRequest(
+    @field:Positive
     val clinicId: Long,
+    @field:Positive
     val doctorId: Long,
+    @field:Positive
     val treatmentTypeId: Long,
     val equipmentId: Long? = null,
+    @field:NotBlank
     val patientName: String,
     val patientPhone: String? = null,
+    @field:NotNull
+    @field:FutureOrPresent
     val appointmentDate: LocalDate,
+    @field:NotNull
     val startTime: LocalTime,
+    @field:NotNull
     val endTime: LocalTime,
 ) : Serializable {
     companion object {

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/CreateEquipmentUnavailabilityRequest.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/CreateEquipmentUnavailabilityRequest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.clinic.appointment.api.dto
 
+import jakarta.validation.constraints.NotNull
 import java.io.Serializable
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -21,9 +22,12 @@ data class CreateEquipmentUnavailabilityRequest(
     val unavailableDate: LocalDate? = null,
     val isRecurring: Boolean = false,
     val recurringDayOfWeek: DayOfWeek? = null,
+    @field:NotNull
     val effectiveFrom: LocalDate,
     val effectiveUntil: LocalDate? = null,
+    @field:NotNull
     val startTime: LocalTime,
+    @field:NotNull
     val endTime: LocalTime,
     val reason: String? = null,
 ) : Serializable {

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UnavailabilityExceptionRequest.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UnavailabilityExceptionRequest.kt
@@ -1,6 +1,7 @@
 package io.bluetape4k.clinic.appointment.api.dto
 
 import io.bluetape4k.clinic.appointment.model.tables.ExceptionType
+import jakarta.validation.constraints.NotNull
 import java.io.Serializable
 import java.time.LocalDate
 import java.time.LocalTime
@@ -16,7 +17,9 @@ import java.time.LocalTime
  * @property reason 사유
  */
 data class UnavailabilityExceptionRequest(
+    @field:NotNull
     val originalDate: LocalDate,
+    @field:NotNull
     val exceptionType: ExceptionType,
     val rescheduledDate: LocalDate? = null,
     val rescheduledStartTime: LocalTime? = null,

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UpdateEquipmentUnavailabilityRequest.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UpdateEquipmentUnavailabilityRequest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.clinic.appointment.api.dto
 
+import jakarta.validation.constraints.NotNull
 import java.io.Serializable
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -21,9 +22,12 @@ data class UpdateEquipmentUnavailabilityRequest(
     val unavailableDate: LocalDate? = null,
     val isRecurring: Boolean = false,
     val recurringDayOfWeek: DayOfWeek? = null,
+    @field:NotNull
     val effectiveFrom: LocalDate,
     val effectiveUntil: LocalDate? = null,
+    @field:NotNull
     val startTime: LocalTime,
+    @field:NotNull
     val endTime: LocalTime,
     val reason: String? = null,
 ) : Serializable {

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UpdateStatusRequest.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/UpdateStatusRequest.kt
@@ -1,5 +1,6 @@
 package io.bluetape4k.clinic.appointment.api.dto
 
+import jakarta.validation.constraints.NotBlank
 import java.io.Serializable
 
 /**
@@ -9,6 +10,7 @@ import java.io.Serializable
  * @property reason 상태 변경 사유 (optional, 예: "임시휴진", "의사 확인 완료")
  */
 data class UpdateStatusRequest(
+    @field:NotBlank
     val status: String,
     val reason: String? = null,
 ) : Serializable {

--- a/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentControllerTest.kt
+++ b/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentControllerTest.kt
@@ -46,6 +46,7 @@ class AppointmentControllerTest @Autowired constructor() : AbstractApiIntegratio
 
     companion object : KLogging() {
         private const val BASE_URL = "/api/appointments"
+        private val futureDate: LocalDate = LocalDate.now().plusMonths(6)
     }
 
     @LocalServerPort
@@ -145,7 +146,7 @@ class AppointmentControllerTest @Autowired constructor() : AbstractApiIntegratio
                 "treatmentTypeId": $treatmentTypeId,
                 "patientName": "John Doe",
                 "patientPhone": "010-1234-5678",
-                "appointmentDate": "2026-04-06",
+                "appointmentDate": "$futureDate",
                 "startTime": "10:00",
                 "endTime": "10:30"
             }
@@ -163,6 +164,68 @@ class AppointmentControllerTest @Autowired constructor() : AbstractApiIntegratio
         response.jsonPath<String>("$.data.status") shouldBeEqualTo "REQUESTED"
         response.jsonPath<String>("$.data.timezone") shouldBeEqualTo "Asia/Seoul"
         response.jsonPath<String>("$.data.locale") shouldBeEqualTo "ko-KR"
+    }
+
+    @Test
+    fun `POST - return 400 when patientName is blank`() {
+        val body = """
+            {
+                "clinicId": $clinicId,
+                "doctorId": $doctorId,
+                "treatmentTypeId": $treatmentTypeId,
+                "patientName": "",
+                "appointmentDate": "$futureDate",
+                "startTime": "10:00",
+                "endTime": "10:30"
+            }
+        """.trimIndent()
+
+        val response = client.post()
+            .uri(BASE_URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(body)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.BAD_REQUEST
+        response.jsonPath<Boolean>("$.success").shouldBeFalse()
+    }
+
+    @Test
+    fun `POST - return 400 when clinicId is zero`() {
+        val body = """
+            {
+                "clinicId": 0,
+                "doctorId": $doctorId,
+                "treatmentTypeId": $treatmentTypeId,
+                "patientName": "John Doe",
+                "appointmentDate": "$futureDate",
+                "startTime": "10:00",
+                "endTime": "10:30"
+            }
+        """.trimIndent()
+
+        val response = client.post()
+            .uri(BASE_URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(body)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.BAD_REQUEST
+        response.jsonPath<Boolean>("$.success").shouldBeFalse()
+    }
+
+    @Test
+    fun `POST - return 400 when request body is malformed`() {
+        val body = """{ "clinicId": "not-a-number" }"""
+
+        val response = client.post()
+            .uri(BASE_URL)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(body)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.BAD_REQUEST
+        response.jsonPath<Boolean>("$.success").shouldBeFalse()
     }
 
     @Test
@@ -239,7 +302,7 @@ class AppointmentControllerTest @Autowired constructor() : AbstractApiIntegratio
 
         val response = client.get()
             .uri("$BASE_URL?clinicId={clinicId}&startDate={startDate}&endDate={endDate}",
-                clinicId, "2026-04-01", "2026-04-30")
+                clinicId, futureDate.withDayOfMonth(1), futureDate.withDayOfMonth(futureDate.lengthOfMonth()))
             .execute()
 
         response.statusCode shouldBeEqualTo HttpStatus.OK
@@ -302,7 +365,7 @@ class AppointmentControllerTest @Autowired constructor() : AbstractApiIntegratio
                 "doctorId": $expatDoctorId,
                 "treatmentTypeId": $expatTreatmentId,
                 "patientName": "김철수",
-                "appointmentDate": "2026-04-06",
+                "appointmentDate": "$futureDate",
                 "startTime": "10:00",
                 "endTime": "10:30"
             }
@@ -327,7 +390,7 @@ class AppointmentControllerTest @Autowired constructor() : AbstractApiIntegratio
                 it[Appointments.treatmentTypeId] = this@AppointmentControllerTest.treatmentTypeId
                 it[patientName] = "Jane Doe"
                 it[patientPhone] = "010-9876-5432"
-                it[appointmentDate] = LocalDate.of(2026, 4, 6)
+                it[appointmentDate] = futureDate
                 it[startTime] = LocalTime.of(11, 0)
                 it[endTime] = LocalTime.of(11, 30)
                 it[Appointments.status] = AppointmentState.REQUESTED

--- a/docs/lessons/2026-05-18-issue-92-valid-annotation.md
+++ b/docs/lessons/2026-05-18-issue-92-valid-annotation.md
@@ -1,0 +1,29 @@
+# Issue #92 — @Valid 어노테이션 누락 수정
+
+## 근본 원인
+
+Controller의 `@RequestBody` 파라미터에 `@Valid`가 없어서 DTO에 Bean Validation 제약 조건을 선언해도 실제로 검증이 실행되지 않았다. 잘못된 요청이 서비스 레이어까지 도달하여 예측 불가능한 에러를 유발했다.
+
+## 결정 사항
+
+1. 모든 `@RequestBody` 파라미터에 `@Valid` 추가 (6개)
+2. DTO에 적절한 제약 조건 어노테이션 추가 (`@Positive`, `@NotBlank`, `@NotNull`, `@FutureOrPresent`)
+3. `GlobalExceptionHandler`에 `MethodArgumentNotValidException` + `HttpMessageNotReadableException` 핸들러 추가
+4. Kotlin data class에서 `@field:` use-site target 필수 사용
+
+## 교훈
+
+### Kotlin data class + Bean Validation
+
+- Kotlin `data class` 생성자 프로퍼티에 어노테이션을 달 때 **`@field:`** 접두어가 없으면 어노테이션이 생성자 파라미터에만 적용되어 Bean Validation이 무시된다.
+- Non-nullable Kotlin 타입(`LocalDate`, `LocalTime` 등)에 `@field:NotNull`을 붙여도 Jackson이 먼저 실패하므로 `MethodArgumentNotValidException` 대신 `HttpMessageNotReadableException`이 발생한다. → 별도 핸들러 필요.
+
+### `@FutureOrPresent` 제약 조건의 테스트 영향
+
+- 테스트에서 고정 날짜를 사용하면 시간이 지남에 따라 `@FutureOrPresent`에 걸려 테스트가 실패할 수 있다.
+- 날짜를 충분히 미래로 설정하거나, `LocalDate.now().plusMonths(6)` 같은 동적 날짜 생성을 고려해야 한다.
+
+## 검증
+
+- 89개 테스트 통과 (3개 validation error-path 테스트 신규 추가)
+- Tier 4 리뷰: P0=0, P1=0 (HIGH 2건 즉시 수정 반영)


### PR DESCRIPTION
## Summary

Adds  annotation to all  parameters and Bean Validation constraint annotations to request DTOs, ensuring invalid input is rejected at the controller layer with proper 400 responses.

## Changes

- Add `@Valid` to all 6 `@RequestBody` parameters across `AppointmentController` and `EquipmentUnavailabilityController`
- Add `MethodArgumentNotValidException` handler → 400 with field-level error messages
- Add `HttpMessageNotReadableException` handler → 400 for malformed JSON
- Add validation annotations to DTOs:
  - `CreateAppointmentRequest`: `@Positive`, `@NotBlank`, `@NotNull`, `@FutureOrPresent`
  - `UpdateStatusRequest`: `@NotBlank` on status
  - `CreateEquipmentUnavailabilityRequest`: `@NotNull` on required fields
  - `UpdateEquipmentUnavailabilityRequest`: `@NotNull` on required fields
  - `UnavailabilityExceptionRequest`: `@NotNull` on originalDate, exceptionType
- Add 3 validation error-path integration tests
- Use dynamic future dates in tests to avoid date-bomb failures

## Test Results

```
./gradlew :appointment-api:test :appointment-core:test --no-configuration-cache
BUILD SUCCESSFUL in 22s
89 tests passing, 0 failed
```

## Verification

- [x] All tests passing
- [x] Tier 4 code review: P0=0, P1=0
- [x] Codex CLI review: P0=0, P1=0
- [x] Lessons committed

Closes #92