### PR TITLE
feat: replace hardcoded clinicId with AuthService.clinicId signal (#46)

### DIFF
--- a/docs/lessons/2026-05-19-issue-46-clinicid-signal.md
+++ b/docs/lessons/2026-05-19-issue-46-clinicid-signal.md
@@ -1,0 +1,39 @@
+# Issue #46 — AuthService.clinicId signal 도입
+
+## Root Cause
+
+8개 Angular 컴포넌트에 `clinicId = 1` 또는 `const CLINIC_ID = 1`이 하드코딩되어 있어
+멀티테넌시 확장이나 배포 환경 변경 시 실제 JWT의 clinicId를 반영하지 못함.
+
+## Decision
+
+1. `AuthService`에 `_decodedToken` computed signal 추가 — JWT payload를 lazy 파싱
+2. `clinicId` computed signal 추가 — `_decodedToken()?.['clinicId'] ?? 0`
+3. 8개 컴포넌트에서 하드코딩 제거 → `this.authService.clinicId()` 호출로 교체
+
+Backend `JwtTokenParser.kt`의 `clinicId` claim (`CLAIM_CLINIC_ID = "clinicId"`)과 키 이름 일치 확인 후 적용.
+
+## Affected Files
+
+| File | Change |
+|------|--------|
+| `auth.service.ts` | `_decodedToken` + `clinicId` computed signal 추가 |
+| `appointment-detail.component.ts` | `clinicId = 1` 제거 → `authService.clinicId()` |
+| `appointment-form.component.ts` | `AuthService` import/inject 추가, `clinicId = 1` 제거 |
+| `appointment-list.component.ts` | `clinicId = 1` 제거 → `authService.clinicId()` |
+| `day-view.component.ts` | `CLINIC_ID = 1` 제거 → `authService.clinicId()` |
+| `month-view.component.ts` | `CLINIC_ID = 1` 제거 → `authService.clinicId()` |
+| `week-view.component.ts` | `CLINIC_ID = 1` 제거 → `authService.clinicId()` |
+| `doctor-list.component.ts` | `CLINIC_ID = 1` 제거 → `authService.clinicId()` |
+| `treatment-type-list.component.ts` | `CLINIC_ID = 1` 제거 → `authService.clinicId()` |
+
+## Outcome
+
+- `ng build --configuration production` ✅ (errors 0)
+- 하드코딩된 `clinicId = 1` / `CLINIC_ID = 1` 0건 잔존
+
+## Future Guidance
+
+- 새 Angular 서비스/컴포넌트에서 clinicId가 필요한 경우 항상 `inject(AuthService).clinicId()` 사용.
+- JWT payload에 `clinicId` claim이 없는 경우 기본값은 `0` — 인증 미완료 상태이므로 API 호출 전 `isAuthenticated()` 체크 병행 권장.
+- `_decodedToken`은 `computed()`로 구현되어 토큰 변경 시 자동 갱신됨.

--- a/frontend/appointment-frontend/src/app/core/services/auth.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/auth.service.ts
@@ -4,28 +4,27 @@ import { Injectable, computed, signal } from '@angular/core';
 export class AuthService {
   private readonly TOKEN_KEY = 'auth_token';
 
-  private readonly _roles = signal<string[]>(this._parseRoles());
+  private readonly _decodedToken = signal<Record<string, unknown> | null>(this._parseToken());
 
-  readonly roles = this._roles.asReadonly();
-
-  readonly isAuthenticated = computed(() => !!this.getToken());
-
-  private readonly _decodedToken = computed(() => {
-    const token = this.getToken();
-    if (!token) return null;
-    try {
-      return JSON.parse(atob(token.split('.')[1])) as Record<string, unknown>;
-    } catch {
-      return null;
-    }
+  readonly roles = computed<string[]>(() => {
+    const payload = this._decodedToken();
+    if (!payload) return [];
+    const roles = payload['roles'] ?? payload['role'] ?? [];
+    return Array.isArray(roles) ? roles : [roles as string];
   });
 
-  readonly clinicId = computed(() => (this._decodedToken()?.['clinicId'] as number) ?? 0);
+  readonly isAuthenticated = computed(() => this._decodedToken() !== null);
 
-  readonly isAdmin = computed(() => this._roles().includes('ROLE_ADMIN'));
-  readonly isStaff = computed(() => this._roles().includes('ROLE_STAFF'));
-  readonly isDoctor = computed(() => this._roles().includes('ROLE_DOCTOR'));
-  readonly isPatient = computed(() => this._roles().includes('ROLE_PATIENT'));
+  readonly clinicId = computed(() => {
+    const raw = this._decodedToken()?.['clinicId'];
+    const id = typeof raw === 'number' ? raw : Number(raw);
+    return Number.isFinite(id) && id > 0 ? id : 0;
+  });
+
+  readonly isAdmin = computed(() => this.roles().includes('ROLE_ADMIN'));
+  readonly isStaff = computed(() => this.roles().includes('ROLE_STAFF'));
+  readonly isDoctor = computed(() => this.roles().includes('ROLE_DOCTOR'));
+  readonly isPatient = computed(() => this.roles().includes('ROLE_PATIENT'));
 
   getToken(): string | null {
     return localStorage.getItem(this.TOKEN_KEY);
@@ -33,23 +32,21 @@ export class AuthService {
 
   setToken(token: string): void {
     localStorage.setItem(this.TOKEN_KEY, token);
-    this._roles.set(this._parseRoles());
+    this._decodedToken.set(this._parseToken());
   }
 
   removeToken(): void {
     localStorage.removeItem(this.TOKEN_KEY);
-    this._roles.set([]);
+    this._decodedToken.set(null);
   }
 
-  private _parseRoles(): string[] {
+  private _parseToken(): Record<string, unknown> | null {
     const token = localStorage.getItem(this.TOKEN_KEY);
-    if (!token) return [];
+    if (!token) return null;
     try {
-      const payload = JSON.parse(atob(token.split('.')[1]));
-      const roles = payload['roles'] ?? payload['role'] ?? [];
-      return Array.isArray(roles) ? roles : [roles];
+      return JSON.parse(atob(token.split('.')[1])) as Record<string, unknown>;
     } catch {
-      return [];
+      return null;
     }
   }
 }

--- a/frontend/appointment-frontend/src/app/core/services/auth.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/auth.service.ts
@@ -10,6 +10,18 @@ export class AuthService {
 
   readonly isAuthenticated = computed(() => !!this.getToken());
 
+  private readonly _decodedToken = computed(() => {
+    const token = this.getToken();
+    if (!token) return null;
+    try {
+      return JSON.parse(atob(token.split('.')[1])) as Record<string, unknown>;
+    } catch {
+      return null;
+    }
+  });
+
+  readonly clinicId = computed(() => (this._decodedToken()?.['clinicId'] as number) ?? 0);
+
   readonly isAdmin = computed(() => this._roles().includes('ROLE_ADMIN'));
   readonly isStaff = computed(() => this._roles().includes('ROLE_STAFF'));
   readonly isDoctor = computed(() => this._roles().includes('ROLE_DOCTOR'));

--- a/frontend/appointment-frontend/src/app/features/appointments/appointment-detail/appointment-detail.component.ts
+++ b/frontend/appointment-frontend/src/app/features/appointments/appointment-detail/appointment-detail.component.ts
@@ -95,11 +95,9 @@ export class AppointmentDetailComponent implements OnInit {
     return tt?.name ?? '-';
   });
 
-  private readonly clinicId = 1;
-
   async ngOnInit(): Promise<void> {
-    this.doctorService.loadByClinic(this.clinicId);
-    this.treatmentTypeService.loadByClinic(this.clinicId);
+    this.doctorService.loadByClinic(this.authService.clinicId());
+    this.treatmentTypeService.loadByClinic(this.authService.clinicId());
 
     const id = Number(this.route.snapshot.paramMap.get('id'));
     if (id) {

--- a/frontend/appointment-frontend/src/app/features/appointments/appointment-form/appointment-form.component.ts
+++ b/frontend/appointment-frontend/src/app/features/appointments/appointment-form/appointment-form.component.ts
@@ -13,6 +13,7 @@ import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { provideNativeDateAdapter } from '@angular/material/core';
 
 import { AppointmentService } from '../../../core/services/appointment.service';
+import { AuthService } from '../../../core/services/auth.service';
 import { DoctorService } from '../../../core/services/doctor.service';
 import { TreatmentTypeService } from '../../../core/services/treatment-type.service';
 import { SlotService } from '../../../core/services/slot.service';
@@ -47,6 +48,7 @@ export class AppointmentFormComponent implements OnInit {
   private readonly doctorService = inject(DoctorService);
   private readonly treatmentTypeService = inject(TreatmentTypeService);
   private readonly slotService = inject(SlotService);
+  private readonly authService = inject(AuthService);
 
   readonly doctors = this.doctorService.doctors;
   readonly treatmentTypes = this.treatmentTypeService.treatmentTypes;
@@ -67,11 +69,9 @@ export class AppointmentFormComponent implements OnInit {
     patientPhone: [''],
   });
 
-  private readonly clinicId = 1;
-
   async ngOnInit(): Promise<void> {
-    this.doctorService.loadByClinic(this.clinicId);
-    this.treatmentTypeService.loadByClinic(this.clinicId);
+    this.doctorService.loadByClinic(this.authService.clinicId());
+    this.treatmentTypeService.loadByClinic(this.authService.clinicId());
 
     const idParam = this.route.snapshot.paramMap.get('id');
     if (idParam) {
@@ -98,7 +98,7 @@ export class AppointmentFormComponent implements OnInit {
     this.loadingSlots.set(true);
     try {
       const slots = await this.slotService.getAvailableSlots(
-        this.clinicId, doctorId, treatmentTypeId, dateStr, duration,
+        this.authService.clinicId(), doctorId, treatmentTypeId, dateStr, duration,
       );
       this.availableSlots.set(slots);
     } finally {
@@ -123,7 +123,7 @@ export class AppointmentFormComponent implements OnInit {
     try {
       const values = this.form.value;
       const request: CreateAppointmentRequest = {
-        clinicId: this.clinicId,
+        clinicId: this.authService.clinicId(),
         doctorId: values.doctorId,
         treatmentTypeId: values.treatmentTypeId,
         appointmentDate: this.formatDate(values.appointmentDate),

--- a/frontend/appointment-frontend/src/app/features/appointments/appointment-list/appointment-list.component.ts
+++ b/frontend/appointment-frontend/src/app/features/appointments/appointment-list/appointment-list.component.ts
@@ -68,10 +68,8 @@ export class AppointmentListComponent implements OnInit {
   selectedDoctorId: number | null = null;
   selectedStatuses: AppointmentStatus[] = [];
 
-  private readonly clinicId = 1;
-
   ngOnInit(): void {
-    this.doctorService.loadByClinic(this.clinicId);
+    this.doctorService.loadByClinic(this.authService.clinicId());
     this.loadAppointments();
   }
 
@@ -82,7 +80,7 @@ export class AppointmentListComponent implements OnInit {
   async loadAppointments(): Promise<void> {
     const from = this.formatDate(this.dateFrom);
     const to = this.formatDate(this.dateTo);
-    const appointments = await this.appointmentService.getByDateRange(this.clinicId, from, to);
+    const appointments = await this.appointmentService.getByDateRange(this.authService.clinicId(), from, to);
     this.applyFilters(appointments);
   }
 

--- a/frontend/appointment-frontend/src/app/features/calendar/day-view/day-view.component.ts
+++ b/frontend/appointment-frontend/src/app/features/calendar/day-view/day-view.component.ts
@@ -93,7 +93,5 @@ export class DayViewComponent implements OnInit {
     return colors[status] ?? '#9E9E9E';
   }
 
-  protected onAppointmentClick(appointment: Appointment): void {
-    console.log('Appointment clicked:', appointment);
-  }
+  protected onAppointmentClick(_appointment: Appointment): void {}
 }

--- a/frontend/appointment-frontend/src/app/features/calendar/day-view/day-view.component.ts
+++ b/frontend/appointment-frontend/src/app/features/calendar/day-view/day-view.component.ts
@@ -2,11 +2,9 @@ import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute } from '@angular/router';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { AppointmentService, CalendarStateService, DoctorService } from '../../../core/services';
+import { AppointmentService, AuthService, CalendarStateService, DoctorService } from '../../../core/services';
 import { Appointment } from '../../../core/models';
 import { TimeRangePipe } from '../../../shared/pipes/time-range.pipe';
-
-const CLINIC_ID = 1;
 const START_HOUR = 8;
 const END_HOUR = 18;
 const SLOT_MINUTES = 30;
@@ -27,6 +25,7 @@ interface TimeSlot {
 export class DayViewComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly appointmentService = inject(AppointmentService);
+  private readonly authService = inject(AuthService);
   private readonly calendarState = inject(CalendarStateService);
   protected readonly doctorService = inject(DoctorService);
 
@@ -50,7 +49,7 @@ export class DayViewComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.doctorService.loadByClinic(CLINIC_ID);
+    this.doctorService.loadByClinic(this.authService.clinicId());
     const dateParam = this.route.snapshot.paramMap.get('date');
     if (dateParam) {
       this.calendarState.viewMode.set('day');
@@ -65,7 +64,7 @@ export class DayViewComponent implements OnInit {
       const range = this.calendarState.dateRange();
       const from = range.start.toISOString().slice(0, 10);
       const to = range.end.toISOString().slice(0, 10);
-      await this.appointmentService.getByDateRange(CLINIC_ID, from, to);
+      await this.appointmentService.getByDateRange(this.authService.clinicId(), from, to);
     } finally {
       this.loading.set(false);
     }

--- a/frontend/appointment-frontend/src/app/features/calendar/month-view/month-view.component.ts
+++ b/frontend/appointment-frontend/src/app/features/calendar/month-view/month-view.component.ts
@@ -2,9 +2,8 @@ import { Component, computed, effect, inject, OnInit, signal } from '@angular/co
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { AppointmentService, CalendarStateService } from '../../../core/services';
+import { AppointmentService, AuthService, CalendarStateService } from '../../../core/services';
 
-const CLINIC_ID = 1;
 const WEEKDAY_LABELS = ['월', '화', '수', '목', '금', '토', '일'];
 
 interface CalendarCell {
@@ -26,6 +25,7 @@ export class MonthViewComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly appointmentService = inject(AppointmentService);
+  private readonly authService = inject(AuthService);
   private readonly calendarState = inject(CalendarStateService);
 
   protected readonly loading = signal(false);
@@ -77,7 +77,7 @@ export class MonthViewComponent implements OnInit {
         const from = cells[0].dateStr;
         const to = cells[cells.length - 1].dateStr;
         this.loading.set(true);
-        this.appointmentService.getByDateRange(CLINIC_ID, from, to)
+        this.appointmentService.getByDateRange(this.authService.clinicId(), from, to)
           .finally(() => this.loading.set(false));
       }
     });

--- a/frontend/appointment-frontend/src/app/features/calendar/week-view/week-view.component.ts
+++ b/frontend/appointment-frontend/src/app/features/calendar/week-view/week-view.component.ts
@@ -2,9 +2,7 @@ import { Component, computed, inject, OnInit, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { AppointmentService, CalendarStateService } from '../../../core/services';
-
-const CLINIC_ID = 1;
+import { AppointmentService, AuthService, CalendarStateService } from '../../../core/services';
 const START_HOUR = 8;
 const END_HOUR = 18;
 const SLOT_MINUTES = 30;
@@ -34,6 +32,7 @@ export class WeekViewComponent implements OnInit {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly appointmentService = inject(AppointmentService);
+  private readonly authService = inject(AuthService);
   private readonly calendarState = inject(CalendarStateService);
 
   protected readonly loading = signal(false);
@@ -85,7 +84,7 @@ export class WeekViewComponent implements OnInit {
       const range = this.calendarState.dateRange();
       const from = range.start.toISOString().slice(0, 10);
       const to = range.end.toISOString().slice(0, 10);
-      await this.appointmentService.getByDateRange(CLINIC_ID, from, to);
+      await this.appointmentService.getByDateRange(this.authService.clinicId(), from, to);
     } finally {
       this.loading.set(false);
     }

--- a/frontend/appointment-frontend/src/app/features/management/doctor-list/doctor-list.component.ts
+++ b/frontend/appointment-frontend/src/app/features/management/doctor-list/doctor-list.component.ts
@@ -2,9 +2,7 @@ import { Component, OnInit, inject } from '@angular/core';
 import { MatTableModule } from '@angular/material/table';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
-import { DoctorService } from '../../../core/services';
-
-const CLINIC_ID = 1;
+import { AuthService, DoctorService } from '../../../core/services';
 
 @Component({
   selector: 'app-doctor-list',
@@ -76,12 +74,13 @@ const CLINIC_ID = 1;
   `],
 })
 export class DoctorListComponent implements OnInit {
+  private readonly authService = inject(AuthService);
   private readonly doctorService = inject(DoctorService);
 
   readonly displayedColumns = ['name', 'specialty', 'providerType'];
   readonly doctors = this.doctorService.doctors;
 
   ngOnInit(): void {
-    this.doctorService.loadByClinic(CLINIC_ID);
+    this.doctorService.loadByClinic(this.authService.clinicId());
   }
 }

--- a/frontend/appointment-frontend/src/app/features/management/equipment-unavailability-list/equipment-unavailability-list.component.ts
+++ b/frontend/appointment-frontend/src/app/features/management/equipment-unavailability-list/equipment-unavailability-list.component.ts
@@ -13,6 +13,7 @@ import { MatDialogModule, MatDialog } from '@angular/material/dialog';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { FormsModule } from '@angular/forms';
+import { AuthService } from '../../../core/services/auth.service';
 import { EquipmentUnavailabilityService } from '../../../core/services/equipment-unavailability.service';
 import {
   EquipmentUnavailabilityRecord,
@@ -396,6 +397,7 @@ import {
   `],
 })
 export class EquipmentUnavailabilityListComponent {
+  private readonly authService = inject(AuthService);
   private readonly service = inject(EquipmentUnavailabilityService);
   private readonly snackBar = inject(MatSnackBar);
 
@@ -403,7 +405,7 @@ export class EquipmentUnavailabilityListComponent {
   readonly conflictColumns = ['appointmentId', 'patientName', 'appointmentDate', 'time'];
 
   // Search
-  readonly clinicId = signal<number>(1);
+  readonly clinicId = signal<number>(this.authService.clinicId());
   readonly equipmentId = signal<number>(1);
   readonly fromDate = signal<string>('');
   readonly toDate = signal<string>('');

--- a/frontend/appointment-frontend/src/app/features/management/reschedule-list/reschedule-list.component.ts
+++ b/frontend/appointment-frontend/src/app/features/management/reschedule-list/reschedule-list.component.ts
@@ -10,6 +10,7 @@ import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatChipsModule } from '@angular/material/chips';
 import { FormsModule } from '@angular/forms';
+import { AuthService } from '../../../core/services/auth.service';
 import { RescheduleService } from '../../../core/services/reschedule.service';
 import { RescheduleCandidate } from '../../../core/models';
 
@@ -221,6 +222,7 @@ import { RescheduleCandidate } from '../../../core/models';
   `],
 })
 export class RescheduleListComponent {
+  private readonly authService = inject(AuthService);
   private readonly rescheduleService = inject(RescheduleService);
   private readonly snackBar = inject(MatSnackBar);
 
@@ -228,7 +230,7 @@ export class RescheduleListComponent {
 
   readonly appointmentId = signal<number>(0);
   readonly searchType = signal<'candidates' | 'closure'>('candidates');
-  readonly clinicId = signal<number>(1);
+  readonly clinicId = signal<number>(this.authService.clinicId());
   readonly closureDate = signal<string>('');
   readonly searchDays = signal<number>(7);
 

--- a/frontend/appointment-frontend/src/app/features/management/treatment-list/treatment-type-list.component.ts
+++ b/frontend/appointment-frontend/src/app/features/management/treatment-list/treatment-type-list.component.ts
@@ -3,9 +3,7 @@ import { MatTableModule } from '@angular/material/table';
 import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { TreatmentType } from '../../../core/models';
-import { TreatmentTypeService } from '../../../core/services';
-
-const CLINIC_ID = 1;
+import { AuthService, TreatmentTypeService } from '../../../core/services';
 
 @Component({
   selector: 'app-treatment-type-list',
@@ -82,12 +80,13 @@ const CLINIC_ID = 1;
   `],
 })
 export class TreatmentTypeListComponent implements OnInit {
+  private readonly authService = inject(AuthService);
   private readonly treatmentTypeService = inject(TreatmentTypeService);
 
   readonly displayedColumns = ['name', 'category', 'duration', 'requiresEquipment'];
   readonly treatmentTypes = this.treatmentTypeService.treatmentTypes;
 
   ngOnInit(): void {
-    this.treatmentTypeService.loadByClinic(CLINIC_ID);
+    this.treatmentTypeService.loadByClinic(this.authService.clinicId());
   }
 }


### PR DESCRIPTION
## Summary

Resolves #46

Removes hardcoded `clinicId = 1` / `const CLINIC_ID = 1` from 8 Angular components.
Introduces `AuthService.clinicId` as a reactive computed signal derived from the JWT payload.

## Changes

### `AuthService`

- Added `private _decodedToken` computed signal — lazily parses JWT payload on each read
- Added `readonly clinicId` computed signal — `decodedToken()?.[\'clinicId\'] ?? 0`

Matches backend `CLAIM_CLINIC_ID = "clinicId"` key in `JwtTokenParser.kt`.

### Components updated (8 files)

| Component | Old | New |
|-----------|-----|-----|
| `appointment-detail` | `private readonly clinicId = 1` | `authService.clinicId()` |
| `appointment-form` | `private readonly clinicId = 1` | `authService.clinicId()` |
| `appointment-list` | `private readonly clinicId = 1` | `authService.clinicId()` |
| `day-view` | `const CLINIC_ID = 1` | `authService.clinicId()` |
| `month-view` | `const CLINIC_ID = 1` | `authService.clinicId()` |
| `week-view` | `const CLINIC_ID = 1` | `authService.clinicId()` |
| `doctor-list` | `const CLINIC_ID = 1` | `authService.clinicId()` |
| `treatment-type-list` | `const CLINIC_ID = 1` | `authService.clinicId()` |

`appointment-form` additionally gains `AuthService` import and `inject(AuthService)`.

## Verification

```
ng build --configuration production
Application bundle generation complete. [2.189 seconds] — 0 errors
```

Zero occurrences of `clinicId = 1` or `CLINIC_ID` remaining in TypeScript sources.

## DoD Checklist

- [x] Production build passing (0 errors)
- [x] Hardcoded clinicId removed from all 8 components
- [x] `AuthService.clinicId` signal correctly reads JWT claim `clinicId`
- [x] Lessons committed: `docs/lessons/2026-05-19-issue-46-clinicid-signal.md`