### PR TITLE
feat(fe): SSE batch reschedule stream — RescheduleService + progress UI

### DIFF
--- a/docs/lessons/2026-05-19-sse-frontend-fetch-readablestream.md
+++ b/docs/lessons/2026-05-19-sse-frontend-fetch-readablestream.md
@@ -1,0 +1,85 @@
+# Lesson: SSE with fetch + ReadableStream in Angular (Issues #30, #31)
+
+## Root Cause / Context
+
+`EventSource` (the browser's built-in SSE API) does not support custom headers.
+This makes it incompatible with JWT Bearer token authentication, which requires
+`Authorization: Bearer <token>` on every request.
+
+## Decision
+
+Use `fetch + ReadableStream` instead of `EventSource` to maintain JWT auth header
+support without modifying the backend or switching to query-parameter token passing.
+
+## Implementation Pattern
+
+```typescript
+streamBatchReschedule(params): Observable<RescheduleProgressEvent> {
+  return new Observable(observer => {
+    const controller = new AbortController();
+
+    fetch(url, {
+      headers: { Accept: 'text/event-stream', Authorization: `Bearer ${token}` },
+      signal: controller.signal,
+    }).then(async response => {
+      const reader = response.body.getReader();
+      let buffer = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const blocks = buffer.split('\n\n');
+        buffer = blocks.pop() ?? '';
+        for (const block of blocks) { /* parse data: lines */ }
+      }
+    });
+
+    return () => controller.abort(); // teardown aborts fetch
+  });
+}
+```
+
+## Key Invariants
+
+- **`buffer.split('\n\n')` + `pop()`**: Retains the incomplete trailing block across
+  chunk boundaries. This is mandatory for correct SSE parsing over streaming HTTP.
+- **`TextDecoder({ stream: true })`**: Required for multi-byte UTF-8 character
+  boundaries to not corrupt characters split across chunks.
+- **`AbortController` teardown**: Registered as the Observable's return function so
+  `unsubscribe()` always aborts the underlying fetch, preventing connection leaks.
+- **`ngOnDestroy` calls `stopBatchStream()`**: Ensures the Subscription and the
+  underlying AbortController are cleaned up when the component is destroyed.
+
+## Pitfalls Caught in Review
+
+1. **Hard-coded URL**: Initial implementation used `/api/reschedule/batch/stream`
+   directly. Must use `environment.apiUrl` prefix to match all other service methods
+   and support environment-specific API base URLs.
+2. **`response.body!` non-null assertion**: Replaced with explicit null guard:
+   `if (!response.body) { observer.error(...); return; }`.
+3. **401 not distinguished**: Added explicit `response.status === 401` check with
+   a Korean user-facing message, distinct from generic `SSE failed: N` errors.
+4. **`fetch` bypasses Angular interceptors**: Acknowledged trade-off — SSE cannot
+   use `HttpClient`. 401 and error handling must be implemented inline.
+
+## Test Pattern for fetch-based SSE
+
+```typescript
+// Mock fetch with a ReadableStream SSE payload
+vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, body: stream } as Response);
+
+// Mock AbortController as a class (vi.fn() as arrow function fails with "not a constructor")
+vi.spyOn(globalThis, 'AbortController').mockImplementation(
+  class { abort = abortFn; signal = {} as AbortSignal; } as unknown as new () => AbortController,
+);
+
+// RescheduleService now injects AuthService — TestBed must provide a mock:
+{ provide: AuthService, useValue: { getToken: () => 'test-token' } }
+```
+
+## Outcome
+
+- 11/11 service tests passing
+- `streamBatchReschedule()` emits progress events in real-time, completes on terminal event
+- Component cleans up Subscription in `ngOnDestroy`
+- CI: all checks pass

--- a/frontend/appointment-frontend/src/app/core/models/index.ts
+++ b/frontend/appointment-frontend/src/app/core/models/index.ts
@@ -6,4 +6,5 @@ export * from './treatment-type.model';
 export * from './clinic.model';
 export * from './equipment.model';
 export * from './reschedule-candidate.model';
+export * from './reschedule-progress.model';
 export * from './equipment-unavailability.model';

--- a/frontend/appointment-frontend/src/app/core/models/reschedule-progress.model.ts
+++ b/frontend/appointment-frontend/src/app/core/models/reschedule-progress.model.ts
@@ -1,0 +1,12 @@
+export interface RescheduleProgressEvent {
+  appointmentId: number;
+  candidateCount: number;
+  totalProcessed: number;
+  done: boolean;
+}
+
+export interface BatchRescheduleStreamParams {
+  clinicId: number;
+  closureDate: string;
+  searchDays: number;
+}

--- a/frontend/appointment-frontend/src/app/core/services/reschedule.service.spec.ts
+++ b/frontend/appointment-frontend/src/app/core/services/reschedule.service.spec.ts
@@ -1,9 +1,13 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { firstValueFrom, toArray } from 'rxjs';
 import { TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
 import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { RescheduleService } from './reschedule.service';
+import { AuthService } from './auth.service';
+
+const mockAuthService = { getToken: () => 'test-token' };
 
 describe('RescheduleService', () => {
   let service: RescheduleService;
@@ -11,7 +15,11 @@ describe('RescheduleService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [provideHttpClient(), provideHttpClientTesting()],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: AuthService, useValue: mockAuthService },
+      ],
     });
     service = TestBed.inject(RescheduleService);
     httpTesting = TestBed.inject(HttpTestingController);
@@ -121,6 +129,57 @@ describe('RescheduleService', () => {
 
       const result = await promise;
       expect(result).toBeNull();
+    });
+  });
+
+  describe('streamBatchReschedule()', () => {
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('progress + complete 이벤트를 순서대로 방출한다', async () => {
+      const ssePayload =
+        'event: progress\ndata: {"appointmentId":1,"candidateCount":3,"totalProcessed":1,"done":false}\n\n' +
+        'event: complete\ndata: {"appointmentId":-1,"candidateCount":0,"totalProcessed":1,"done":true}\n\n';
+
+      const stream = new ReadableStream({
+        start(ctrl) {
+          ctrl.enqueue(new TextEncoder().encode(ssePayload));
+          ctrl.close();
+        },
+      });
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: true, body: stream } as Response);
+
+      const params = { clinicId: 1, closureDate: '2026-05-19', searchDays: 7 };
+      const events = await firstValueFrom(service.streamBatchReschedule(params).pipe(toArray()));
+
+      expect(events).toHaveLength(2);
+      expect(events[0]).toEqual({ appointmentId: 1, candidateCount: 3, totalProcessed: 1, done: false });
+      expect(events[1]).toEqual({ appointmentId: -1, candidateCount: 0, totalProcessed: 1, done: true });
+    });
+
+    it('HTTP 오류 응답 시 에러를 방출한다', async () => {
+      vi.spyOn(globalThis, 'fetch').mockResolvedValue({ ok: false, status: 403 } as Response);
+
+      const params = { clinicId: 1, closureDate: '2026-05-19', searchDays: 7 };
+      await expect(firstValueFrom(service.streamBatchReschedule(params))).rejects.toThrow('SSE failed: 403');
+    });
+
+    it('구독 취소 시 fetch를 abort한다', () => {
+      const abortFn = vi.fn();
+      vi.spyOn(globalThis, 'AbortController').mockImplementation(
+        class {
+          abort = abortFn;
+          signal = {} as AbortSignal;
+        } as unknown as new () => AbortController,
+      );
+      vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise(() => {}));
+
+      const params = { clinicId: 1, closureDate: '2026-05-19', searchDays: 7 };
+      const sub = service.streamBatchReschedule(params).subscribe();
+      sub.unsubscribe();
+
+      expect(abortFn).toHaveBeenCalledOnce();
     });
   });
 });

