### PR TITLE
feat: add GET /api/appointments/{id}/history endpoint

### DIFF
--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.logging.debug
 import io.bluetape4k.clinic.appointment.api.dto.ApiResponse
 import io.bluetape4k.clinic.appointment.api.dto.AppointmentResponse
 import io.bluetape4k.clinic.appointment.api.dto.CreateAppointmentRequest
+import io.bluetape4k.clinic.appointment.api.dto.StateHistoryResponse
 import io.bluetape4k.clinic.appointment.api.dto.UpdateStatusRequest
 import io.bluetape4k.clinic.appointment.api.dto.toResponse
 import io.bluetape4k.clinic.appointment.api.service.AppointmentService
@@ -65,6 +66,13 @@ class AppointmentController(
         val (timezone, locale) = timezoneService.getTimezoneAndLocale(saved.clinicId)
         return ResponseEntity.status(HttpStatus.CREATED)
             .body(ApiResponse.ok(saved.toResponse(timezone, locale)))
+    }
+
+    @GetMapping("/{id}/history")
+    fun getHistory(@PathVariable id: Long): ResponseEntity<ApiResponse<List<StateHistoryResponse>>> {
+        log.debug { "GET /api/appointments/$id/history" }
+        val history = appointmentService.getStateHistory(id)
+        return ResponseEntity.ok(ApiResponse.ok(history.map { it.toResponse() }))
     }
 
     @PatchMapping("/{id}/status")

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/StateHistoryResponse.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/StateHistoryResponse.kt
@@ -1,0 +1,38 @@
+package io.bluetape4k.clinic.appointment.api.dto
+
+import io.bluetape4k.support.requireNotNull
+import io.bluetape4k.clinic.appointment.model.tables.AppointmentStateHistoryRecord
+import java.io.Serializable
+import java.time.Instant
+
+/**
+ * Appointment state history response for API consumers.
+ *
+ * @property id history entry ID
+ * @property appointmentId appointment ID
+ * @property fromState previous state name
+ * @property toState new state name
+ * @property reason state change reason
+ * @property changedAt timestamp of the state change
+ */
+data class StateHistoryResponse(
+    val id: Long,
+    val appointmentId: Long,
+    val fromState: String,
+    val toState: String,
+    val reason: String? = null,
+    val changedAt: Instant? = null,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+fun AppointmentStateHistoryRecord.toResponse() = StateHistoryResponse(
+    id = id.requireNotNull("id"),
+    appointmentId = appointmentId,
+    fromState = fromState.name,
+    toState = toState.name,
+    reason = reason,
+    changedAt = changedAt,
+)

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/AppointmentService.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/AppointmentService.kt
@@ -104,6 +104,15 @@ class AppointmentService(
             ?: throw NoSuchElementException("Appointment not found after status update: $id")
     }
 
+    fun getStateHistory(appointmentId: Long): List<AppointmentStateHistoryRecord> {
+        log.debug { "getStateHistory: appointmentId=$appointmentId" }
+        return transaction {
+            appointmentRepository.findByIdOrNull(appointmentId)
+                ?: throw NoSuchElementException("Appointment not found: $appointmentId")
+            stateHistoryRepository.findByAppointmentId(appointmentId)
+        }
+    }
+
     suspend fun cancel(id: Long, reason: String? = null): AppointmentRecord {
         log.debug { "cancel: id=$id, reason=$reason" }
         val record = transaction { appointmentRepository.findByIdOrNull(id) }

--- a/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentControllerTest.kt
+++ b/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentControllerTest.kt
@@ -284,6 +284,51 @@ class AppointmentControllerTest @Autowired constructor() : AbstractApiIntegratio
     }
 
     @Test
+    fun `GET - state history after status change`() {
+        val appointmentId = createTestAppointment()
+
+        client.patch()
+            .uri("$BASE_URL/{id}/status", appointmentId)
+            .contentType(MediaType.APPLICATION_JSON)
+            .body("""{"status": "CONFIRMED"}""")
+            .execute()
+
+        val response = client.get()
+            .uri("$BASE_URL/{id}/history", appointmentId)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.OK
+        response.jsonPath<Boolean>("$.success").shouldBeTrue()
+        val history = response.jsonPath<List<*>>("$.data").shouldNotBeNull()
+        history.shouldNotBeEmpty()
+        response.jsonPath<String>("$.data[0].fromState") shouldBeEqualTo "REQUESTED"
+        response.jsonPath<String>("$.data[0].toState") shouldBeEqualTo "CONFIRMED"
+    }
+
+    @Test
+    fun `GET - history returns empty list for new appointment`() {
+        val appointmentId = createTestAppointment()
+
+        val response = client.get()
+            .uri("$BASE_URL/{id}/history", appointmentId)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.OK
+        response.jsonPath<Boolean>("$.success").shouldBeTrue()
+        response.jsonPath<List<*>>("$.data").shouldNotBeNull().shouldBeEmpty()
+    }
+
+    @Test
+    fun `GET - history returns 404 for non-existent appointment`() {
+        val response = client.get()
+            .uri("$BASE_URL/{id}/history", 999999)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.NOT_FOUND
+        response.jsonPath<Boolean>("$.success").shouldBeFalse()
+    }
+
+    @Test
     fun `DELETE - cancel appointment`() {
         val appointmentId = createTestAppointment()
 

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentStateHistoryRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentStateHistoryRepository.kt
@@ -4,6 +4,7 @@ import io.bluetape4k.logging.KLogging
 import io.bluetape4k.clinic.appointment.model.tables.AppointmentStateHistory
 import io.bluetape4k.clinic.appointment.model.tables.AppointmentStateHistoryRecord
 import org.jetbrains.exposed.v1.core.ResultRow
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.insertAndGetId
 import org.jetbrains.exposed.v1.jdbc.selectAll
@@ -35,16 +36,16 @@ class AppointmentStateHistoryRepository {
     }
 
     /**
-     * 예약의 모든 상태 변경 이력을 조회합니다 (시간순).
+     * 예약의 모든 상태 변경 이력을 조회합니다 (최신순).
      *
      * @param appointmentId 예약 ID
-     * @return 상태 변경 이력 목록
+     * @return 상태 변경 이력 목록 (newest first)
      */
     fun findByAppointmentId(appointmentId: Long): List<AppointmentStateHistoryRecord> =
         AppointmentStateHistory
             .selectAll()
             .where { AppointmentStateHistory.appointmentId eq appointmentId }
-            .orderBy(AppointmentStateHistory.changedAt)
+            .orderBy(AppointmentStateHistory.changedAt to SortOrder.DESC, AppointmentStateHistory.id to SortOrder.DESC)
             .map { it.toRecord() }
 
     private fun ResultRow.toRecord() = AppointmentStateHistoryRecord(

--- a/docs/lessons/2026-05-18-issue-95-state-history-endpoint.md
+++ b/docs/lessons/2026-05-18-issue-95-state-history-endpoint.md
@@ -1,0 +1,33 @@
+# Issue #95: State History Endpoint
+
+## 요약
+
+예약 상태 변경 이력 조회 API (`GET /api/appointments/{id}/history`) 구현.
+
+## 핵심 결정
+
+1. **DTO 분리**: `AppointmentStateHistoryRecord`의 `AppointmentState` sealed class를 API에서 직접 노출하면
+   `{"name":"REQUESTED"}` 형태로 직렬화됨. `StateHistoryResponse` DTO를 만들어 `fromState`/`toState`를
+   `String`으로 평탄화하여 소비자 친화적 JSON 생성.
+
+2. **단일 트랜잭션**: 존재 확인 + 이력 조회를 별도 `transaction {}`으로 분리하면 race condition 가능.
+   하나의 트랜잭션으로 통합.
+
+3. **정렬 전략**: DB 레벨에서 `changedAt DESC, id DESC`로 정렬하여 동일 timestamp 내에서도
+   결정적 순서 보장. Kotlin 메모리 정렬 제거.
+
+4. **ID 검증**: persisted record의 `id`는 non-null이어야 하므로 `?: 0L` 대신
+   `requireNotNull("id")` 사용으로 silent failure 방지.
+
+## 리뷰 결과
+
+| Reviewer | P0 | P1 | P2 |
+|----------|----|----|-----|
+| Claude Code Tier 4 | 0 | 2 (fixed) | 3 |
+| Codex CLI | 0 | 1 (cross-cutting, deferred) | 1 (fixed) |
+
+- Codex P1 (clinic ownership check): 기존 모든 endpoint에 동일하게 부재. 별도 security issue로 분리 필요.
+
+## 검증
+
+- `./gradlew :appointment-api:test` — 15 tests, 0 failures, ~20s


### PR DESCRIPTION
## Summary

Adds state change history retrieval endpoint for appointments (closes #95).

## Changes

- **`StateHistoryResponse` DTO** — maps sealed class `AppointmentState` to flat String for clean JSON
- **`GET /api/appointments/{id}/history`** — returns descending-order history list
- **`AppointmentService.getStateHistory()`** — single-transaction existence check + history fetch
- **Repository sort** — `changedAt DESC, id DESC` for deterministic ordering
- **Integration tests** — history after status change, empty history for new appointment, 404 for non-existent

## Review Fixes Applied

- Merged double-transaction into single transaction (race window)
- `requireNotNull` instead of `?: 0L` for persisted ID
- DB-level DESC sort with secondary key (deterministic tie-breaking)

## Test Results

```
Module: :appointment-api
Tests:  15 passing, 0 failed, 0 skipped
Time:   ~20s
```

## Verification

```bash
./gradlew :appointment-api:test --no-configuration-cache
```