### PR TITLE
feat: add environment.ts and inject apiUrl into all Angular services

### DIFF
--- a/docs/lessons/2026-05-18-issue-48-environment-config.md
+++ b/docs/lessons/2026-05-18-issue-48-environment-config.md
@@ -1,0 +1,34 @@
+# Issue #48 — Angular environment.ts API baseUrl injection
+
+## Root Cause
+
+All Angular services had `/api/...` baseUrl hardcoded as string literals,
+making it impossible to change the API root URL at build time for different
+deployment targets.
+
+## Decision
+
+Introduce Angular's standard environment file pattern:
+- `src/environments/environment.ts` — development (production: false)
+- `src/environments/environment.prod.ts` — production (production: true)
+- `angular.json` fileReplacements to swap files at `--configuration=production`
+- All service `baseUrl` fields replaced with `${environment.apiUrl}/...`
+
+Both files intentionally use `apiUrl: '/api'` (relative path) so that:
+- Dev uses the Angular proxy (`proxy.conf.json`) to forward `/api` → backend
+- Prod uses Nginx/reverse proxy to forward `/api` → backend
+- Future deployments can change only `environment.prod.ts` to use an absolute URL
+
+## Outcome
+
+- `ng build --configuration=development` ✅
+- `ng build --configuration=production` ✅ (fileReplacements applied)
+- 8 pre-existing spec failures unrelated to this change (response-shape mismatch
+  in `HttpTestingController` specs — tracked separately)
+
+## Future Guidance
+
+- When adding new Angular services, always use `environment.apiUrl` as the base,
+  never hardcode `/api`.
+- If spec files still use hardcoded URL strings in `httpTesting.expectOne()`,
+  update them to use `environment.apiUrl` to avoid silent drift when the URL changes.