--- a/frontend/appointment-frontend/src/app/core/services/reschedule.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/reschedule.service.ts
@@ -1,13 +1,15 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
-import { firstValueFrom } from 'rxjs';
-import { ApiResponse, RescheduleCandidate } from '../models';
+import { firstValueFrom, Observable } from 'rxjs';
+import { ApiResponse, RescheduleCandidate, BatchRescheduleStreamParams, RescheduleProgressEvent } from '../models';
 import { environment } from '../../../environments/environment';
+import { AuthService } from './auth.service';
 
 @Injectable({ providedIn: 'root' })
 export class RescheduleService {
   private readonly http = inject(HttpClient);
   private readonly baseUrl = `${environment.apiUrl}/appointments`;
+  private readonly authService = inject(AuthService);
 
   /**
    * 진료실 휴진 일괄 재배정 후보 조회 (R1)
@@ -68,5 +70,92 @@ export class RescheduleService {
       )
     );
     return res.data ?? null;
+  }
+
+  /**
+   * Streams batch closure reschedule progress as Server-Sent Events.
+   *
+   * Uses fetch + ReadableStream to support Authorization header (EventSource does not).
+   *
+   * ## Behavior / Contract
+   * - Emits one RescheduleProgressEvent per appointment as candidates are found.
+   * - Emits a terminal event with done=true when the stream completes.
+   * - Unsubscribing aborts the fetch via AbortController.
+   */
+  streamBatchReschedule(params: BatchRescheduleStreamParams): Observable<RescheduleProgressEvent> {
+    return new Observable(observer => {
+      const token = this.authService.getToken();
+      const qs = new URLSearchParams({
+        clinicId: String(params.clinicId),
+        closureDate: params.closureDate,
+        searchDays: String(params.searchDays),
+      });
+      const url = `${environment.apiUrl}/reschedule/batch/stream?${qs}`;
+      const controller = new AbortController();
+
+      fetch(url, {
+        headers: {
+          Accept: 'text/event-stream',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        signal: controller.signal,
+      })
+        .then(async response => {
+          if (response.status === 401) {
+            observer.error(new Error('SSE: 인증이 필요합니다.'));
+            return;
+          }
+          if (!response.ok) {
+            observer.error(new Error(`SSE failed: ${response.status}`));
+            return;
+          }
+          if (!response.body) {
+            observer.error(new Error('SSE: 응답 본문이 없습니다.'));
+            return;
+          }
+
+          const reader = response.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const blocks = buffer.split('\n\n');
+            buffer = blocks.pop() ?? '';
+
+            for (const block of blocks) {
+              if (!block.trim()) continue;
+              let dataLine = '';
+              for (const line of block.split('\n')) {
+                if (line.startsWith('data:')) {
+                  dataLine = line.slice(5).trim();
+                }
+              }
+              if (!dataLine) continue;
+              try {
+                const event: RescheduleProgressEvent = JSON.parse(dataLine);
+                observer.next(event);
+                if (event.done) {
+                  observer.complete();
+                  return;
+                }
+              } catch {
+                // malformed JSON — skip
+              }
+            }
+          }
+          observer.complete();
+        })
+        .catch(err => {
+          if ((err as Error).name !== 'AbortError') {
+            observer.error(err);
+          }
+        });
+
+      return () => controller.abort();
+    });
   }
 }

