### PR TITLE
feat(sse): GET /api/reschedule/batch/stream — SSE batch reschedule stream endpoint

### DIFF
--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleBatchStreamController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleBatchStreamController.kt
@@ -5,6 +5,7 @@ import io.bluetape4k.clinic.appointment.service.ClosureRescheduleService
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.logging.debug
 import io.bluetape4k.logging.warn
+import io.bluetape4k.support.requireInRange
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -18,7 +19,6 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
 import java.time.LocalDate
-import java.util.concurrent.Executors
 
 /**
  * SSE endpoint for streaming batch reschedule progress.
@@ -37,9 +37,7 @@ import java.util.concurrent.Executors
 class RescheduleBatchStreamController(
     private val closureRescheduleService: ClosureRescheduleService,
 ) {
-    companion object : KLogging() {
-        private val executor = Executors.newVirtualThreadPerTaskExecutor()
-    }
+    companion object : KLogging()
 
     /**
      * Streams batch closure reschedule progress as Server-Sent Events.
@@ -61,10 +59,11 @@ class RescheduleBatchStreamController(
         @Parameter(description = "Number of days to search for alternative slots")
         @RequestParam(defaultValue = "7") searchDays: Int,
     ): SseEmitter {
+        searchDays.requireInRange(1, 30, "searchDays")
         log.debug { "GET /api/reschedule/batch/stream - clinic=$clinicId, date=$closureDate, searchDays=$searchDays" }
 
         val emitter = SseEmitter(0L) // no timeout — stream length is proportional to affected count
-        executor.submit {
+        Thread.ofVirtual().start {
             runCatching {
                 var totalProcessed = 0
 

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleBatchStreamController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleBatchStreamController.kt
@@ -1,0 +1,105 @@
+package io.bluetape4k.clinic.appointment.api.controller
+
+import io.bluetape4k.clinic.appointment.api.dto.RescheduleProgressEvent
+import io.bluetape4k.clinic.appointment.service.ClosureRescheduleService
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.logging.warn
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter
+import java.time.LocalDate
+import java.util.concurrent.Executors
+
+/**
+ * SSE endpoint for streaming batch reschedule progress.
+ *
+ * ## Behavior / Contract
+ * - One SSE event is sent per appointment as it completes candidate search.
+ * - A terminal event with [RescheduleProgressEvent.done] = true signals completion.
+ * - If no appointments are affected, only the terminal event is sent.
+ * - On error, the SSE stream is completed with an error state.
+ *
+ * @param closureRescheduleService batch reschedule service
+ */
+@Tag(name = "Reschedule", description = "Appointment rescheduling")
+@RestController
+@RequestMapping("/api/reschedule")
+class RescheduleBatchStreamController(
+    private val closureRescheduleService: ClosureRescheduleService,
+) {
+    companion object : KLogging() {
+        private val executor = Executors.newVirtualThreadPerTaskExecutor()
+    }
+
+    /**
+     * Streams batch closure reschedule progress as Server-Sent Events.
+     *
+     * @param clinicId clinic to reschedule
+     * @param closureDate date of the clinic closure
+     * @param searchDays number of days to search for alternative slots (default 7)
+     * @return SSE stream of [RescheduleProgressEvent] — one per appointment plus a terminal event
+     */
+    @Operation(summary = "Stream batch closure reschedule progress via SSE")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "SSE stream started"),
+        ApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
+    @GetMapping("/batch/stream", produces = [MediaType.TEXT_EVENT_STREAM_VALUE])
+    fun streamBatchReschedule(
+        @RequestParam clinicId: Long,
+        @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) closureDate: LocalDate,
+        @Parameter(description = "Number of days to search for alternative slots")
+        @RequestParam(defaultValue = "7") searchDays: Int,
+    ): SseEmitter {
+        log.debug { "GET /api/reschedule/batch/stream - clinic=$clinicId, date=$closureDate, searchDays=$searchDays" }
+
+        val emitter = SseEmitter(0L) // no timeout — stream length is proportional to affected count
+        executor.submit {
+            runCatching {
+                var totalProcessed = 0
+
+                val count = closureRescheduleService.streamClosureReschedule(
+                    clinicId = clinicId,
+                    closureDate = closureDate,
+                    searchDays = searchDays,
+                ) { appointmentId, candidateCount ->
+                    totalProcessed++
+                    val event = RescheduleProgressEvent(
+                        appointmentId = appointmentId,
+                        candidateCount = candidateCount,
+                        totalProcessed = totalProcessed,
+                        done = false,
+                    )
+                    emitter.send(
+                        SseEmitter.event()
+                            .name("progress")
+                            .data(event, MediaType.APPLICATION_JSON)
+                    )
+                }
+
+                val terminal = RescheduleProgressEvent.completed(count)
+                emitter.send(
+                    SseEmitter.event()
+                        .name("complete")
+                        .data(terminal, MediaType.APPLICATION_JSON)
+                )
+                emitter.complete()
+            }.onFailure { ex ->
+                log.warn(ex) { "SSE batch reschedule failed - clinic=$clinicId, date=$closureDate" }
+                emitter.completeWithError(ex)
+            }
+        }
+
+        return emitter
+    }
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/RescheduleProgressEvent.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/RescheduleProgressEvent.kt
@@ -1,0 +1,36 @@
+package io.bluetape4k.clinic.appointment.api.dto
+
+import io.bluetape4k.logging.KLogging
+import java.io.Serializable
+
+/**
+ * SSE payload emitted for each appointment processed during a batch reschedule stream.
+ *
+ * ## Behavior / Contract
+ * - One event is emitted per appointment as it completes candidate search.
+ * - A final event with [done] = true and [appointmentId] = -1 signals stream completion.
+ *
+ * @param appointmentId ID of the processed appointment; -1 for the terminal completion event
+ * @param candidateCount number of candidate slots found for this appointment
+ * @param totalProcessed running count of appointments processed so far
+ * @param done true only on the terminal event that signals stream completion
+ */
+data class RescheduleProgressEvent(
+    val appointmentId: Long,
+    val candidateCount: Int,
+    val totalProcessed: Int,
+    val done: Boolean,
+) : Serializable {
+    companion object : KLogging() {
+        private const val serialVersionUID: Long = 1L
+
+        /** Terminal event signalling batch completion. */
+        fun completed(totalProcessed: Int): RescheduleProgressEvent =
+            RescheduleProgressEvent(
+                appointmentId = -1L,
+                candidateCount = 0,
+                totalProcessed = totalProcessed,
+                done = true,
+            )
+    }
+}

