### PR TITLE
feat: add OpenAPI annotations to all controllers (#94)

### DIFF
--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt
@@ -10,6 +10,11 @@ import io.bluetape4k.clinic.appointment.api.dto.UpdateStatusRequest
 import io.bluetape4k.clinic.appointment.api.dto.toResponse
 import io.bluetape4k.clinic.appointment.api.service.AppointmentService
 import io.bluetape4k.clinic.appointment.timezone.ClinicTimezoneService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse as OApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -31,6 +36,7 @@ import java.time.LocalDate
  * @param appointmentService 예약 유스케이스 서비스
  * @param timezoneService 병원 타임존 조회 서비스
  */
+@Tag(name = "Appointments", description = "Appointment scheduling and management")
 @RestController
 @RequestMapping("/api/appointments")
 class AppointmentController(
@@ -39,11 +45,16 @@ class AppointmentController(
 ) {
     companion object : KLogging()
 
+    @Operation(summary = "Get appointments by date range")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @GetMapping
     fun getByDateRange(
         @RequestParam clinicId: Long,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate,
+        @Parameter(description = "Start date (ISO format)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) startDate: LocalDate,
+        @Parameter(description = "End date (ISO format)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) endDate: LocalDate,
     ): ResponseEntity<ApiResponse<List<AppointmentResponse>>> {
         log.debug { "GET /api/appointments?clinicId=$clinicId&startDate=$startDate&endDate=$endDate" }
         val records = appointmentService.getByDateRange(clinicId, startDate, endDate)
@@ -51,6 +62,11 @@ class AppointmentController(
         return ResponseEntity.ok(ApiResponse.ok(records.map { it.toResponse(timezone, locale) }))
     }
 
+    @Operation(summary = "Get appointment by ID")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "404", description = "Appointment not found"),
+    )
     @GetMapping("/{id}")
     fun getById(@PathVariable id: Long): ResponseEntity<ApiResponse<AppointmentResponse>> {
         log.debug { "GET /api/appointments/$id" }
@@ -59,6 +75,12 @@ class AppointmentController(
         return ResponseEntity.ok(ApiResponse.ok(record.toResponse(timezone, locale)))
     }
 
+    @Operation(summary = "Create a new appointment")
+    @ApiResponses(
+        OApiResponse(responseCode = "201", description = "Appointment created"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "409", description = "Scheduling conflict"),
+    )
     @PostMapping
     fun create(@Valid @RequestBody request: CreateAppointmentRequest): ResponseEntity<ApiResponse<AppointmentResponse>> {
         log.debug { "POST /api/appointments - patient=${request.patientName}" }
@@ -68,6 +90,11 @@ class AppointmentController(
             .body(ApiResponse.ok(saved.toResponse(timezone, locale)))
     }
 
+    @Operation(summary = "Get state change history for an appointment")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "404", description = "Appointment not found"),
+    )
     @GetMapping("/{id}/history")
     fun getHistory(@PathVariable id: Long): ResponseEntity<ApiResponse<List<StateHistoryResponse>>> {
         log.debug { "GET /api/appointments/$id/history" }
@@ -75,6 +102,13 @@ class AppointmentController(
         return ResponseEntity.ok(ApiResponse.ok(history.map { it.toResponse() }))
     }
 
+    @Operation(summary = "Update appointment status")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "404", description = "Appointment not found"),
+        OApiResponse(responseCode = "409", description = "Invalid state transition"),
+    )
     @PatchMapping("/{id}/status")
     suspend fun updateStatus(
         @PathVariable id: Long,
@@ -86,10 +120,16 @@ class AppointmentController(
         return ResponseEntity.ok(ApiResponse.ok(updated.toResponse(timezone, locale)))
     }
 
+    @Operation(summary = "Cancel an appointment")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "404", description = "Appointment not found"),
+        OApiResponse(responseCode = "409", description = "Invalid state transition"),
+    )
     @DeleteMapping("/{id}")
     suspend fun cancel(
         @PathVariable id: Long,
-        @RequestParam(required = false) reason: String?,
+        @Parameter(description = "Cancellation reason", required = false) @RequestParam(required = false) reason: String?,
     ): ResponseEntity<ApiResponse<AppointmentResponse>> {
         log.debug { "DELETE /api/appointments/$id reason=$reason" }
         val cancelled = appointmentService.cancel(id, reason)

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/ClinicController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/ClinicController.kt
@@ -10,6 +10,10 @@ import io.bluetape4k.exposed.core.ExposedPage
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.requirePositiveNumber
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse as OApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -25,6 +29,7 @@ import org.springframework.web.bind.annotation.RestController
  *
  * @param clinicRepository 병원 Repository
  */
+@Tag(name = "Clinics", description = "Clinic management")
 @RestController
 @RequestMapping("/api/clinics")
 class ClinicController(
@@ -39,6 +44,10 @@ class ClinicController(
      * @param size 페이지 크기 (default 20, max 100)
      * @return 페이징된 클리닉 목록
      */
+    @Operation(summary = "Get all clinics with pagination")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+    )
     @GetMapping
     fun getAll(
         @RequestParam(defaultValue = "0") page: Int,
@@ -57,6 +66,12 @@ class ClinicController(
      * @param clinicId 클리닉 ID
      * @return 클리닉 정보
      */
+    @Operation(summary = "Get clinic by ID")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "404", description = "Clinic not found"),
+    )
     @GetMapping("/{clinicId}")
     fun getById(
         @PathVariable clinicId: Long,
@@ -74,6 +89,11 @@ class ClinicController(
      * @param clinicId 클리닉 ID
      * @return 요일별 운영 시간 목록
      */
+    @Operation(summary = "Get operating hours for a clinic")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @GetMapping("/{clinicId}/operating-hours")
     fun getOperatingHours(
         @PathVariable clinicId: Long,
@@ -90,6 +110,11 @@ class ClinicController(
      * @param clinicId 클리닉 ID
      * @return 기본 휴식 시간 목록
      */
+    @Operation(summary = "Get default break times for a clinic")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @GetMapping("/{clinicId}/break-times")
     fun getBreakTimes(
         @PathVariable clinicId: Long,

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/DoctorController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/DoctorController.kt
@@ -10,6 +10,11 @@ import io.bluetape4k.exposed.core.ExposedPage
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.requirePositiveNumber
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse as OApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.springframework.format.annotation.DateTimeFormat
@@ -28,6 +33,7 @@ import java.time.LocalDate
  *
  * @param doctorRepository 의사 Repository
  */
+@Tag(name = "Doctors", description = "Doctor management")
 @RestController
 @RequestMapping("/api")
 class DoctorController(
@@ -43,6 +49,11 @@ class DoctorController(
      * @param size 페이지 크기 (default 20, max 100)
      * @return 페이징된 의사 목록
      */
+    @Operation(summary = "Get doctors by clinic with pagination")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @GetMapping("/clinics/{clinicId}/doctors")
     fun getByClinic(
         @PathVariable clinicId: Long,
@@ -63,6 +74,12 @@ class DoctorController(
      * @param doctorId 의사 ID
      * @return 의사 정보
      */
+    @Operation(summary = "Get doctor by ID")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "404", description = "Doctor not found"),
+    )
     @GetMapping("/doctors/{doctorId}")
     fun getById(
         @PathVariable doctorId: Long,
@@ -80,6 +97,11 @@ class DoctorController(
      * @param doctorId 의사 ID
      * @return 요일별 운영 스케줄 목록
      */
+    @Operation(summary = "Get schedules for a doctor")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @GetMapping("/doctors/{doctorId}/schedules")
     fun getSchedules(
         @PathVariable doctorId: Long,
@@ -98,11 +120,16 @@ class DoctorController(
      * @param to 조회 종료 날짜
      * @return 휴무 정보 목록
      */
+    @Operation(summary = "Get absences for a doctor within date range")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @GetMapping("/doctors/{doctorId}/absences")
     fun getAbsences(
         @PathVariable doctorId: Long,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+        @Parameter(description = "Start date (ISO format)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @Parameter(description = "End date (ISO format)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
     ): ResponseEntity<ApiResponse<List<DoctorAbsenceRecord>>> {
         doctorId.requirePositiveNumber("doctorId")
         log.debug { "GET absences doctorId=$doctorId, from=$from, to=$to" }

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentController.kt
@@ -8,6 +8,10 @@ import io.bluetape4k.exposed.core.ExposedPage
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.requirePositiveNumber
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse as OApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.springframework.http.ResponseEntity
@@ -24,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController
  *
  * @param equipmentRepository 장비 Repository
  */
+@Tag(name = "Equipments", description = "Equipment management")
 @RestController
 @RequestMapping("/api")
 class EquipmentController(
@@ -39,6 +44,11 @@ class EquipmentController(
      * @param size 페이지 크기 (default 20, max 100)
      * @return 페이징된 장비 목록
      */
+    @Operation(summary = "Get equipments by clinic with pagination")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @GetMapping("/clinics/{clinicId}/equipments")
     fun getByClinic(
         @PathVariable clinicId: Long,
@@ -59,6 +69,12 @@ class EquipmentController(
      * @param equipmentId 장비 ID
      * @return 장비 정보
      */
+    @Operation(summary = "Get equipment by ID")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "404", description = "Equipment not found"),
+    )
     @GetMapping("/equipments/{equipmentId}")
     fun getById(
         @PathVariable equipmentId: Long,

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentUnavailabilityController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/EquipmentUnavailabilityController.kt
@@ -14,6 +14,11 @@ import io.bluetape4k.clinic.appointment.service.EquipmentUnavailabilityService
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.requirePositiveNumber
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse as OApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -36,6 +41,7 @@ import java.time.LocalDate
  *
  * @param service 장비 사용불가 서비스
  */
+@Tag(name = "Equipment Unavailability", description = "Equipment unavailability schedule management")
 @RestController
 @RequestMapping("/api/clinics/{clinicId}/equipments/{equipmentId}/unavailabilities")
 class EquipmentUnavailabilityController(
@@ -52,12 +58,17 @@ class EquipmentUnavailabilityController(
      * @param to 조회 종료 날짜
      * @return 사용불가 스케줄 목록
      */
+    @Operation(summary = "Get equipment unavailability schedules")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @GetMapping
     fun getUnavailabilities(
         @PathVariable clinicId: Long,
         @PathVariable equipmentId: Long,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
+        @Parameter(description = "Start date (ISO format)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate,
+        @Parameter(description = "End date (ISO format)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate,
     ): ResponseEntity<ApiResponse<List<EquipmentUnavailabilityRecord>>> {
         clinicId.requirePositiveNumber("clinicId")
         equipmentId.requirePositiveNumber("equipmentId")
@@ -74,6 +85,11 @@ class EquipmentUnavailabilityController(
      * @param request 사용불가 스케줄 생성 요청
      * @return 생성된 사용불가 스케줄
      */
+    @Operation(summary = "Create equipment unavailability schedule")
+    @ApiResponses(
+        OApiResponse(responseCode = "201", description = "Created"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @PostMapping
     fun create(
         @PathVariable clinicId: Long,
@@ -109,6 +125,12 @@ class EquipmentUnavailabilityController(
      * @param request 수정 요청
      * @return 수정된 사용불가 스케줄
      */
+    @Operation(summary = "Update equipment unavailability schedule")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "404", description = "Unavailability not found"),
+    )
     @PutMapping("/{id}")
     fun update(
         @PathVariable clinicId: Long,
@@ -145,6 +167,12 @@ class EquipmentUnavailabilityController(
      * @param id 사용불가 스케줄 ID
      * @return 204 No Content
      */
+    @Operation(summary = "Delete equipment unavailability schedule")
+    @ApiResponses(
+        OApiResponse(responseCode = "204", description = "Deleted"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "404", description = "Unavailability not found"),
+    )
     @DeleteMapping("/{id}")
     fun delete(
         @PathVariable clinicId: Long,
@@ -168,6 +196,12 @@ class EquipmentUnavailabilityController(
      * @param request 예외 처리 요청
      * @return 생성된 예외 레코드
      */
+    @Operation(summary = "Add exception to unavailability schedule")
+    @ApiResponses(
+        OApiResponse(responseCode = "201", description = "Created"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "404", description = "Unavailability not found"),
+    )
     @PostMapping("/{id}/exceptions")
     fun addException(
         @PathVariable clinicId: Long,
@@ -200,6 +234,12 @@ class EquipmentUnavailabilityController(
      * @param exId 예외 ID
      * @return 204 No Content
      */
+    @Operation(summary = "Delete unavailability exception")
+    @ApiResponses(
+        OApiResponse(responseCode = "204", description = "Deleted"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "404", description = "Exception not found"),
+    )
     @DeleteMapping("/{id}/exceptions/{exId}")
     fun deleteException(
         @PathVariable clinicId: Long,
@@ -224,6 +264,12 @@ class EquipmentUnavailabilityController(
      * @param id 사용불가 스케줄 ID
      * @return 충돌 예약 목록
      */
+    @Operation(summary = "Detect conflicting appointments")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "404", description = "Unavailability not found"),
+    )
     @GetMapping("/{id}/conflicts")
     fun detectConflicts(
         @PathVariable clinicId: Long,
@@ -247,6 +293,11 @@ class EquipmentUnavailabilityController(
      * @param request 사용불가 스케줄 생성 요청
      * @return 충돌 예약 미리보기
      */
+    @Operation(summary = "Preview conflicts before creating unavailability")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @PostMapping("/preview-conflicts")
     fun previewConflicts(
         @PathVariable clinicId: Long,

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleController.kt
@@ -8,6 +8,11 @@ import io.bluetape4k.clinic.appointment.api.dto.toResponse
 import io.bluetape4k.clinic.appointment.model.tables.RescheduleCandidates
 import io.bluetape4k.clinic.appointment.repository.toRescheduleCandidateRecord
 import io.bluetape4k.clinic.appointment.service.ClosureRescheduleService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse as OApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.selectAll
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
@@ -29,6 +34,7 @@ import java.time.LocalDate
  *
  * @param closureRescheduleService 휴진 재배정 서비스
  */
+@Tag(name = "Reschedule", description = "Appointment rescheduling")
 @RestController
 @RequestMapping("/api/appointments/{id}/reschedule")
 class RescheduleController(
@@ -48,12 +54,17 @@ class RescheduleController(
      * @param searchDays 재배정 검색 기간 (기본값: 7일)
      * @return 예약별 재배정 후보 목록 (Map: appointmentId -> 후보 슬롯 목록)
      */
+    @Operation(summary = "Process closure reschedule for affected appointments")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @PostMapping("/closure")
     fun processClosureReschedule(
         @PathVariable id: Long,
         @RequestParam clinicId: Long,
         @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) closureDate: LocalDate,
-        @RequestParam(defaultValue = "7") searchDays: Int,
+        @Parameter(description = "Number of days to search for alternative slots") @RequestParam(defaultValue = "7") searchDays: Int,
     ): ResponseEntity<ApiResponse<Map<Long, List<RescheduleCandidateResponse>>>> {
         log.debug { "POST /api/appointments/$id/reschedule/closure - clinic=$clinicId, date=$closureDate" }
         val result = closureRescheduleService.processClosureReschedule(clinicId, closureDate, searchDays)
@@ -71,6 +82,11 @@ class RescheduleController(
      * @param id 원본 예약 ID
      * @return 재배정 후보 목록
      */
+    @Operation(summary = "Get reschedule candidates for an appointment")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "404", description = "Appointment not found"),
+    )
     @GetMapping("/candidates")
     fun getCandidates(
         @PathVariable id: Long,
@@ -96,6 +112,12 @@ class RescheduleController(
      * @param candidateId 선택한 재배정 후보 ID
      * @return 생성된 새로운 예약 ID
      */
+    @Operation(summary = "Confirm a reschedule with selected candidate")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "404", description = "Candidate not found"),
+    )
     @PostMapping("/confirm/{candidateId}")
     fun confirmReschedule(
         @PathVariable id: Long,
@@ -115,6 +137,11 @@ class RescheduleController(
      * @param id 원본 예약 ID
      * @return 생성된 새로운 예약 ID (없으면 null)
      */
+    @Operation(summary = "Auto-reschedule using best available candidate")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "404", description = "Appointment not found"),
+    )
     @PostMapping("/auto")
     fun autoReschedule(
         @PathVariable id: Long,

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/SlotController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/SlotController.kt
@@ -7,6 +7,11 @@ import io.bluetape4k.clinic.appointment.api.dto.SlotResponse
 import io.bluetape4k.clinic.appointment.api.dto.toResponse
 import io.bluetape4k.clinic.appointment.service.SlotCalculationService
 import io.bluetape4k.clinic.appointment.model.service.SlotQuery
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse as OApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -24,6 +29,7 @@ import java.time.LocalDate
  *
  * @param slotCalculationService 가용 슬롯 계산 서비스
  */
+@Tag(name = "Slots", description = "Available time slot queries")
 @RestController
 @RequestMapping("/api/clinics/{clinicId}/slots")
 class SlotController(
@@ -44,13 +50,18 @@ class SlotController(
      * @param requestedDurationMinutes 요청한 진료 시간 (분, optional)
      * @return 가용 슬롯 목록
      */
+    @Operation(summary = "Get available appointment slots")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @GetMapping
     fun getAvailableSlots(
         @PathVariable clinicId: Long,
         @RequestParam doctorId: Long,
         @RequestParam treatmentTypeId: Long,
-        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
-        @RequestParam(required = false) requestedDurationMinutes: Int? = null,
+        @Parameter(description = "Target date (ISO format)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) date: LocalDate,
+        @Parameter(description = "Requested duration in minutes", required = false) @RequestParam(required = false) requestedDurationMinutes: Int? = null,
     ): ResponseEntity<ApiResponse<List<SlotResponse>>> {
         log.debug { "GET /api/clinics/$clinicId/slots - doctor=$doctorId, treatment=$treatmentTypeId, date=$date" }
         val query = SlotQuery(

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/TreatmentTypeController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/TreatmentTypeController.kt
@@ -8,6 +8,10 @@ import io.bluetape4k.exposed.core.ExposedPage
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.support.requirePositiveNumber
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.responses.ApiResponse as OApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 import org.springframework.http.ResponseEntity
@@ -24,6 +28,7 @@ import org.springframework.web.bind.annotation.RestController
  *
  * @param treatmentTypeRepository 진료 유형 Repository
  */
+@Tag(name = "Treatment Types", description = "Treatment type management")
 @RestController
 @RequestMapping("/api")
 class TreatmentTypeController(
@@ -39,6 +44,11 @@ class TreatmentTypeController(
      * @param size 페이지 크기 (default 20, max 100)
      * @return 페이징된 진료 유형 목록
      */
+    @Operation(summary = "Get treatment types by clinic with pagination")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
     @GetMapping("/clinics/{clinicId}/treatment-types")
     fun getByClinic(
         @PathVariable clinicId: Long,
@@ -59,6 +69,12 @@ class TreatmentTypeController(
      * @param treatmentTypeId 진료 유형 ID
      * @return 진료 유형 정보
      */
+    @Operation(summary = "Get treatment type by ID")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+        OApiResponse(responseCode = "404", description = "Treatment type not found"),
+    )
     @GetMapping("/treatment-types/{treatmentTypeId}")
     fun getById(
         @PathVariable treatmentTypeId: Long,

--- a/docs/lessons/2026-05-18-issue-94-openapi-annotations.md
+++ b/docs/lessons/2026-05-18-issue-94-openapi-annotations.md
@@ -1,0 +1,31 @@
+# Issue #94 — OpenAPI Annotations
+
+## 날짜: 2026-05-18
+
+## 요약
+
+8개 controller 전체에 `@Tag`, `@Operation`, `@ApiResponses`, `@Parameter` 추가.
+
+## 주요 교훈
+
+### 1. Import 충돌 해결
+
+프로젝트에 이미 `io.bluetape4k.clinic.appointment.api.dto.ApiResponse`가 존재하므로
+Swagger의 `io.swagger.v3.oas.annotations.responses.ApiResponse`를 `OApiResponse`로
+alias import하여 충돌 방지.
+
+### 2. 어노테이션 배치 순서
+
+```kotlin
+@Operation(summary = "...")   // OpenAPI docs
+@ApiResponses(...)            // HTTP response codes
+@GetMapping("/path")          // Spring mapping
+fun method(...)
+```
+
+기존 KDoc은 유지. `@Tag`는 클래스 레벨에서 `@RestController` 위에 배치.
+
+### 3. @Parameter 선별적 적용
+
+모든 파라미터에 `@Parameter`를 붙이면 noise. 날짜(ISO format), searchDays, 
+optional reason 등 의미가 불분명한 것에만 적용.


### PR DESCRIPTION
## Summary

Adds `@Tag`, `@Operation`, `@ApiResponses`, and `@Parameter` OpenAPI annotations to all 8 controllers so Swagger UI renders documented endpoints.

Closes #94

## Changes

| Controller | Tag | Endpoints |
|-----------|-----|-----------|
| ClinicController | Clinics | 4 |
| DoctorController | Doctors | 4 |
| EquipmentController | Equipments | 2 |
| TreatmentTypeController | Treatment Types | 2 |
| AppointmentController | Appointments | 6 |
| RescheduleController | Reschedule | 4 |
| SlotController | Slots | 1 |
| EquipmentUnavailabilityController | Equipment Unavailability | 8 |

### Details
- `@Tag` at class level for Swagger UI grouping
- `@Operation(summary)` on each public endpoint
- `@ApiResponses` with applicable HTTP status codes (200, 201, 204, 400, 404, 409)
- `@Parameter` for non-obvious query params (dates, searchDays, reason, requestedDurationMinutes)
- Aliased import (`OApiResponse`) to avoid conflict with project DTO

## Verification

```
./gradlew :appointment-api:test
BUILD SUCCESSFUL — 92 tests passing, 0 failed
```

Swagger UI at `/swagger-ui/index.html` will now show grouped, documented endpoints.

## Commits

- feat: add OpenAPI annotations to all controllers (#94)
- docs: add lessons learned for issue #94 OpenAPI annotations