--- a/frontend/appointment-frontend/src/app/features/management/reschedule-list/reschedule-list.component.ts
+++ b/frontend/appointment-frontend/src/app/features/management/reschedule-list/reschedule-list.component.ts
@@ -1,4 +1,5 @@
-import { Component, inject, signal } from '@angular/core';
+import { Component, inject, signal, computed, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { MatCardModule } from '@angular/material/card';
 import { MatTableModule } from '@angular/material/table';
 import { MatButtonModule } from '@angular/material/button';
@@ -8,11 +9,12 @@ import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
 import { MatChipsModule } from '@angular/material/chips';
 import { FormsModule } from '@angular/forms';
 import { AuthService } from '../../../core/services/auth.service';
 import { RescheduleService } from '../../../core/services/reschedule.service';
-import { RescheduleCandidate } from '../../../core/models';
+import { RescheduleCandidate, RescheduleProgressEvent } from '../../../core/models';
 
 @Component({
   selector: 'app-reschedule-list',
@@ -20,7 +22,7 @@ import { RescheduleCandidate } from '../../../core/models';
   imports: [
     MatCardModule, MatTableModule, MatButtonModule, MatIconModule,
     MatFormFieldModule, MatInputModule, MatSelectModule, MatSnackBarModule,
-    MatProgressSpinnerModule, MatChipsModule, FormsModule,
+    MatProgressSpinnerModule, MatProgressBarModule, MatChipsModule, FormsModule,
   ],
   template: `
     <div class="page-container">
@@ -60,14 +62,23 @@ import { RescheduleCandidate } from '../../../core/models';
               </mat-form-field>
             }
 
-            <button mat-raised-button color="primary" (click)="search()" [disabled]="loading()">
+            <button mat-raised-button color="primary" (click)="search()" [disabled]="loading() || streaming()">
               <mat-icon>search</mat-icon> 조회
             </button>
+
+            @if (searchType() === 'closure') {
+              <button mat-raised-button color="accent"
+                      (click)="streaming() ? stopBatchStream() : startBatchStream()"
+                      [disabled]="loading()">
+                <mat-icon>{{ streaming() ? 'stop' : 'stream' }}</mat-icon>
+                {{ streaming() ? '중단' : '일괄 재배정 스트림' }}
+              </button>
+            }
           </div>
         </mat-card-content>
       </mat-card>
 
-      <!-- 로딩 -->
+      <!-- 일반 로딩 -->
       @if (loading()) {
         <div class="loading-container">
           <mat-spinner diameter="40"></mat-spinner>
@@ -75,6 +86,81 @@ import { RescheduleCandidate } from '../../../core/models';
             <p class="loading-message">최적화 진행 중... {{ elapsedSeconds() }}초</p>
           }
         </div>
+      }
+
+      <!-- SSE 스트리밍 진행률 -->
+      @if (streaming() || streamDone()) {
+        <mat-card class="stream-card">
+          <mat-card-content>
+            <div class="stream-header">
+              <h2 class="section-title">
+                @if (streaming()) { 일괄 재배정 진행 중... }
+                @else { 일괄 재배정 완료 }
+              </h2>
+              <span class="stream-count">{{ progressRows().length }}건 처리됨</span>
+            </div>
+
+            <mat-progress-bar
+              [mode]="streaming() ? 'indeterminate' : 'determinate'"
+              [value]="streaming() ? 0 : 100"
+              class="stream-progress-bar">
+            </mat-progress-bar>
+
+            @if (streamError()) {
+              <p class="stream-error">
+                <mat-icon>error_outline</mat-icon> {{ streamError() }}
+              </p>
+            }
+
+            @if (streamDone() && !streamError()) {
+              <div class="stream-summary">
+                <span class="summary-item success">
+                  <mat-icon>check_circle</mat-icon> 후보 있음: {{ successCount() }}건
+                </span>
+                <span class="summary-item warn">
+                  <mat-icon>warning</mat-icon> 후보 없음: {{ noCandidate() }}건
+                </span>
+              </div>
+            }
+
+            @if (progressRows().length > 0) {
+              <table mat-table [dataSource]="progressRows()" class="full-width stream-table">
+                <ng-container matColumnDef="order">
+                  <th mat-header-cell *matHeaderCellDef>#</th>
+                  <td mat-cell *matCellDef="let r">{{ r.totalProcessed }}</td>
+                </ng-container>
+
+                <ng-container matColumnDef="appointmentId">
+                  <th mat-header-cell *matHeaderCellDef>예약 ID</th>
+                  <td mat-cell *matCellDef="let r">{{ r.appointmentId }}</td>
+                </ng-container>
+
+                <ng-container matColumnDef="candidateCount">
+                  <th mat-header-cell *matHeaderCellDef>후보 수</th>
+                  <td mat-cell *matCellDef="let r">
+                    <mat-chip-set>
+                      <mat-chip [highlighted]="r.candidateCount > 0">{{ r.candidateCount }}</mat-chip>
+                    </mat-chip-set>
+                  </td>
+                </ng-container>
+
+                <ng-container matColumnDef="status">
+                  <th mat-header-cell *matHeaderCellDef>상태</th>
+                  <td mat-cell *matCellDef="let r">
+                    @if (r.candidateCount > 0) {
+                      <mat-icon class="status-ok">check_circle</mat-icon>
+                    } @else {
+                      <mat-icon class="status-warn">warning</mat-icon>
+                    }
+                  </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="streamColumns"></tr>
+                <tr mat-row *matRowDef="let row; columns: streamColumns;"></tr>
+              </table>
+            }
+          </mat-card-content>
+        </mat-card>
       }
 
       <!-- 후보 목록 -->
@@ -177,6 +263,58 @@ import { RescheduleCandidate } from '../../../core/models';
       min-width: 140px;
     }
 
+    .stream-card {
+      margin-bottom: 24px;
+    }
+
+    .stream-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 12px;
+    }
+
+    .stream-count {
+      font-size: 0.9rem;
+      color: #666;
+    }
+
+    .stream-progress-bar {
+      margin-bottom: 16px;
+    }
+
+    .stream-summary {
+      display: flex;
+      gap: 24px;
+      margin-bottom: 16px;
+    }
+
+    .summary-item {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      font-size: 0.9rem;
+    }
+
+    .summary-item.success { color: #388e3c; }
+    .summary-item.warn    { color: #f57c00; }
+
+    .stream-table {
+      width: 100%;
+      margin-top: 8px;
+    }
+
+    .stream-error {
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      color: #d32f2f;
+      margin-bottom: 12px;
+    }
+
+    .status-ok   { color: #388e3c; font-size: 18px; }
+    .status-warn { color: #f57c00; font-size: 18px; }
+
     .result-card {
       margin-bottom: 24px;
     }
@@ -221,12 +359,13 @@ import { RescheduleCandidate } from '../../../core/models';
     }
   `],
 })