--- a/frontend/appointment-frontend/angular.json
+++ b/frontend/appointment-frontend/angular.json
@@ -35,6 +35,12 @@
           },
           "configurations": {
             "production": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/environment.prod.ts"
+                }
+              ],
               "budgets": [
                 {
                   "type": "initial",

--- a/frontend/appointment-frontend/src/app/core/services/appointment.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/appointment.service.ts
@@ -2,11 +2,12 @@ import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ApiResponse, Appointment, CreateAppointmentRequest, UpdateStatusRequest } from '../models';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class AppointmentService {
   private readonly http = inject(HttpClient);
-  private readonly baseUrl = '/api/appointments';
+  private readonly baseUrl = `${environment.apiUrl}/appointments`;
 
   private readonly _appointments = signal<Appointment[]>([]);
   readonly appointments = this._appointments.asReadonly();

--- a/frontend/appointment-frontend/src/app/core/services/clinic.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/clinic.service.ts
@@ -2,11 +2,12 @@ import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ApiResponse, Clinic, ClinicBreakTime, OperatingHours, PagedData } from '../models';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class ClinicService {
   private readonly http = inject(HttpClient);
-  private readonly baseUrl = '/api/clinics';
+  private readonly baseUrl = `${environment.apiUrl}/clinics`;
 
   private readonly _clinics = signal<Clinic[]>([]);
   readonly clinics = this._clinics.asReadonly();

--- a/frontend/appointment-frontend/src/app/core/services/doctor.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/doctor.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ApiResponse, Doctor, DoctorAbsence, DoctorSchedule, PagedData } from '../models';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class DoctorService {
@@ -17,7 +18,7 @@ export class DoctorService {
     try {
       const res = await firstValueFrom(
         this.http.get<ApiResponse<PagedData<Doctor>>>(
-          `/api/clinics/${clinicId}/doctors`
+          `${environment.apiUrl}/clinics/${clinicId}/doctors`
         )
       );
       const data = res.data?.content ?? [];
@@ -30,7 +31,7 @@ export class DoctorService {
 
   async getById(doctorId: number): Promise<Doctor> {
     const res = await firstValueFrom(
-      this.http.get<ApiResponse<Doctor>>(`/api/doctors/${doctorId}`)
+      this.http.get<ApiResponse<Doctor>>(`${environment.apiUrl}/doctors/${doctorId}`)
     );
     return res.data!;
   }
@@ -38,7 +39,7 @@ export class DoctorService {
   async getSchedules(doctorId: number): Promise<DoctorSchedule[]> {
     const res = await firstValueFrom(
       this.http.get<ApiResponse<DoctorSchedule[]>>(
-        `/api/doctors/${doctorId}/schedules`
+        `${environment.apiUrl}/doctors/${doctorId}/schedules`
       )
     );
     return res.data ?? [];
@@ -50,7 +51,7 @@ export class DoctorService {
       .set('to', to);
     const res = await firstValueFrom(
       this.http.get<ApiResponse<DoctorAbsence[]>>(
-        `/api/doctors/${doctorId}/absences`,
+        `${environment.apiUrl}/doctors/${doctorId}/absences`,
         { params }
       )
     );

--- a/frontend/appointment-frontend/src/app/core/services/equipment-unavailability.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/equipment-unavailability.service.ts
@@ -10,13 +10,14 @@ import {
   UnavailabilityExceptionRequest,
   UpdateEquipmentUnavailabilityRequest,
 } from '../models';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class EquipmentUnavailabilityService {
   private readonly http = inject(HttpClient);
 
   private baseUrl(clinicId: number, equipmentId: number): string {
-    return `/api/clinics/${clinicId}/equipments/${equipmentId}/unavailabilities`;
+    return `${environment.apiUrl}/clinics/${clinicId}/equipments/${equipmentId}/unavailabilities`;
   }
 
   /** 사용불가 스케줄 목록 조회 (E1) */

--- a/frontend/appointment-frontend/src/app/core/services/equipment.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/equipment.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ApiResponse, Equipment, PagedData } from '../models';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class EquipmentService {
@@ -17,7 +18,7 @@ export class EquipmentService {
     try {
       const res = await firstValueFrom(
         this.http.get<ApiResponse<PagedData<Equipment>>>(
-          `/api/clinics/${clinicId}/equipments`
+          `${environment.apiUrl}/clinics/${clinicId}/equipments`
         )
       );
       const data = res.data?.content ?? [];
@@ -30,7 +31,7 @@ export class EquipmentService {
 
   async getById(equipmentId: number): Promise<Equipment> {
     const res = await firstValueFrom(
-      this.http.get<ApiResponse<Equipment>>(`/api/equipments/${equipmentId}`)
+      this.http.get<ApiResponse<Equipment>>(`${environment.apiUrl}/equipments/${equipmentId}`)
     );
     return res.data!;
   }

--- a/frontend/appointment-frontend/src/app/core/services/reschedule.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/reschedule.service.ts
@@ -2,11 +2,12 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ApiResponse, RescheduleCandidate } from '../models';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class RescheduleService {
   private readonly http = inject(HttpClient);
-  private readonly baseUrl = '/api/appointments';
+  private readonly baseUrl = `${environment.apiUrl}/appointments`;
 
   /**
    * 진료실 휴진 일괄 재배정 후보 조회 (R1)

--- a/frontend/appointment-frontend/src/app/core/services/slot.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/slot.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ApiResponse, AvailableSlot } from '../models';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class SlotService {
@@ -25,7 +26,7 @@ export class SlotService {
 
     const res = await firstValueFrom(
       this.http.get<ApiResponse<AvailableSlot[]>>(
-        `/api/clinics/${clinicId}/slots`,
+        `${environment.apiUrl}/clinics/${clinicId}/slots`,
         { params }
       )
     );

--- a/frontend/appointment-frontend/src/app/core/services/treatment-type.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/treatment-type.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { firstValueFrom } from 'rxjs';
 import { ApiResponse, PagedData, TreatmentType } from '../models';
+import { environment } from '../../../environments/environment';
 
 @Injectable({ providedIn: 'root' })
 export class TreatmentTypeService {
@@ -17,7 +18,7 @@ export class TreatmentTypeService {
     try {
       const res = await firstValueFrom(
         this.http.get<ApiResponse<PagedData<TreatmentType>>>(
-          `/api/clinics/${clinicId}/treatment-types`
+          `${environment.apiUrl}/clinics/${clinicId}/treatment-types`
         )
       );
       const data = res.data?.content ?? [];
@@ -31,7 +32,7 @@ export class TreatmentTypeService {
   async getById(treatmentTypeId: number): Promise<TreatmentType> {
     const res = await firstValueFrom(
       this.http.get<ApiResponse<TreatmentType>>(
-        `/api/treatment-types/${treatmentTypeId}`
+        `${environment.apiUrl}/treatment-types/${treatmentTypeId}`
       )
     );
     return res.data!;

--- a/frontend/appointment-frontend/src/environments/environment.prod.ts
+++ b/frontend/appointment-frontend/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiUrl: '/api',
+};

--- a/frontend/appointment-frontend/src/environments/environment.ts
+++ b/frontend/appointment-frontend/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiUrl: '/api',
+};


### PR DESCRIPTION
## Summary

Introduces Angular's standard environment file pattern to replace hardcoded `/api/` prefixes across all services.

## Changes

### New files
- `src/environments/environment.ts` — dev config (`production: false`, `apiUrl: '/api'`)
- `src/environments/environment.prod.ts` — prod config (`production: true`, `apiUrl: '/api'`)

### Modified files
- `angular.json` — `fileReplacements` added for `--configuration=production`
- 8 service files — `baseUrl` replaced with `${environment.apiUrl}/...`

## Why both environments use `/api`

Relative path intentionally — dev uses Angular proxy, prod uses Nginx reverse proxy. Future absolute URL change only requires editing `environment.prod.ts`.

## Test Results

```
ng build --configuration=development  — BUILD SUCCESSFUL
ng build --configuration=production   — BUILD SUCCESSFUL
```

8 pre-existing spec failures (HttpTestingController response-shape mismatch) are unrelated to this change.

## DoD Checklist

| Item | Status |
|------|--------|
| dev build passing | ✅ |
| prod build passing | ✅ |
| All services use environment.apiUrl | ✅ |
| Tier 4 code review (CRITICAL/HIGH 0) | ✅ |
| Codex CLI review (CRITICAL/HIGH 0) | ✅ |
| Lessons committed | ✅ |

Closes #48