--- a/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleBatchStreamControllerTest.kt
+++ b/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/RescheduleBatchStreamControllerTest.kt
@@ -1,0 +1,203 @@
+package io.bluetape4k.clinic.appointment.api.controller
+
+import io.bluetape4k.clinic.appointment.api.test.AbstractApiIntegrationTest
+import io.bluetape4k.clinic.appointment.event.AppointmentEventLogs
+import io.bluetape4k.clinic.appointment.model.tables.AppointmentNotes
+import io.bluetape4k.clinic.appointment.model.tables.AppointmentStateHistory
+import io.bluetape4k.clinic.appointment.model.tables.Appointments
+import io.bluetape4k.clinic.appointment.model.tables.BreakTimes
+import io.bluetape4k.clinic.appointment.model.tables.ClinicClosures
+import io.bluetape4k.clinic.appointment.model.tables.ClinicDefaultBreakTimes
+import io.bluetape4k.clinic.appointment.model.tables.Clinics
+import io.bluetape4k.clinic.appointment.model.tables.ConsultationTopics
+import io.bluetape4k.clinic.appointment.model.tables.DoctorAbsences
+import io.bluetape4k.clinic.appointment.model.tables.DoctorSchedules
+import io.bluetape4k.clinic.appointment.model.tables.Doctors
+import io.bluetape4k.clinic.appointment.model.tables.Equipments
+import io.bluetape4k.clinic.appointment.model.tables.Holidays
+import io.bluetape4k.clinic.appointment.model.tables.OperatingHoursTable
+import io.bluetape4k.clinic.appointment.model.tables.RescheduleCandidates
+import io.bluetape4k.clinic.appointment.model.tables.TreatmentEquipments
+import io.bluetape4k.clinic.appointment.model.tables.TreatmentTypes
+import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeFalse
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldContain
+import io.bluetape4k.logging.KLogging
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestClient
+import java.time.DayOfWeek
+import java.time.LocalDate
+import java.time.LocalTime
+
+class RescheduleBatchStreamControllerTest @Autowired constructor() : AbstractApiIntegrationTest() {
+
+    companion object : KLogging() {
+        private const val STREAM_URL = "/api/reschedule/batch/stream"
+        // 2026-04-06 is Monday — in operating hours window
+        private val CLOSURE_DATE: LocalDate = LocalDate.of(2026, 4, 6)
+    }
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    private lateinit var client: RestClient
+
+    private var clinicId: Long = 0
+    private var doctorId: Long = 0
+    private var treatmentTypeId: Long = 0
+
+    @BeforeEach
+    fun setup() {
+        client = RestClient.builder()
+            .baseUrl("http://localhost:$port")
+            .build()
+
+        transaction {
+            SchemaUtils.create(
+                Clinics, OperatingHoursTable, ClinicDefaultBreakTimes, BreakTimes, ClinicClosures,
+                Doctors, DoctorSchedules, DoctorAbsences,
+                TreatmentTypes, Equipments, TreatmentEquipments,
+                ConsultationTopics, Holidays,
+                Appointments, AppointmentNotes, AppointmentStateHistory,
+                RescheduleCandidates, AppointmentEventLogs,
+            )
+
+            AppointmentEventLogs.deleteAll()
+            AppointmentStateHistory.deleteAll()
+            RescheduleCandidates.deleteAll()
+            AppointmentNotes.deleteAll()
+            Appointments.deleteAll()
+            TreatmentEquipments.deleteAll()
+            Equipments.deleteAll()
+            ConsultationTopics.deleteAll()
+            TreatmentTypes.deleteAll()
+            DoctorAbsences.deleteAll()
+            DoctorSchedules.deleteAll()
+            Doctors.deleteAll()
+            Holidays.deleteAll()
+            ClinicClosures.deleteAll()
+            BreakTimes.deleteAll()
+            ClinicDefaultBreakTimes.deleteAll()
+            OperatingHoursTable.deleteAll()
+            Clinics.deleteAll()
+
+            clinicId = Clinics.insertAndGetId {
+                it[name] = "Stream Test Clinic"
+                it[slotDurationMinutes] = 30
+                it[timezone] = "Asia/Seoul"
+                it[locale] = "ko-KR"
+                it[maxConcurrentPatients] = 3
+                it[openOnHolidays] = false
+            }.value
+
+            doctorId = Doctors.insertAndGetId {
+                it[Doctors.clinicId] = this@RescheduleBatchStreamControllerTest.clinicId
+                it[name] = "Dr. Stream"
+                it[specialty] = "General"
+                it[providerType] = "DOCTOR"
+                it[maxConcurrentPatients] = 1
+            }.value
+
+            treatmentTypeId = TreatmentTypes.insertAndGetId {
+                it[TreatmentTypes.clinicId] = this@RescheduleBatchStreamControllerTest.clinicId
+                it[name] = "General Checkup"
+                it[category] = "GENERAL"
+                it[defaultDurationMinutes] = 30
+                it[requiredProviderType] = "DOCTOR"
+                it[requiresEquipment] = false
+                it[maxConcurrentPatients] = 1
+            }.value
+
+            for (day in listOf(
+                DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY,
+                DayOfWeek.THURSDAY, DayOfWeek.FRIDAY
+            )) {
+                OperatingHoursTable.insertAndGetId {
+                    it[OperatingHoursTable.clinicId] = this@RescheduleBatchStreamControllerTest.clinicId
+                    it[dayOfWeek] = day
+                    it[openTime] = LocalTime.of(9, 0)
+                    it[closeTime] = LocalTime.of(18, 0)
+                    it[isActive] = true
+                }
+                DoctorSchedules.insertAndGetId {
+                    it[DoctorSchedules.doctorId] = this@RescheduleBatchStreamControllerTest.doctorId
+                    it[dayOfWeek] = day
+                    it[startTime] = LocalTime.of(9, 0)
+                    it[endTime] = LocalTime.of(18, 0)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun `searchDays below minimum returns 400`() {
+        val response = client.get()
+            .uri("$STREAM_URL?clinicId=$clinicId&closureDate=$CLOSURE_DATE&searchDays=0")
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.BAD_REQUEST
+        response.jsonPath<Boolean>("$.success").shouldBeFalse()
+    }
+
+    @Test
+    fun `searchDays above maximum returns 400`() {
+        val response = client.get()
+            .uri("$STREAM_URL?clinicId=$clinicId&closureDate=$CLOSURE_DATE&searchDays=31")
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.BAD_REQUEST
+        response.jsonPath<Boolean>("$.success").shouldBeFalse()
+    }
+
+    @Test
+    fun `no affected appointments emits only terminal done event`() {
+        // No appointment inserted on CLOSURE_DATE
+        val response = client.get()
+            .uri("$STREAM_URL?clinicId=$clinicId&closureDate=$CLOSURE_DATE&searchDays=3")
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.OK
+        response.body shouldContain "\"done\":true"
+        response.body shouldContain "\"totalProcessed\":0"
+    }
+
+    @Test
+    fun `affected appointment emits progress event then terminal event`() {
+        transaction {
+            Appointments.insertAndGetId {
+                it[Appointments.clinicId] = this@RescheduleBatchStreamControllerTest.clinicId
+                it[Appointments.doctorId] = this@RescheduleBatchStreamControllerTest.doctorId
+                it[Appointments.treatmentTypeId] = this@RescheduleBatchStreamControllerTest.treatmentTypeId
+                it[patientName] = "Patient SSE"
+                it[patientPhone] = "010-5555-6666"
+                it[appointmentDate] = CLOSURE_DATE
+                it[startTime] = LocalTime.of(10, 0)
+                it[endTime] = LocalTime.of(10, 30)
+                it[Appointments.status] = AppointmentState.CONFIRMED
+            }
+        }
+
+        val response = client.get()
+            .uri("$STREAM_URL?clinicId=$clinicId&closureDate=$CLOSURE_DATE&searchDays=3")
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.OK
+        // progress event emitted for the appointment
+        response.body shouldContain "event:progress"
+        // terminal complete event
+        response.body shouldContain "event:complete"
+        response.body shouldContain "\"done\":true"
+        response.body shouldContain "\"totalProcessed\":1"
+        response.body shouldContain "\"done\":false"
+    }
+}

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleService.kt
@@ -107,15 +107,17 @@ class ClosureRescheduleService(
      * Processes closure reschedule one appointment at a time and reports progress via callback.
      *
      * ## Behavior / Contract
-     * - Calls [onProgress] after each appointment is fully processed.
-     * - The callback receives the appointment ID and the count of candidates found.
+     * - Each appointment is processed in its own transaction so the DB connection is released
+     *   between appointments. [onProgress] is called AFTER each per-appointment transaction commits,
+     *   never while a DB connection is held. This is safe for callers that perform network I/O
+     *   (e.g. SSE flush) inside the callback.
      * - Does NOT emit a terminal signal; the caller is responsible for signalling completion.
-     * - Runs inside a single transaction; if any step fails the whole batch is rolled back.
+     * - Status-update and state-history writes use a single shared transaction before per-appointment processing.
      *
      * @param clinicId clinic to reschedule for
      * @param closureDate date of the clinic closure
      * @param searchDays number of days to search for alternative slots (default 7)
-     * @param onProgress called after each appointment with (appointmentId, candidateCount)
+     * @param onProgress called AFTER each appointment's transaction commits, with (appointmentId, candidateCount)
      * @return total number of appointments processed
      */
     fun streamClosureReschedule(
@@ -123,59 +125,63 @@ class ClosureRescheduleService(
         closureDate: LocalDate,
         searchDays: Int = 7,
         onProgress: (appointmentId: Long, candidateCount: Int) -> Unit,
-    ): Int = transaction {
-        val affected = appointmentRepository.findActiveByClinicAndDate(clinicId, closureDate, ACTIVE_STATUSES)
-        if (affected.isEmpty()) return@transaction 0
+    ): Int {
+        val affected = transaction {
+            val list = appointmentRepository.findActiveByClinicAndDate(clinicId, closureDate, ACTIVE_STATUSES)
+            if (list.isEmpty()) return@transaction emptyList()
 
-        appointmentRepository.updateStatusByClinicAndDate(
-            clinicId,
-            closureDate,
-            ACTIVE_STATUSES,
-            AppointmentState.PENDING_RESCHEDULE
-        )
-
-        for (appointment in affected) {
-            stateHistoryRepository.save(
-                AppointmentStateHistoryRecord(
-                    appointmentId = appointment.id.requireNotNull("appointment.id"),
-                    fromState = appointment.status,
-                    toState = AppointmentState.PENDING_RESCHEDULE,
-                    reason = "임시휴진으로 인한 재배정",
-                )
+            appointmentRepository.updateStatusByClinicAndDate(
+                clinicId, closureDate, ACTIVE_STATUSES, AppointmentState.PENDING_RESCHEDULE
             )
+            for (appointment in list) {
+                stateHistoryRepository.save(
+                    AppointmentStateHistoryRecord(
+                        appointmentId = appointment.id.requireNotNull("appointment.id"),
+                        fromState = appointment.status,
+                        toState = AppointmentState.PENDING_RESCHEDULE,
+                        reason = "임시휴진으로 인한 재배정",
+                    )
+                )
+            }
+            list
         }
+
+        if (affected.isEmpty()) return 0
 
         var processed = 0
         for (appointment in affected) {
             val appointmentId = appointment.id.requireNotNull("appointment.id")
-            var candidateCount = 0
-            var priority = 0
-
-            for (dayOffset in 1..searchDays) {
-                val candidateDate = closureDate.plusDays(dayOffset.toLong())
-                val slots = slotCalculationService.findAvailableSlots(
-                    SlotQuery(clinicId, appointment.doctorId, appointment.treatmentTypeId, candidateDate)
-                )
-                for (slot in slots) {
-                    rescheduleCandidateRepository.save(
-                        RescheduleCandidateRecord(
-                            originalAppointmentId = appointmentId,
-                            candidateDate = candidateDate,
-                            startTime = slot.startTime,
-                            endTime = slot.endTime,
-                            doctorId = appointment.doctorId,
-                            priority = priority,
-                        )
+            // Per-appointment transaction — releases DB connection before onProgress callback
+            val candidateCount = transaction {
+                var count = 0
+                var priority = 0
+                for (dayOffset in 1..searchDays) {
+                    val candidateDate = closureDate.plusDays(dayOffset.toLong())
+                    val slots = slotCalculationService.findAvailableSlots(
+                        SlotQuery(clinicId, appointment.doctorId, appointment.treatmentTypeId, candidateDate)
                     )
-                    candidateCount++
-                    priority++
+                    for (slot in slots) {
+                        rescheduleCandidateRepository.save(
+                            RescheduleCandidateRecord(
+                                originalAppointmentId = appointmentId,
+                                candidateDate = candidateDate,
+                                startTime = slot.startTime,
+                                endTime = slot.endTime,
+                                doctorId = appointment.doctorId,
+                                priority = priority,
+                            )
+                        )
+                        count++
+                        priority++
+                    }
                 }
+                count
             }
-
+            // DB connection released — safe to call onProgress with network I/O
             onProgress(appointmentId, candidateCount)
             processed++
         }
-        processed
+        return processed
     }
 
     /**

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleService.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/service/ClosureRescheduleService.kt
@@ -104,6 +104,81 @@ class ClosureRescheduleService(
         }
 
     /**
+     * Processes closure reschedule one appointment at a time and reports progress via callback.
+     *
+     * ## Behavior / Contract
+     * - Calls [onProgress] after each appointment is fully processed.
+     * - The callback receives the appointment ID and the count of candidates found.
+     * - Does NOT emit a terminal signal; the caller is responsible for signalling completion.
+     * - Runs inside a single transaction; if any step fails the whole batch is rolled back.
+     *
+     * @param clinicId clinic to reschedule for
+     * @param closureDate date of the clinic closure
+     * @param searchDays number of days to search for alternative slots (default 7)
+     * @param onProgress called after each appointment with (appointmentId, candidateCount)
+     * @return total number of appointments processed
+     */
+    fun streamClosureReschedule(
+        clinicId: Long,
+        closureDate: LocalDate,
+        searchDays: Int = 7,
+        onProgress: (appointmentId: Long, candidateCount: Int) -> Unit,
+    ): Int = transaction {
+        val affected = appointmentRepository.findActiveByClinicAndDate(clinicId, closureDate, ACTIVE_STATUSES)
+        if (affected.isEmpty()) return@transaction 0
+
+        appointmentRepository.updateStatusByClinicAndDate(
+            clinicId,
+            closureDate,
+            ACTIVE_STATUSES,
+            AppointmentState.PENDING_RESCHEDULE
+        )
+
+        for (appointment in affected) {
+            stateHistoryRepository.save(
+                AppointmentStateHistoryRecord(
+                    appointmentId = appointment.id.requireNotNull("appointment.id"),
+                    fromState = appointment.status,
+                    toState = AppointmentState.PENDING_RESCHEDULE,
+                    reason = "임시휴진으로 인한 재배정",
+                )
+            )
+        }
+
+        var processed = 0
+        for (appointment in affected) {
+            val appointmentId = appointment.id.requireNotNull("appointment.id")
+            var candidateCount = 0
+            var priority = 0
+
+            for (dayOffset in 1..searchDays) {
+                val candidateDate = closureDate.plusDays(dayOffset.toLong())
+                val slots = slotCalculationService.findAvailableSlots(
+                    SlotQuery(clinicId, appointment.doctorId, appointment.treatmentTypeId, candidateDate)
+                )
+                for (slot in slots) {
+                    rescheduleCandidateRepository.save(
+                        RescheduleCandidateRecord(
+                            originalAppointmentId = appointmentId,
+                            candidateDate = candidateDate,
+                            startTime = slot.startTime,
+                            endTime = slot.endTime,
+                            doctorId = appointment.doctorId,
+                            priority = priority,
+                        )
+                    )
+                    candidateCount++
+                    priority++
+                }
+            }
+
+            onProgress(appointmentId, candidateCount)
+            processed++
+        }
+        processed
+    }
+
+    /**
      * 관리자가 재배정 후보를 선택하여 확정합니다.
      * 원래 예약은 RESCHEDULED로 전환하고, 새 예약을 생성합니다.
      *

--- a/docs/lessons/2026-05-19-sse-batch-stream-transaction-pattern.md
+++ b/docs/lessons/2026-05-19-sse-batch-stream-transaction-pattern.md
@@ -1,0 +1,91 @@
+# SSE 배치 스트림 — 트랜잭션-over-SSE P0 버그 및 수정 패턴
+
+## 작업 개요
+
+Issue #29: GET /api/reschedule/batch/stream — 임시휴진 일괄 재배정 진행 상황을 SSE로 스트리밍하는 엔드포인트 구현.
+
+## P0 버그: 트랜잭션 안에서 SSE 전송
+
+### 문제
+
+초기 설계에서 `onProgress` 콜백(SSE 이벤트 전송)이 `transaction {}` 블록 안에서 호출되었다.
+
+```kotlin
+// WRONG — DB 연결을 유지한 채 네트워크 I/O 수행
+transaction {
+    for (appointment in affected) {
+        // ... DB 작업 ...
+        onProgress(appointmentId, candidateCount) // SSE flush + 클라이언트 연결
+    }
+}
+```
+
+**결과:**
+- JDBC 커넥션이 SSE flush + 클라이언트 연결 해제 동안 유지됨
+- 클라이언트 연결이 끊기면 전체 배치가 롤백됨
+- 커넥션 풀 고갈 위험
+
+### 수정
+
+트랜잭션을 두 레벨로 분리:
+
+1. **공유 트랜잭션**: 상태 업데이트(PENDING_RESCHEDULE) + 이력 저장
+2. **예약별 트랜잭션**: 후보 슬롯 저장 (각 예약마다 별도 트랜잭션)
+3. **onProgress 호출**: 예약별 트랜잭션 커밋 후, DB 커넥션 해제 이후
+
+```kotlin
+// CORRECT — onProgress는 트랜잭션 바깥에서 호출
+val affected = transaction { /* 상태 업데이트 */ }
+
+for (appointment in affected) {
+    val candidateCount = transaction { /* 후보 저장 */ }
+    onProgress(appointmentId, candidateCount) // 커넥션 해제 후 안전
+}
+```
+
+**Why:** 네트워크 I/O(SSE flush)와 DB 트랜잭션을 동시에 유지하면 커넥션 풀 고갈과 의도치 않은 롤백이 발생한다.
+
+## P1: 정적 Executor 제거
+
+### 문제
+
+```kotlin
+companion object : KLogging() {
+    private val executor = Executors.newVirtualThreadPerTaskExecutor() // 앱 종료 시 닫히지 않음
+}
+```
+
+`companion object`의 정적 executor는 스프링 컨텍스트와 수명이 다르고, 커넥션 수 제한 없음.
+
+### 수정
+
+```kotlin
+Thread.ofVirtual().start { /* SSE 작업 */ }
+```
+
+각 SSE 요청마다 새 가상 스레드를 생성. `SseEmitter` 특성상 요청당 하나의 스레드만 필요하므로 스레드 폭발 위험 없음.
+
+## P1: searchDays 범위 검증
+
+`searchDays` 상한 없이 DB를 수십 일치 스캔 가능 → 무제한 부하.
+
+```kotlin
+searchDays.requireInRange(1, 30, "searchDays")
+```
+
+`GlobalExceptionHandler`가 `IllegalArgumentException`을 400으로 변환하므로 별도 처리 불필요.
+
+## SSE 컨트롤러 설계 원칙
+
+1. `SseEmitter(0L)` — 타임아웃 없음 (배치 크기에 비례한 시간 필요)
+2. 가상 스레드로 백그라운드 처리 (`Thread.ofVirtual().start {}`)
+3. `runCatching { }.onFailure { emitter.completeWithError(ex) }` — 에러 시 스트림 종료
+4. 마지막에 반드시 `emitter.complete()` 호출
+5. `done=true` 터미널 이벤트로 스트림 완료 신호
+
+## 테스트 포인트
+
+- `searchDays=0`, `searchDays=31` → 400
+- 영향받는 예약 없음 → 터미널 이벤트만 (totalProcessed=0)
+- 예약 존재 → progress 이벤트 + 터미널 이벤트 (totalProcessed=1)
+- `RestClient.exchange { response.bodyTo(String::class.java) }` 패턴으로 SSE 스트림 전체 수신 가능


### PR DESCRIPTION
## Summary

Implements SSE streaming endpoint for batch closure reschedule progress (Issue #29).

### Changes

| File | Change |
|------|--------|
| `RescheduleProgressEvent.kt` | New SSE payload DTO (Serializable, KLogging) |
| `ClosureRescheduleService.kt` | Add `streamClosureReschedule()` with per-appointment transactions |
| `RescheduleBatchStreamController.kt` | New SSE controller (`GET /api/reschedule/batch/stream`) |
| `RescheduleBatchStreamControllerTest.kt` | 4 integration tests |
| `docs/lessons/2026-05-19-...` | Lessons: transaction-over-SSE P0 pattern |

### Behavior

- One `progress` SSE event per appointment after its candidate search transaction commits
- Terminal `complete` event (`done=true`) after all appointments processed
- If no appointments affected, only the terminal event is sent
- On error: stream closed with `emitter.completeWithError(ex)`

### P0 Fix: Transaction-over-SSE

`onProgress` callback (SSE flush) was originally called inside `transaction {}`, holding the JDBC connection during network I/O. Fixed by splitting into:

1. Shared transaction: status update + state history
2. Per-appointment transaction: candidate slot writes
3. `onProgress` called **after** per-appointment transaction commits — DB connection released

### P1 Fixes

- **Static executor removed**: replaced `Executors.newVirtualThreadPerTaskExecutor()` in companion with `Thread.ofVirtual().start {}` per request
- **searchDays validated**: `requireInRange(1, 30, "searchDays")` — returns 400 for out-of-range values

### Test Results

```
Module : :appointment-api
Result : 96 passing, 0 failed
Time   : 1m 20s
```

### Closes #29