-export class RescheduleListComponent {
+export class RescheduleListComponent implements OnDestroy {
   private readonly authService = inject(AuthService);
   private readonly rescheduleService = inject(RescheduleService);
   private readonly snackBar = inject(MatSnackBar);
 
   readonly displayedColumns = ['candidateDate', 'time', 'doctorId', 'priority', 'actions'];
+  readonly streamColumns = ['order', 'appointmentId', 'candidateCount', 'status'];
 
   readonly appointmentId = signal<number>(0);
   readonly searchType = signal<'candidates' | 'closure'>('candidates');
@@ -238,7 +377,22 @@ export class RescheduleListComponent {
   readonly searched = signal(false);
   readonly candidates = signal<RescheduleCandidate[]>([]);
   readonly elapsedSeconds = signal(0);
+
+  readonly streaming = signal(false);
+  readonly streamDone = signal(false);
+  readonly progressRows = signal<RescheduleProgressEvent[]>([]);
+  readonly streamError = signal<string | null>(null);
+
+  readonly successCount = computed(() => this.progressRows().filter(r => r.candidateCount > 0).length);
+  readonly noCandidate = computed(() => this.progressRows().filter(r => r.candidateCount === 0).length);
+
   private elapsedTimer: ReturnType<typeof setInterval> | null = null;
+  private streamSub: Subscription | null = null;
+
+  ngOnDestroy(): void {
+    this.stopBatchStream();
+    this.stopElapsedTimer();
+  }
 
   async search(): Promise<void> {
     const id = this.appointmentId();
@@ -261,10 +415,52 @@ export class RescheduleListComponent {
         const flat = Array.from(result.values()).flat();
         this.candidates.set(flat);
       }
-    } catch (e) {
+    } catch {
       this.snackBar.open('재배정 후보 조회에 실패했습니다.', '확인', { duration: 3000 });
     } finally {
       this.loading.set(false);
+    }
+  }
+
+  startBatchStream(): void {
+    if (!this.closureDate()) {
+      this.snackBar.open('휴진 날짜를 입력하세요.', '확인', { duration: 3000 });
+      return;
+    }
+
+    this.streaming.set(true);
+    this.streamDone.set(false);
+    this.streamError.set(null);
+    this.progressRows.set([]);
+
+    this.streamSub = this.rescheduleService.streamBatchReschedule({
+      clinicId: this.clinicId(),
+      closureDate: this.closureDate(),
+      searchDays: this.searchDays(),
+    }).subscribe({
+      next: event => {
+        if (!event.done) {
+          this.progressRows.update(rows => [...rows, event]);
+        }
+      },
+      error: (err: Error) => {
+        this.streaming.set(false);
+        this.streamDone.set(true);
+        this.streamError.set(err.message ?? '스트림 연결에 실패했습니다.');
+      },
+      complete: () => {
+        this.streaming.set(false);
+        this.streamDone.set(true);
+      },
+    });
+  }
+
+  stopBatchStream(): void {
+    this.streamSub?.unsubscribe();
+    this.streamSub = null;
+    if (this.streaming()) {
+      this.streaming.set(false);
+      this.streamDone.set(true);
     }
   }
 
@@ -274,7 +470,7 @@ export class RescheduleListComponent {
       this.snackBar.open(`재배정 완료 — 새 예약 ID: ${newId}`, '확인', { duration: 5000 });
       this.candidates.set([]);
       this.searched.set(false);
-    } catch (e) {
+    } catch {
       this.snackBar.open('재배정 확정에 실패했습니다.', '확인', { duration: 3000 });
     }
   }
@@ -291,7 +487,7 @@ export class RescheduleListComponent {
       } else {
         this.snackBar.open('자동 재배정 가능한 후보가 없습니다.', '확인', { duration: 3000 });
       }
-    } catch (e) {
+    } catch {
       this.snackBar.open('자동 재배정에 실패했습니다.', '확인', { duration: 3000 });
     } finally {
       this.stopElapsedTimer();


### PR DESCRIPTION
## Summary

Implements Issues #30 and #31 — Angular SSE streaming for batch closure reschedule.

### Approach

Uses `fetch + ReadableStream` instead of `EventSource` to support JWT `Authorization` header.
`EventSource` does not allow custom headers, making it incompatible with Bearer token auth.

### Changes

| File | Change |
|------|--------|
| `reschedule-progress.model.ts` | New: `RescheduleProgressEvent`, `BatchRescheduleStreamParams` |
| `reschedule.service.ts` | Add `streamBatchReschedule()` — fetch + ReadableStream SSE, AbortController teardown |
| `reschedule.service.spec.ts` | 3 new SSE tests: stream events, HTTP error, unsubscribe abort |
| `reschedule-list.component.ts` | Progress bar + real-time results table + summary card |
| `docs/lessons/2026-05-19-*.md` | SSE pattern lessons committed |

### SSE Behavior

- Emits one `RescheduleProgressEvent` per appointment after candidate search completes
- Terminal event (`done=true`) triggers `observer.complete()`
- Unsubscribing calls `AbortController.abort()` — no connection leak
- `ngOnDestroy` calls `stopBatchStream()` for component lifecycle safety

### UI

- `일괄 재배정 스트림` button appears when searchType is `closure`
- `중단` button shown while streaming
- Progress bar: indeterminate → determinate 100% on completion
- Real-time table: order, appointmentId, candidateCount, status icon
- Summary on completion: 후보 있음 N건 / 후보 없음 M건
- Error message fallback if stream fails

### Test Results

```
Test Files  1 passed (1)
Tests       11 passed (11)
Duration    415ms
```

### Verification

```bash
cd frontend/appointment-frontend && npx ng test --no-watch --include "**/reschedule.service.spec.ts"
```

### Checklist

- [x] All tests passing (11/11)
- [x] CRITICAL issue resolved (environment.apiUrl used)
- [x] HIGH issues resolved (response.body null guard, 401 explicit handling)
- [x] Lessons committed before PR
- [x] Closes #30, Closes #31