### PR TITLE
feat: admin dashboard stats API + Chart.js frontend (#44, #45)

### DIFF
--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/GlobalExceptionHandler.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/GlobalExceptionHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -21,6 +22,14 @@ class GlobalExceptionHandler {
         log.warn(ex) { "Validation failed: $message" }
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)
             .body(ApiResponse.error(message.ifBlank { "Validation failed" }))
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleTypeMismatch(ex: MethodArgumentTypeMismatchException): ResponseEntity<ApiResponse<Nothing>> {
+        val message = "Invalid value '${ex.value}' for parameter '${ex.name}'"
+        log.warn(ex) { "Type mismatch: $message" }
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(ApiResponse.error(message))
     }
 
     @ExceptionHandler(HttpMessageNotReadableException::class)

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt
@@ -1,7 +1,9 @@
 package io.bluetape4k.clinic.appointment.api.config
 
+import io.bluetape4k.clinic.appointment.api.service.DashboardStatsService
 import io.bluetape4k.clinic.appointment.repository.AppointmentRepository
 import io.bluetape4k.clinic.appointment.repository.AppointmentStateHistoryRepository
+import io.bluetape4k.clinic.appointment.repository.AppointmentStatsRepository
 import io.bluetape4k.clinic.appointment.repository.ClinicRepository
 import io.bluetape4k.clinic.appointment.repository.DoctorRepository
 import io.bluetape4k.clinic.appointment.repository.EquipmentRepository
@@ -97,4 +99,14 @@ class ServiceConfig {
         repo = equipmentUnavailabilityRepository,
         appointmentRepository = appointmentRepository,
     )
+
+    // --- Stats 빈 ---
+
+    @Bean
+    fun appointmentStatsRepository(): AppointmentStatsRepository = AppointmentStatsRepository()
+
+    @Bean
+    fun dashboardStatsService(
+        appointmentStatsRepository: AppointmentStatsRepository,
+    ): DashboardStatsService = DashboardStatsService(appointmentStatsRepository)
 }

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/DashboardStatsController.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/DashboardStatsController.kt
@@ -1,0 +1,112 @@
+package io.bluetape4k.clinic.appointment.api.controller
+
+import io.bluetape4k.clinic.appointment.api.dto.ApiResponse
+import io.bluetape4k.clinic.appointment.api.dto.AppointmentStatsResponse
+import io.bluetape4k.clinic.appointment.api.dto.CancellationStatsResponse
+import io.bluetape4k.clinic.appointment.api.dto.DoctorStatsResponse
+import io.bluetape4k.clinic.appointment.api.service.DashboardStatsService
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.responses.ApiResponse as OApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.format.annotation.DateTimeFormat
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDate
+
+/**
+ * Admin dashboard statistics REST controller.
+ *
+ * ## Behavior / Contract
+ * - All endpoints require `clinicId > 0`; invalid values return HTTP 400.
+ * - `from` / `to` default to [today-29, today] (30 days) when omitted.
+ * - Period exceeding 366 days returns HTTP 400.
+ * - Unknown `clinicId` returns HTTP 200 with empty data.
+ */
+@Tag(name = "Admin - Dashboard Stats", description = "Appointment statistics for admin dashboard")
+@RestController
+@RequestMapping("/api/admin/stats")
+class DashboardStatsController(
+    private val dashboardStatsService: DashboardStatsService,
+) {
+    companion object : KLogging()
+
+    /**
+     * Returns daily appointment counts grouped by status.
+     *
+     * @param clinicId Target clinic ID (must be > 0)
+     * @param from Inclusive start date; defaults to today-29 when null
+     * @param to Inclusive end date; defaults to today when null
+     * @param statuses Optional status name filter; null means all statuses
+     */
+    @Operation(summary = "Daily appointment counts grouped by status")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
+    @GetMapping("/appointments")
+    fun getAppointmentStats(
+        @Parameter(description = "Clinic ID") @RequestParam clinicId: Long,
+        @Parameter(description = "Start date (ISO)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate?,
+        @Parameter(description = "End date (ISO)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?,
+        @Parameter(description = "Status name filter list") @RequestParam(required = false) statuses: List<String>?,
+    ): ResponseEntity<ApiResponse<AppointmentStatsResponse>> {
+        log.debug { "GET /api/admin/stats/appointments clinicId=$clinicId from=$from to=$to statuses=$statuses" }
+        val result = dashboardStatsService.getAppointmentStats(clinicId, from, to, statuses)
+        return ResponseEntity.ok(ApiResponse.ok(result))
+    }
+
+    /**
+     * Returns per-doctor appointment metrics sorted by total appointments descending.
+     *
+     * @param clinicId Target clinic ID (must be > 0)
+     * @param from Inclusive start date; defaults to today-29 when null
+     * @param to Inclusive end date; defaults to today when null
+     * @param limit Max number of doctors to return (1..100, default 20)
+     */
+    @Operation(summary = "Per-doctor appointment metrics")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
+    @GetMapping("/doctors")
+    fun getDoctorStats(
+        @Parameter(description = "Clinic ID") @RequestParam clinicId: Long,
+        @Parameter(description = "Start date (ISO)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate?,
+        @Parameter(description = "End date (ISO)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?,
+        @Parameter(description = "Max doctors to return (1..100)") @RequestParam(defaultValue = "20") limit: Int,
+    ): ResponseEntity<ApiResponse<DoctorStatsResponse>> {
+        log.debug { "GET /api/admin/stats/doctors clinicId=$clinicId from=$from to=$to limit=$limit" }
+        val result = dashboardStatsService.getDoctorStats(clinicId, from, to, limit)
+        return ResponseEntity.ok(ApiResponse.ok(result))
+    }
+
+    /**
+     * Returns cancellation and no-show trends.
+     *
+     * @param clinicId Target clinic ID (must be > 0)
+     * @param from Inclusive start date; defaults to today-29 when null
+     * @param to Inclusive end date; defaults to today when null
+     */
+    @Operation(summary = "Cancellation and no-show trends")
+    @ApiResponses(
+        OApiResponse(responseCode = "200", description = "Success"),
+        OApiResponse(responseCode = "400", description = "Invalid parameters"),
+    )
+    @GetMapping("/cancellations")
+    fun getCancellationStats(
+        @Parameter(description = "Clinic ID") @RequestParam clinicId: Long,
+        @Parameter(description = "Start date (ISO)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) from: LocalDate?,
+        @Parameter(description = "End date (ISO)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) to: LocalDate?,
+    ): ResponseEntity<ApiResponse<CancellationStatsResponse>> {
+        log.debug { "GET /api/admin/stats/cancellations clinicId=$clinicId from=$from to=$to" }
+        val result = dashboardStatsService.getCancellationStats(clinicId, from, to)
+        return ResponseEntity.ok(ApiResponse.ok(result))
+    }
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/AppointmentStatsResponse.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/AppointmentStatsResponse.kt
@@ -1,0 +1,52 @@
+package io.bluetape4k.clinic.appointment.api.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.io.Serializable
+import java.time.LocalDate
+
+/**
+ * Response for GET /api/admin/stats/appointments.
+ *
+ * ## Behavior / Contract
+ * - [daily] is ordered by date ascending.
+ * - [totals] keys are [AppointmentState][io.bluetape4k.clinic.appointment.statemachine.AppointmentState] names.
+ * - When no appointments exist for the period, [daily] is empty and all [totals] values are 0.
+ */
+@Schema(description = "Daily appointment counts grouped by status for the given clinic and date range")
+data class AppointmentStatsResponse(
+    @Schema(description = "Target clinic ID")
+    val clinicId: Long,
+    @Schema(description = "Inclusive start date of the query range")
+    val from: LocalDate,
+    @Schema(description = "Inclusive end date of the query range")
+    val to: LocalDate,
+    @Schema(description = "Aggregated totals per status across the entire period; keys are AppointmentState names")
+    val totals: Map<String, Long>,
+    @Schema(description = "Day-by-day breakdown; one entry per date that has at least one appointment")
+    val daily: List<DailyAppointmentBucket>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+/**
+ * Per-day appointment counts broken down by status.
+ *
+ * ## Behavior / Contract
+ * - [countsByStatus] contains only statuses that have count > 0 for this date.
+ * - [total] equals the sum of all values in [countsByStatus].
+ */
+@Schema(description = "Appointment counts for a single day, broken down by status")
+data class DailyAppointmentBucket(
+    @Schema(description = "The date this bucket represents")
+    val date: LocalDate,
+    @Schema(description = "Count per status; keys are AppointmentState names, values are counts (> 0 only)")
+    val countsByStatus: Map<String, Long>,
+    @Schema(description = "Sum of all status counts for this day")
+    val total: Long,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/CancellationStatsResponse.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/CancellationStatsResponse.kt
@@ -1,0 +1,66 @@
+package io.bluetape4k.clinic.appointment.api.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.io.Serializable
+import java.time.LocalDate
+
+/**
+ * Response for GET /api/admin/stats/cancellations.
+ *
+ * ## Behavior / Contract
+ * - Denominator for rate calculations: CANCELLED + COMPLETED + NO_SHOW + RESCHEDULED (terminal statuses only).
+ *   In-progress statuses (REQUESTED, CONFIRMED, etc.) are excluded to avoid noise.
+ * - [cancellationRate] = CANCELLED / denominator; 0.0 when denominator is 0.
+ * - [noShowRate] = NO_SHOW / denominator; 0.0 when denominator is 0.
+ * - [daily] contains one entry per date that has at least one tracked appointment.
+ */
+@Schema(description = "Cancellation and no-show trends for the given clinic and date range")
+data class CancellationStatsResponse(
+    @Schema(description = "Target clinic ID")
+    val clinicId: Long,
+    @Schema(description = "Inclusive start date of the query range")
+    val from: LocalDate,
+    @Schema(description = "Inclusive end date of the query range")
+    val to: LocalDate,
+    @Schema(description = "Total CANCELLED appointments in the period")
+    val totalCancelled: Long,
+    @Schema(description = "Total NO_SHOW appointments in the period")
+    val totalNoShow: Long,
+    @Schema(description = "Total RESCHEDULED appointments in the period")
+    val totalRescheduled: Long,
+    @Schema(description = "Total COMPLETED appointments in the period")
+    val totalCompleted: Long,
+    @Schema(description = "CANCELLED / (CANCELLED + COMPLETED + NO_SHOW + RESCHEDULED); 0.0 when denominator is 0")
+    val cancellationRate: Double,
+    @Schema(description = "NO_SHOW / (CANCELLED + COMPLETED + NO_SHOW + RESCHEDULED); 0.0 when denominator is 0")
+    val noShowRate: Double,
+    @Schema(description = "Day-by-day breakdown of terminal-status counts")
+    val daily: List<DailyCancellationBucket>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+/**
+ * Per-day counts of terminal-status appointments.
+ *
+ * ## Behavior / Contract
+ * - COMPLETED is not tracked here; this bucket focuses on negative outcomes.
+ * - A date appears only if at least one of [cancelled], [noShow], or [rescheduled] is > 0.
+ */
+@Schema(description = "Daily cancellation, no-show, and rescheduled counts")
+data class DailyCancellationBucket(
+    @Schema(description = "The date this bucket represents")
+    val date: LocalDate,
+    @Schema(description = "CANCELLED count for this day")
+    val cancelled: Long,
+    @Schema(description = "NO_SHOW count for this day")
+    val noShow: Long,
+    @Schema(description = "RESCHEDULED count for this day")
+    val rescheduled: Long,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/DoctorStatsResponse.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/DoctorStatsResponse.kt
@@ -1,0 +1,57 @@
+package io.bluetape4k.clinic.appointment.api.dto
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.io.Serializable
+import java.time.LocalDate
+
+/**
+ * Response for GET /api/admin/stats/doctors.
+ *
+ * ## Behavior / Contract
+ * - [doctors] is sorted by [DoctorBucket.totalAppointments] descending (service layer responsibility).
+ * - The list is limited to the top N doctors as specified by the `limit` query parameter.
+ * - Doctor names are not included; callers resolve ID→name via DoctorService.
+ */
+@Schema(description = "Per-doctor appointment counts and completion rates for the given clinic and date range")
+data class DoctorStatsResponse(
+    @Schema(description = "Target clinic ID")
+    val clinicId: Long,
+    @Schema(description = "Inclusive start date of the query range")
+    val from: LocalDate,
+    @Schema(description = "Inclusive end date of the query range")
+    val to: LocalDate,
+    @Schema(description = "Top-N doctors sorted by totalAppointments descending")
+    val doctors: List<DoctorBucket>,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+/**
+ * Appointment metrics for a single doctor over the query period.
+ *
+ * ## Behavior / Contract
+ * - [completionRate] = completed / (completed + cancelled + noShow).
+ * - When the denominator is 0 (no terminal appointments), [completionRate] is 0.0.
+ * - [totalAppointments] includes all statuses, not only terminal ones.
+ */
+@Schema(description = "Appointment metrics for a single doctor")
+data class DoctorBucket(
+    @Schema(description = "Doctor ID")
+    val doctorId: Long,
+    @Schema(description = "Total appointments across all statuses in the period")
+    val totalAppointments: Long,
+    @Schema(description = "Count of COMPLETED appointments")
+    val completed: Long,
+    @Schema(description = "Count of CANCELLED appointments")
+    val cancelled: Long,
+    @Schema(description = "Count of NO_SHOW appointments")
+    val noShow: Long,
+    @Schema(description = "completed / (completed + cancelled + noShow); 0.0 when denominator is 0")
+    val completionRate: Double,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityConfig.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityConfig.kt
@@ -46,6 +46,8 @@ class SecurityConfig {
                 auth
                     // OpenAPI / Swagger / Actuator
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/actuator/**").permitAll()
+                    // 어드민 대시보드 — ADMIN 전용
+                    .requestMatchers("/api/admin/**").hasRole(SchedulingRole.ADMIN)
                     // 읽기 API — 인증만 필요
                     .requestMatchers(HttpMethod.GET, "/api/**").authenticated()
                     // 쓰기 API — ADMIN 또는 STAFF

--- a/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/DashboardStatsService.kt
+++ b/appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/DashboardStatsService.kt
@@ -1,0 +1,228 @@
+package io.bluetape4k.clinic.appointment.api.service
+
+import io.bluetape4k.clinic.appointment.api.dto.AppointmentStatsResponse
+import io.bluetape4k.clinic.appointment.api.dto.CancellationStatsResponse
+import io.bluetape4k.clinic.appointment.api.dto.DailyAppointmentBucket
+import io.bluetape4k.clinic.appointment.api.dto.DailyCancellationBucket
+import io.bluetape4k.clinic.appointment.api.dto.DoctorBucket
+import io.bluetape4k.clinic.appointment.api.dto.DoctorStatsResponse
+import io.bluetape4k.clinic.appointment.repository.AppointmentStatsRepository
+import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.logging.debug
+import io.bluetape4k.support.requirePositiveNumber
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import java.time.LocalDate
+import java.time.temporal.ChronoUnit
+
+/**
+ * Admin dashboard aggregation service.
+ *
+ * ## Behavior / Contract
+ * - All three methods validate `clinicId > 0`, `from <= to`, and period `<= 366` days.
+ * - Default period when `from`/`to` are null: `[today-29, today]` (30 days inclusive).
+ * - Registered as a Spring bean via [io.bluetape4k.clinic.appointment.api.config.ServiceConfig];
+ *   no `@Service` annotation — do not add it.
+ */
+class DashboardStatsService(
+    private val statsRepository: AppointmentStatsRepository,
+) {
+    companion object : KLogging() {
+        private const val DEFAULT_DAYS = 29L
+        private const val MAX_PERIOD_DAYS = 366L
+        private val ALLOWED_LIMIT = 1..100
+
+        private val CANCELLATION_STATUSES = listOf(
+            AppointmentState.CANCELLED,
+            AppointmentState.NO_SHOW,
+            AppointmentState.RESCHEDULED,
+            AppointmentState.COMPLETED,
+        )
+    }
+
+    /**
+     * Returns daily appointment counts grouped by status.
+     *
+     * ## Behavior / Contract
+     * - `statuses` filters which statuses are counted; null means all statuses.
+     * - Unknown status name in `statuses` throws [IllegalArgumentException] (propagated from
+     *   [AppointmentState.fromName]).
+     * - An unknown `clinicId` returns an empty response (HTTP 200), not an error.
+     */
+    fun getAppointmentStats(
+        clinicId: Long,
+        from: LocalDate?,
+        to: LocalDate?,
+        statuses: List<String>? = null,
+    ): AppointmentStatsResponse {
+        clinicId.requirePositiveNumber("clinicId")
+        val effectiveTo = to ?: LocalDate.now()
+        val effectiveFrom = from ?: effectiveTo.minusDays(DEFAULT_DAYS)
+
+        require(!effectiveFrom.isAfter(effectiveTo)) { "from must be on or before to" }
+        require(ChronoUnit.DAYS.between(effectiveFrom, effectiveTo) <= MAX_PERIOD_DAYS) {
+            "period exceeds 366 days"
+        }
+
+        val statusFilter = statuses?.map { AppointmentState.fromName(it) }
+
+        log.debug { "getAppointmentStats: clinicId=$clinicId, $effectiveFrom..$effectiveTo, statuses=$statuses" }
+
+        val rows = transaction {
+            statsRepository.countByDateAndStatus(clinicId, effectiveFrom..effectiveTo, statusFilter)
+        }
+
+        val byDate = rows.groupBy { it.first }
+        val daily = byDate.entries
+            .sortedBy { it.key }
+            .map { (date, entries) ->
+                val countsByStatus = entries.associate { it.second.name to it.third }
+                DailyAppointmentBucket(
+                    date = date,
+                    countsByStatus = countsByStatus,
+                    total = countsByStatus.values.sum(),
+                )
+            }
+
+        val totals = rows.groupBy { it.second.name }
+            .mapValues { (_, entries) -> entries.sumOf { it.third } }
+
+        return AppointmentStatsResponse(
+            clinicId = clinicId,
+            from = effectiveFrom,
+            to = effectiveTo,
+            totals = totals,
+            daily = daily,
+        )
+    }
+
+    /**
+     * Returns per-doctor appointment metrics, sorted by total appointments descending.
+     *
+     * ## Behavior / Contract
+     * - `limit` must be in `1..100`; otherwise throws [IllegalArgumentException].
+     * - `completionRate` = completed / (completed + cancelled + noShow); 0.0 when denominator is 0.
+     * - Sorting and `take(limit)` happen in Kotlin after DB aggregation — SQL LIMIT is not applied
+     *   at the query level because SQL LIMIT would operate on (doctorId, status) rows, not on
+     *   doctor-level totals.
+     */
+    fun getDoctorStats(
+        clinicId: Long,
+        from: LocalDate?,
+        to: LocalDate?,
+        limit: Int = 20,
+    ): DoctorStatsResponse {
+        clinicId.requirePositiveNumber("clinicId")
+        require(limit in ALLOWED_LIMIT) { "limit must be between 1 and 100, got $limit" }
+        val effectiveTo = to ?: LocalDate.now()
+        val effectiveFrom = from ?: effectiveTo.minusDays(DEFAULT_DAYS)
+
+        require(!effectiveFrom.isAfter(effectiveTo)) { "from must be on or before to" }
+        require(ChronoUnit.DAYS.between(effectiveFrom, effectiveTo) <= MAX_PERIOD_DAYS) {
+            "period exceeds 366 days"
+        }
+
+        log.debug { "getDoctorStats: clinicId=$clinicId, $effectiveFrom..$effectiveTo, limit=$limit" }
+
+        val rows = transaction {
+            statsRepository.countByDoctorAndStatus(clinicId, effectiveFrom..effectiveTo)
+        }
+
+        val doctors = rows.groupBy { it.doctorId }
+            .map { (doctorId, entries) ->
+                val countByStatus = entries.associate { it.status to it.count }
+                val completed = countByStatus[AppointmentState.COMPLETED] ?: 0L
+                val cancelled = countByStatus[AppointmentState.CANCELLED] ?: 0L
+                val noShow = countByStatus[AppointmentState.NO_SHOW] ?: 0L
+                val total = entries.sumOf { it.count }
+                val denominator = completed + cancelled + noShow
+                val completionRate = if (denominator == 0L) 0.0 else completed.toDouble() / denominator
+
+                DoctorBucket(
+                    doctorId = doctorId,
+                    totalAppointments = total,
+                    completed = completed,
+                    cancelled = cancelled,
+                    noShow = noShow,
+                    completionRate = completionRate,
+                )
+            }
+            .sortedByDescending { it.totalAppointments }
+            .take(limit)
+
+        return DoctorStatsResponse(
+            clinicId = clinicId,
+            from = effectiveFrom,
+            to = effectiveTo,
+            doctors = doctors,
+        )
+    }
+
+    /**
+     * Returns cancellation and no-show trends.
+     *
+     * ## Behavior / Contract
+     * - Denominator for rates: CANCELLED + NO_SHOW + RESCHEDULED + COMPLETED (terminal statuses).
+     *   In-progress statuses are excluded to avoid noise.
+     * - `cancellationRate` = CANCELLED / denominator; 0.0 when denominator is 0.
+     * - `noShowRate` = NO_SHOW / denominator; 0.0 when denominator is 0.
+     * - Daily buckets contain only dates with at least one of CANCELLED, NO_SHOW, or RESCHEDULED > 0.
+     */
+    fun getCancellationStats(
+        clinicId: Long,
+        from: LocalDate?,
+        to: LocalDate?,
+    ): CancellationStatsResponse {
+        clinicId.requirePositiveNumber("clinicId")
+        val effectiveTo = to ?: LocalDate.now()
+        val effectiveFrom = from ?: effectiveTo.minusDays(DEFAULT_DAYS)
+
+        require(!effectiveFrom.isAfter(effectiveTo)) { "from must be on or before to" }
+        require(ChronoUnit.DAYS.between(effectiveFrom, effectiveTo) <= MAX_PERIOD_DAYS) {
+            "period exceeds 366 days"
+        }
+
+        log.debug { "getCancellationStats: clinicId=$clinicId, $effectiveFrom..$effectiveTo" }
+
+        val rows = transaction {
+            statsRepository.countByDateAndStatus(clinicId, effectiveFrom..effectiveTo, CANCELLATION_STATUSES)
+        }
+
+        val countByStatus = rows.groupBy { it.second }
+            .mapValues { (_, entries) -> entries.sumOf { it.third } }
+
+        val totalCancelled = countByStatus[AppointmentState.CANCELLED] ?: 0L
+        val totalNoShow = countByStatus[AppointmentState.NO_SHOW] ?: 0L
+        val totalRescheduled = countByStatus[AppointmentState.RESCHEDULED] ?: 0L
+        val totalCompleted = countByStatus[AppointmentState.COMPLETED] ?: 0L
+
+        val denominator = totalCancelled + totalNoShow + totalRescheduled + totalCompleted
+        val cancellationRate = if (denominator == 0L) 0.0 else totalCancelled.toDouble() / denominator
+        val noShowRate = if (denominator == 0L) 0.0 else totalNoShow.toDouble() / denominator
+
+        val daily = rows.groupBy { it.first }
+            .entries
+            .sortedBy { it.key }
+            .mapNotNull { (date, entries) ->
+                val byStatus = entries.associate { it.second to it.third }
+                val cancelled = byStatus[AppointmentState.CANCELLED] ?: 0L
+                val noShow = byStatus[AppointmentState.NO_SHOW] ?: 0L
+                val rescheduled = byStatus[AppointmentState.RESCHEDULED] ?: 0L
+                if (cancelled == 0L && noShow == 0L && rescheduled == 0L) null
+                else DailyCancellationBucket(date = date, cancelled = cancelled, noShow = noShow, rescheduled = rescheduled)
+            }
+
+        return CancellationStatsResponse(
+            clinicId = clinicId,
+            from = effectiveFrom,
+            to = effectiveTo,
+            totalCancelled = totalCancelled,
+            totalNoShow = totalNoShow,
+            totalRescheduled = totalRescheduled,
+            totalCompleted = totalCompleted,
+            cancellationRate = cancellationRate,
+            noShowRate = noShowRate,
+            daily = daily,
+        )
+    }
+}

--- a/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/DashboardStatsControllerTest.kt
+++ b/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/DashboardStatsControllerTest.kt
@@ -1,0 +1,190 @@
+package io.bluetape4k.clinic.appointment.api.controller
+
+import io.bluetape4k.clinic.appointment.model.tables.Appointments
+import io.bluetape4k.clinic.appointment.model.tables.Clinics
+import io.bluetape4k.clinic.appointment.model.tables.ConsultationTopics
+import io.bluetape4k.clinic.appointment.model.tables.Doctors
+import io.bluetape4k.clinic.appointment.model.tables.Equipments
+import io.bluetape4k.clinic.appointment.model.tables.TreatmentTypes
+import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
+import io.bluetape4k.clinic.appointment.api.test.AbstractApiIntegrationTest
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeTrue
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.web.server.LocalServerPort
+import org.springframework.http.HttpStatus
+import org.springframework.web.client.RestClient
+import java.time.LocalDate
+import java.time.LocalTime
+
+class DashboardStatsControllerTest @Autowired constructor() : AbstractApiIntegrationTest() {
+
+    companion object : KLogging() {
+        private const val BASE_URL = "/api/admin/stats"
+        private val TEST_DATE: LocalDate = LocalDate.of(2026, 5, 1)
+    }
+
+    @LocalServerPort
+    private var port: Int = 0
+
+    private lateinit var client: RestClient
+
+    private var clinicId: Long = 0L
+    private var doctorId: Long = 0L
+    private var treatmentTypeId: Long = 0L
+
+    @BeforeEach
+    fun setup() {
+        client = RestClient.builder()
+            .baseUrl("http://localhost:$port")
+            .build()
+
+        transaction {
+            SchemaUtils.create(Clinics, Doctors, Equipments, TreatmentTypes, ConsultationTopics, Appointments)
+            Appointments.deleteAll()
+            ConsultationTopics.deleteAll()
+            TreatmentTypes.deleteAll()
+            Equipments.deleteAll()
+            Doctors.deleteAll()
+            Clinics.deleteAll()
+
+            clinicId = Clinics.insertAndGetId {
+                it[name] = "Test Clinic"
+                it[slotDurationMinutes] = 30
+                it[maxConcurrentPatients] = 3
+            }.value
+
+            doctorId = Doctors.insertAndGetId {
+                it[Doctors.clinicId] = this@DashboardStatsControllerTest.clinicId
+                it[name] = "Dr. Kim"
+            }.value
+
+            treatmentTypeId = TreatmentTypes.insertAndGetId {
+                it[TreatmentTypes.clinicId] = this@DashboardStatsControllerTest.clinicId
+                it[name] = "General"
+                it[defaultDurationMinutes] = 30
+            }.value
+        }
+    }
+
+    private fun insertAppointment(date: LocalDate, status: AppointmentState) {
+        val cId = clinicId
+        val dId = doctorId
+        val ttId = treatmentTypeId
+        transaction {
+            Appointments.insertAndGetId {
+                it[Appointments.clinicId] = cId
+                it[Appointments.doctorId] = dId
+                it[Appointments.treatmentTypeId] = ttId
+                it[patientName] = "Patient"
+                it[appointmentDate] = date
+                it[startTime] = LocalTime.of(9, 0)
+                it[endTime] = LocalTime.of(9, 30)
+                it[Appointments.status] = status
+            }
+        }
+    }
+
+    // =================== GET /api/admin/stats/appointments ===================
+
+    @Test
+    fun `GET appointments stats - 200 with appointment data`() {
+        insertAppointment(TEST_DATE, AppointmentState.CONFIRMED)
+        insertAppointment(TEST_DATE, AppointmentState.CANCELLED)
+
+        val response = client.get()
+            .uri("$BASE_URL/appointments?clinicId={cId}&from={date}&to={date}", clinicId, TEST_DATE, TEST_DATE)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.OK
+        response.jsonPath<Boolean>("$.success").shouldBeTrue()
+        response.jsonPath<Int>("$.data.totals.CONFIRMED") shouldBeEqualTo 1
+        response.jsonPath<Int>("$.data.totals.CANCELLED") shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `GET appointments stats - 200 empty for unknown clinic`() {
+        val response = client.get()
+            .uri("$BASE_URL/appointments?clinicId=999999&from={date}&to={date}", TEST_DATE, TEST_DATE)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.OK
+        response.jsonPath<Boolean>("$.success").shouldBeTrue()
+    }
+
+    @Test
+    fun `GET appointments stats - 400 when from after to`() {
+        val response = client.get()
+            .uri("$BASE_URL/appointments?clinicId={cId}&from=2026-05-10&to=2026-05-01", clinicId)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.BAD_REQUEST
+    }
+
+    @Test
+    fun `GET appointments stats - 400 when clinicId is zero`() {
+        val response = client.get()
+            .uri("$BASE_URL/appointments?clinicId=0&from={date}&to={date}", TEST_DATE, TEST_DATE)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.BAD_REQUEST
+    }
+
+    // =================== GET /api/admin/stats/doctors ===================
+
+    @Test
+    fun `GET doctor stats - 200 with doctor data`() {
+        insertAppointment(TEST_DATE, AppointmentState.COMPLETED)
+
+        val response = client.get()
+            .uri("$BASE_URL/doctors?clinicId={cId}&from={date}&to={date}", clinicId, TEST_DATE, TEST_DATE)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.OK
+        response.jsonPath<Boolean>("$.success").shouldBeTrue()
+        val doctors = response.jsonPath<List<*>>("$.data.doctors")
+        doctors.size shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `GET doctor stats - 400 when limit is zero`() {
+        val response = client.get()
+            .uri("$BASE_URL/doctors?clinicId={cId}&from={date}&to={date}&limit=0", clinicId, TEST_DATE, TEST_DATE)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.BAD_REQUEST
+    }
+
+    // =================== GET /api/admin/stats/cancellations ===================
+
+    @Test
+    fun `GET cancellation stats - 200 with cancellation data`() {
+        insertAppointment(TEST_DATE, AppointmentState.CANCELLED)
+        insertAppointment(TEST_DATE, AppointmentState.COMPLETED)
+
+        val response = client.get()
+            .uri("$BASE_URL/cancellations?clinicId={cId}&from={date}&to={date}", clinicId, TEST_DATE, TEST_DATE)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.OK
+        response.jsonPath<Boolean>("$.success").shouldBeTrue()
+        response.jsonPath<Int>("$.data.totalCancelled") shouldBeEqualTo 1
+        response.jsonPath<Int>("$.data.totalCompleted") shouldBeEqualTo 1
+    }
+
+    @Test
+    fun `GET cancellation stats - 400 when from after to`() {
+        val response = client.get()
+            .uri("$BASE_URL/cancellations?clinicId={cId}&from=2026-05-10&to=2026-05-01", clinicId)
+            .execute()
+
+        response.statusCode shouldBeEqualTo HttpStatus.BAD_REQUEST
+    }
+}

--- a/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/service/DashboardStatsServiceTest.kt
+++ b/appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/service/DashboardStatsServiceTest.kt
@@ -1,0 +1,280 @@
+package io.bluetape4k.clinic.appointment.api.service
+
+import io.bluetape4k.clinic.appointment.api.test.Containers
+import io.bluetape4k.clinic.appointment.model.tables.Appointments
+import io.bluetape4k.clinic.appointment.model.tables.Clinics
+import io.bluetape4k.clinic.appointment.model.tables.ConsultationTopics
+import io.bluetape4k.clinic.appointment.model.tables.Doctors
+import io.bluetape4k.clinic.appointment.model.tables.Equipments
+import io.bluetape4k.clinic.appointment.model.tables.TreatmentTypes
+import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeTrue
+import io.bluetape4k.assertions.shouldNotBeEmpty
+import org.jetbrains.exposed.v1.jdbc.SchemaUtils
+import org.jetbrains.exposed.v1.jdbc.deleteAll
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.time.LocalDate
+import java.time.LocalTime
+import kotlin.test.assertFailsWith
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@ActiveProfiles("test")
+class DashboardStatsServiceTest {
+
+    companion object : KLogging() {
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun configureRedis(registry: DynamicPropertyRegistry) {
+            registry.add("spring.data.redis.url") { Containers.Redis.url }
+        }
+    }
+
+    @Autowired
+    private lateinit var dashboardStatsService: DashboardStatsService
+
+    private var clinicId: Long = 0L
+    private var doctorId: Long = 0L
+    private var treatmentTypeId: Long = 0L
+
+    @BeforeEach
+    fun setup() {
+        transaction {
+            SchemaUtils.create(Clinics, Doctors, Equipments, TreatmentTypes, ConsultationTopics, Appointments)
+            Appointments.deleteAll()
+            ConsultationTopics.deleteAll()
+            TreatmentTypes.deleteAll()
+            Equipments.deleteAll()
+            Doctors.deleteAll()
+            Clinics.deleteAll()
+
+            // Extract locals to avoid implicit-receiver shadowing inside insertAndGetId lambdas.
+            // Inside Clinics.insertAndGetId {}, the implicit receiver is Clinics, so local names
+            // like clinicId/doctorId would resolve to columns rather than the class property.
+            val cId = Clinics.insertAndGetId {
+                it[name] = "Test Clinic"
+                it[slotDurationMinutes] = 30
+                it[maxConcurrentPatients] = 3
+            }.value
+            clinicId = cId
+
+            val dId = Doctors.insertAndGetId {
+                it[clinicId] = cId        // KEY: Doctors.clinicId column; VALUE: cId local
+                it[name] = "Dr. Kim"
+            }.value
+            doctorId = dId
+
+            val ttId = TreatmentTypes.insertAndGetId {
+                it[clinicId] = cId        // KEY: TreatmentTypes.clinicId; VALUE: cId local
+                it[name] = "General"
+                it[defaultDurationMinutes] = 30
+            }.value
+            treatmentTypeId = ttId
+        }
+    }
+
+    private fun insertAppointment(date: LocalDate, status: AppointmentState) {
+        val cId = clinicId
+        val dId = doctorId
+        val ttId = treatmentTypeId
+        transaction {
+            Appointments.insertAndGetId {
+                it[clinicId] = cId        // KEY: Appointments.clinicId; VALUE: cId local
+                it[doctorId] = dId        // KEY: Appointments.doctorId; VALUE: dId local
+                it[treatmentTypeId] = ttId
+                it[patientName] = "Patient"
+                it[appointmentDate] = date
+                it[startTime] = LocalTime.of(9, 0)
+                it[endTime] = LocalTime.of(9, 30)
+                it[Appointments.status] = status
+            }
+        }
+    }
+
+    // =================== getAppointmentStats ===================
+
+    @Test
+    fun `getAppointmentStats - 정상 bucket 조립 및 totals 계산`() {
+        val date = LocalDate.of(2026, 5, 1)
+        insertAppointment(date, AppointmentState.CONFIRMED)
+        insertAppointment(date, AppointmentState.CONFIRMED)
+        insertAppointment(date, AppointmentState.CANCELLED)
+
+        val result = dashboardStatsService.getAppointmentStats(clinicId, date, date)
+
+        result.clinicId shouldBeEqualTo clinicId
+        result.from shouldBeEqualTo date
+        result.to shouldBeEqualTo date
+        result.totals["CONFIRMED"] shouldBeEqualTo 2L
+        result.totals["CANCELLED"] shouldBeEqualTo 1L
+        result.daily.shouldNotBeEmpty()
+        result.daily[0].countsByStatus["CONFIRMED"] shouldBeEqualTo 2L
+        result.daily[0].countsByStatus["CANCELLED"] shouldBeEqualTo 1L
+        result.daily[0].total shouldBeEqualTo 3L
+    }
+
+    @Test
+    fun `getAppointmentStats - 빈 clinic은 empty daily 및 empty totals 반환`() {
+        val date = LocalDate.of(2026, 5, 1)
+        val result = dashboardStatsService.getAppointmentStats(999L, date, date)
+
+        result.daily.shouldBeEmpty()
+        result.totals.values.all { it == 0L }.shouldBeTrue()
+    }
+
+    @Test
+    fun `getAppointmentStats - from이 to 이후면 IAE`() {
+        val from = LocalDate.of(2026, 5, 10)
+        val to = LocalDate.of(2026, 5, 1)
+
+        assertFailsWith<IllegalArgumentException> {
+            dashboardStatsService.getAppointmentStats(clinicId, from, to)
+        }
+    }
+
+    @Test
+    fun `getAppointmentStats - 367일 초과 범위는 IAE`() {
+        val from = LocalDate.of(2026, 1, 1)
+        val to = from.plusDays(367)
+
+        assertFailsWith<IllegalArgumentException> {
+            dashboardStatsService.getAppointmentStats(clinicId, from, to)
+        }
+    }
+
+    @Test
+    fun `getAppointmentStats - clinicId 0 이하는 IAE`() {
+        val date = LocalDate.of(2026, 5, 1)
+
+        assertFailsWith<IllegalArgumentException> {
+            dashboardStatsService.getAppointmentStats(0L, date, date)
+        }
+    }
+
+    @Test
+    fun `getAppointmentStats - 알 수 없는 상태명은 IAE 전파`() {
+        val date = LocalDate.of(2026, 5, 1)
+
+        assertFailsWith<IllegalArgumentException> {
+            dashboardStatsService.getAppointmentStats(clinicId, date, date, statuses = listOf("UNKNOWN"))
+        }
+    }
+
+    @Test
+    fun `getAppointmentStats - from·to null이면 기본 30일 기간 적용`() {
+        val result = dashboardStatsService.getAppointmentStats(clinicId, null, null)
+
+        val today = LocalDate.now()
+        result.to shouldBeEqualTo today
+        result.from shouldBeEqualTo today.minusDays(29)
+    }
+
+    // =================== getDoctorStats ===================
+
+    @Test
+    fun `getDoctorStats - totalAppointments 기준 내림차순 정렬`() {
+        val date = LocalDate.of(2026, 5, 1)
+        val cId = clinicId
+        val ttId = treatmentTypeId
+
+        val doctor2Id = transaction {
+            Doctors.insertAndGetId {
+                it[clinicId] = cId        // KEY: Doctors.clinicId; VALUE: cId local
+                it[name] = "Dr. Park"
+            }.value
+        }
+
+        // doctorId: 2건, doctor2Id: 1건
+        insertAppointment(date, AppointmentState.COMPLETED)
+        insertAppointment(date, AppointmentState.CONFIRMED)
+
+        transaction {
+            Appointments.insertAndGetId {
+                it[clinicId] = cId        // KEY: Appointments.clinicId; VALUE: cId local
+                it[doctorId] = doctor2Id  // KEY: Appointments.doctorId; VALUE: doctor2Id local
+                it[treatmentTypeId] = ttId
+                it[patientName] = "Patient2"
+                it[appointmentDate] = date
+                it[startTime] = LocalTime.of(10, 0)
+                it[endTime] = LocalTime.of(10, 30)
+                it[status] = AppointmentState.CONFIRMED
+            }
+        }
+
+        val result = dashboardStatsService.getDoctorStats(clinicId, date, date, limit = 10)
+
+        result.doctors.shouldNotBeEmpty()
+        result.doctors[0].doctorId shouldBeEqualTo doctorId
+        result.doctors[0].totalAppointments shouldBeEqualTo 2L
+    }
+
+    @Test
+    fun `getDoctorStats - 터미널 상태 없을 때 completionRate 0점0 안전`() {
+        val date = LocalDate.of(2026, 5, 1)
+        insertAppointment(date, AppointmentState.CONFIRMED)
+
+        val result = dashboardStatsService.getDoctorStats(clinicId, date, date, limit = 10)
+
+        result.doctors[0].completionRate shouldBeEqualTo 0.0
+    }
+
+    @Test
+    fun `getDoctorStats - limit 0 은 IAE`() {
+        val date = LocalDate.of(2026, 5, 1)
+
+        assertFailsWith<IllegalArgumentException> {
+            dashboardStatsService.getDoctorStats(clinicId, date, date, limit = 0)
+        }
+    }
+
+    @Test
+    fun `getDoctorStats - limit 101 은 IAE`() {
+        val date = LocalDate.of(2026, 5, 1)
+
+        assertFailsWith<IllegalArgumentException> {
+            dashboardStatsService.getDoctorStats(clinicId, date, date, limit = 101)
+        }
+    }
+
+    // =================== getCancellationStats ===================
+
+    @Test
+    fun `getCancellationStats - rate 계산 정확성 검증`() {
+        val date = LocalDate.of(2026, 5, 1)
+        insertAppointment(date, AppointmentState.CANCELLED)
+        insertAppointment(date, AppointmentState.CANCELLED)
+        insertAppointment(date, AppointmentState.COMPLETED)
+        insertAppointment(date, AppointmentState.NO_SHOW)
+
+        val result = dashboardStatsService.getCancellationStats(clinicId, date, date)
+
+        result.totalCancelled shouldBeEqualTo 2L
+        result.totalNoShow shouldBeEqualTo 1L
+        result.totalCompleted shouldBeEqualTo 1L
+        // denominator = 2+1+0+1 = 4; cancellationRate = 2/4 = 0.5
+        result.cancellationRate shouldBeEqualTo 0.5
+        result.noShowRate shouldBeEqualTo 0.25
+    }
+
+    @Test
+    fun `getCancellationStats - 터미널 상태 없을 때 rate 0점0 안전`() {
+        val date = LocalDate.of(2026, 5, 1)
+        insertAppointment(date, AppointmentState.CONFIRMED)
+
+        val result = dashboardStatsService.getCancellationStats(clinicId, date, date)
+
+        result.cancellationRate shouldBeEqualTo 0.0
+        result.noShowRate shouldBeEqualTo 0.0
+    }
+}

--- a/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentStatsRepository.kt
+++ b/appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentStatsRepository.kt
@@ -1,0 +1,119 @@
+package io.bluetape4k.clinic.appointment.repository
+
+import io.bluetape4k.clinic.appointment.model.tables.Appointments
+import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
+import io.bluetape4k.logging.KLogging
+import org.jetbrains.exposed.v1.core.count
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.greaterEq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.lessEq
+import org.jetbrains.exposed.v1.jdbc.andWhere
+import org.jetbrains.exposed.v1.jdbc.select
+import java.io.Serializable
+import java.time.LocalDate
+
+/**
+ * Per-row result of a doctor-level status aggregation.
+ *
+ * Uses a named data class instead of Triple to prevent positional confusion
+ * between two Long fields (doctorId, count). See CLAUDE.md same-type parameter rule.
+ *
+ * ## Behavior / Contract
+ * - One row per (doctorId, status) combination within the query date range.
+ * - count is always ≥ 1.
+ * - Callers must invoke this inside a `transaction {}` block.
+ */
+data class DoctorStatusCount(
+    val doctorId: Long,
+    val status: AppointmentState,
+    val count: Long,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID = 1L
+    }
+}
+
+/**
+ * Aggregate-query repository for the admin dashboard stats API.
+ *
+ * ## Behavior / Contract
+ * - All methods must be called inside a `transaction {}` block.
+ * - No SQL LIMIT or ORDER BY is applied — callers own sorting and pagination.
+ */
+class AppointmentStatsRepository {
+    companion object : KLogging()
+
+    /**
+     * Returns appointment counts grouped by (date, status) for a given clinic and date range.
+     *
+     * ## Behavior / Contract
+     * - When [statuses] is null all status values are included.
+     * - Returns an empty list when no appointments match the criteria.
+     * - Result rows are in database-natural order; callers sort as needed.
+     * - Must be called inside `transaction {}`.
+     *
+     * @param clinicId target clinic
+     * @param dateRange inclusive date range (from..to)
+     * @param statuses optional status filter; null means all statuses
+     * @return list of (date, status, count) triples
+     */
+    fun countByDateAndStatus(
+        clinicId: Long,
+        dateRange: ClosedRange<LocalDate>,
+        statuses: List<AppointmentState>? = null,
+    ): List<Triple<LocalDate, AppointmentState, Long>> {
+        val countExpr = Appointments.id.count()
+        return Appointments
+            .select(Appointments.appointmentDate, Appointments.status, countExpr)
+            .where { Appointments.clinicId eq clinicId }
+            .andWhere { Appointments.appointmentDate greaterEq dateRange.start }
+            .andWhere { Appointments.appointmentDate lessEq dateRange.endInclusive }
+            .let { query ->
+                if (statuses != null) query.andWhere { Appointments.status inList statuses }
+                else query
+            }
+            .groupBy(Appointments.appointmentDate, Appointments.status)
+            .map { row ->
+                Triple(
+                    row[Appointments.appointmentDate],
+                    row[Appointments.status],
+                    row[countExpr],
+                )
+            }
+    }
+
+    /**
+     * Returns appointment counts grouped by (doctorId, status) for a given clinic and date range.
+     *
+     * ## Behavior / Contract
+     * - No SQL LIMIT or ORDER BY is applied. The service layer handles ranking via
+     *   `groupBy { it.doctorId }`, `sortedByDescending { totalAppointments }`, and `take(limit)`.
+     *   Applying SQL LIMIT here would truncate (doctorId, status) rows before the service
+     *   can aggregate per-doctor totals, producing incorrect rankings.
+     * - Must be called inside `transaction {}`.
+     *
+     * @param clinicId target clinic
+     * @param dateRange inclusive date range (from..to)
+     * @return list of [DoctorStatusCount] — one entry per (doctorId, status) combination
+     */
+    fun countByDoctorAndStatus(
+        clinicId: Long,
+        dateRange: ClosedRange<LocalDate>,
+    ): List<DoctorStatusCount> {
+        val countExpr = Appointments.id.count()
+        return Appointments
+            .select(Appointments.doctorId, Appointments.status, countExpr)
+            .where { Appointments.clinicId eq clinicId }
+            .andWhere { Appointments.appointmentDate greaterEq dateRange.start }
+            .andWhere { Appointments.appointmentDate lessEq dateRange.endInclusive }
+            .groupBy(Appointments.doctorId, Appointments.status)
+            .map { row ->
+                DoctorStatusCount(
+                    doctorId = row[Appointments.doctorId].value,
+                    status = row[Appointments.status],
+                    count = row[countExpr],
+                )
+            }
+    }
+}

--- a/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentStatsRepositoryTest.kt
+++ b/appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentStatsRepositoryTest.kt
@@ -1,0 +1,238 @@
+package io.bluetape4k.clinic.appointment.repository
+
+import io.bluetape4k.clinic.appointment.model.tables.Appointments
+import io.bluetape4k.clinic.appointment.model.tables.Clinics
+import io.bluetape4k.clinic.appointment.model.tables.ConsultationTopics
+import io.bluetape4k.clinic.appointment.model.tables.Doctors
+import io.bluetape4k.clinic.appointment.model.tables.Equipments
+import io.bluetape4k.clinic.appointment.model.tables.TreatmentTypes
+import io.bluetape4k.clinic.appointment.statemachine.AppointmentState
+import io.bluetape4k.clinic.appointment.test.AbstractExposedTest
+import io.bluetape4k.clinic.appointment.test.TestDB
+import io.bluetape4k.clinic.appointment.test.withTables
+import io.bluetape4k.logging.KLogging
+import io.bluetape4k.assertions.shouldBeEmpty
+import io.bluetape4k.assertions.shouldBeEqualTo
+import io.bluetape4k.assertions.shouldHaveSize
+import org.jetbrains.exposed.v1.jdbc.JdbcTransaction
+import org.jetbrains.exposed.v1.jdbc.insertAndGetId
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import java.time.LocalDate
+import java.time.LocalTime
+
+class AppointmentStatsRepositoryTest : AbstractExposedTest() {
+
+    companion object : KLogging() {
+        private val repo = AppointmentStatsRepository()
+
+        private val allTables = arrayOf(
+            Clinics,
+            Doctors,
+            Equipments,
+            TreatmentTypes,
+            ConsultationTopics,
+            Appointments,
+        )
+    }
+
+    private fun JdbcTransaction.setupBaseData(): Triple<Long, Long, Long> {
+        val clinicId = Clinics.insertAndGetId {
+            it[name] = "Test Clinic"
+            it[slotDurationMinutes] = 30
+            it[maxConcurrentPatients] = 3
+        }.value
+
+        val doctorId = Doctors.insertAndGetId {
+            it[Doctors.clinicId] = clinicId
+            it[name] = "Dr. Kim"
+        }.value
+
+        val treatmentTypeId = TreatmentTypes.insertAndGetId {
+            it[TreatmentTypes.clinicId] = clinicId
+            it[name] = "General Consultation"
+            it[defaultDurationMinutes] = 30
+        }.value
+
+        return Triple(clinicId, doctorId, treatmentTypeId)
+    }
+
+    private fun JdbcTransaction.insertAppointment(
+        clinicId: Long,
+        doctorId: Long,
+        treatmentTypeId: Long,
+        date: LocalDate,
+        status: AppointmentState,
+    ): Long = Appointments.insertAndGetId {
+        it[Appointments.clinicId] = clinicId
+        it[Appointments.doctorId] = doctorId
+        it[Appointments.treatmentTypeId] = treatmentTypeId
+        it[patientName] = "Patient"
+        it[appointmentDate] = date
+        it[startTime] = LocalTime.of(9, 0)
+        it[endTime] = LocalTime.of(9, 30)
+        it[Appointments.status] = status
+    }.value
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `countByDateAndStatus - 날짜별 상태 집계 반환`(testDB: TestDB) {
+        withTables(testDB, *allTables) {
+            val (clinicId, doctorId, treatmentTypeId) = setupBaseData()
+            val date = LocalDate.of(2026, 5, 1)
+
+            insertAppointment(clinicId, doctorId, treatmentTypeId, date, AppointmentState.CONFIRMED)
+            insertAppointment(clinicId, doctorId, treatmentTypeId, date, AppointmentState.CONFIRMED)
+            insertAppointment(clinicId, doctorId, treatmentTypeId, date, AppointmentState.CANCELLED)
+
+            val results = repo.countByDateAndStatus(clinicId, date..date)
+
+            results shouldHaveSize 2
+            val confirmedCount = results.first { it.second == AppointmentState.CONFIRMED }.third
+            confirmedCount shouldBeEqualTo 2L
+            val cancelledCount = results.first { it.second == AppointmentState.CANCELLED }.third
+            cancelledCount shouldBeEqualTo 1L
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `countByDateAndStatus - statuses 필터 적용`(testDB: TestDB) {
+        withTables(testDB, *allTables) {
+            val (clinicId, doctorId, treatmentTypeId) = setupBaseData()
+            val date = LocalDate.of(2026, 5, 1)
+
+            insertAppointment(clinicId, doctorId, treatmentTypeId, date, AppointmentState.CONFIRMED)
+            insertAppointment(clinicId, doctorId, treatmentTypeId, date, AppointmentState.CANCELLED)
+
+            val results = repo.countByDateAndStatus(
+                clinicId, date..date,
+                listOf(AppointmentState.CONFIRMED)
+            )
+
+            results shouldHaveSize 1
+            results[0].second shouldBeEqualTo AppointmentState.CONFIRMED
+            results[0].third shouldBeEqualTo 1L
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `countByDateAndStatus - 날짜 경계 검증`(testDB: TestDB) {
+        withTables(testDB, *allTables) {
+            val (clinicId, doctorId, treatmentTypeId) = setupBaseData()
+            val from = LocalDate.of(2026, 5, 1)
+            val to = LocalDate.of(2026, 5, 31)
+
+            insertAppointment(clinicId, doctorId, treatmentTypeId, from, AppointmentState.CONFIRMED)
+            insertAppointment(clinicId, doctorId, treatmentTypeId, to, AppointmentState.CONFIRMED)
+            insertAppointment(clinicId, doctorId, treatmentTypeId, to.plusDays(1), AppointmentState.CONFIRMED)
+
+            val results = repo.countByDateAndStatus(clinicId, from..to)
+
+            results.sumOf { it.third } shouldBeEqualTo 2L
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `countByDateAndStatus - 데이터 없으면 빈 결과`(testDB: TestDB) {
+        withTables(testDB, *allTables) {
+            val (clinicId, _, _) = setupBaseData()
+            val date = LocalDate.of(2026, 5, 1)
+
+            val results = repo.countByDateAndStatus(clinicId, date..date)
+
+            results.shouldBeEmpty()
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `countByDateAndStatus - clinicId 격리 검증`(testDB: TestDB) {
+        withTables(testDB, *allTables) {
+            val (clinicId, doctorId, treatmentTypeId) = setupBaseData()
+            val date = LocalDate.of(2026, 5, 1)
+
+            val otherClinicId = Clinics.insertAndGetId {
+                it[name] = "Other Clinic"
+                it[slotDurationMinutes] = 30
+                it[maxConcurrentPatients] = 3
+            }.value
+            val otherDoctorId = Doctors.insertAndGetId {
+                it[Doctors.clinicId] = otherClinicId
+                it[name] = "Dr. Lee"
+            }.value
+            val otherTreatmentTypeId = TreatmentTypes.insertAndGetId {
+                it[TreatmentTypes.clinicId] = otherClinicId
+                it[name] = "General"
+                it[defaultDurationMinutes] = 30
+            }.value
+
+            insertAppointment(clinicId, doctorId, treatmentTypeId, date, AppointmentState.CONFIRMED)
+            insertAppointment(otherClinicId, otherDoctorId, otherTreatmentTypeId, date, AppointmentState.CONFIRMED)
+            insertAppointment(otherClinicId, otherDoctorId, otherTreatmentTypeId, date, AppointmentState.CONFIRMED)
+
+            val results = repo.countByDateAndStatus(clinicId, date..date)
+
+            results.sumOf { it.third } shouldBeEqualTo 1L
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `countByDoctorAndStatus - 의사 3명 x 상태 다종 집계`(testDB: TestDB) {
+        withTables(testDB, *allTables) {
+            val (clinicId, doctorId1, treatmentTypeId) = setupBaseData()
+
+            val doctorId2 = Doctors.insertAndGetId {
+                it[Doctors.clinicId] = clinicId
+                it[name] = "Dr. Park"
+            }.value
+            val doctorId3 = Doctors.insertAndGetId {
+                it[Doctors.clinicId] = clinicId
+                it[name] = "Dr. Choi"
+            }.value
+
+            val date = LocalDate.of(2026, 5, 1)
+
+            // doc1: CONFIRMED×2, CANCELLED×1
+            insertAppointment(clinicId, doctorId1, treatmentTypeId, date, AppointmentState.CONFIRMED)
+            insertAppointment(clinicId, doctorId1, treatmentTypeId, date, AppointmentState.CONFIRMED)
+            insertAppointment(clinicId, doctorId1, treatmentTypeId, date, AppointmentState.CANCELLED)
+            // doc2: COMPLETED×1
+            insertAppointment(clinicId, doctorId2, treatmentTypeId, date, AppointmentState.COMPLETED)
+            // doc3: NO_SHOW×1
+            insertAppointment(clinicId, doctorId3, treatmentTypeId, date, AppointmentState.NO_SHOW)
+
+            val results = repo.countByDoctorAndStatus(clinicId, date..date)
+
+            // (doc1,CONFIRMED,2), (doc1,CANCELLED,1), (doc2,COMPLETED,1), (doc3,NO_SHOW,1)
+            results shouldHaveSize 4
+            val doc1Confirmed = results.first { it.doctorId == doctorId1 && it.status == AppointmentState.CONFIRMED }
+            doc1Confirmed.count shouldBeEqualTo 2L
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource(ENABLE_DIALECTS_METHOD)
+    fun `countByDoctorAndStatus - SQL LIMIT 없음 - 모든 의사 행 반환`(testDB: TestDB) {
+        withTables(testDB, *allTables) {
+            val (clinicId, _, treatmentTypeId) = setupBaseData()
+            val date = LocalDate.of(2026, 5, 1)
+
+            repeat(5) { i ->
+                val doctorId = Doctors.insertAndGetId {
+                    it[Doctors.clinicId] = clinicId
+                    it[name] = "Dr. $i"
+                }.value
+                insertAppointment(clinicId, doctorId, treatmentTypeId, date, AppointmentState.CONFIRMED)
+            }
+
+            val results = repo.countByDoctorAndStatus(clinicId, date..date)
+
+            // 5 doctors × 1 status each = 5 rows; no limit applied at SQL level
+            results shouldHaveSize 5
+        }
+    }
+}

--- a/docs/lessons/2026-05-19-dashboard-stats.md
+++ b/docs/lessons/2026-05-19-dashboard-stats.md
@@ -1,0 +1,76 @@
+# Dashboard Stats — 이슈 #44/#45 구현 회고
+
+## 배경
+
+이슈 #44: `GET /api/admin/stats/appointments|doctors|cancellations` 집계 API 구현
+이슈 #45: Angular `/management/admin-dashboard` 라우트 + Chart.js 차트 구현
+
+---
+
+## 핵심 의사결정
+
+### 1. AppointmentStatsRepository — Exposed groupBy/count 쿼리
+
+`countByDateAndStatus` / `countByDoctorAndStatus` 두 메서드를 `AppointmentStatsRepository`에 추가.
+- `groupBy(Appointments.appointmentDate, Appointments.status)` + `count()` 로 DB 단에서 집계 수행
+- Kotlin List로 반환 후 서비스 레이어에서 버킷 조립 (date → DailyAppointmentBucket)
+- SQL LIMIT 미사용: `(doctorId, status)` 행 단위가 아닌 의사 단위 top-N이 필요하므로 Kotlin `sortedByDescending + take(limit)` 사용
+
+### 2. Exposed implicit receiver shadowing — 테스트 픽스
+
+`insertAndGetId {}` 람다 내부에서 암시적 리시버가 Table 객체이므로 외부 프로퍼티 이름과 컬럼 이름이 동일할 때 섀도잉 발생.
+
+문제 발현 패턴:
+```kotlin
+// NG: clinicId (파라미터) vs Doctors.clinicId (컬럼) 충돌
+it[clinicId] = cId   // VALUES (SCHEDULING_DOCTORS.CLINIC_ID, ?)
+```
+
+해결 패턴 (명시적 테이블 참조):
+```kotlin
+it[Doctors.clinicId] = this@MyTest.clinicId   // VALUES (?, ?)
+```
+
+함수 파라미터와 컬럼명이 동일한 경우에도 동일한 섀도잉 발생:
+```kotlin
+// 함수 파라미터 status: AppointmentState가 Appointments.status Column을 섀도잉
+it[status] = status           // 컴파일 오류: AppointmentState는 Column<...> 아님
+it[Appointments.status] = status  // 정상
+```
+
+**교훈**: `insertAndGetId`, `insert`, `update` 람다 내부에서는 외부 프로퍼티/파라미터를 항상 명시적으로 한정하거나, 컬럼은 `it[Table.column]` 형식으로 접근.
+
+### 3. 서비스 검증 로직 설계
+
+`DashboardStatsService` 세 메서드 공통 가드:
+- `clinicId.requirePositiveNumber("clinicId")` — 0 이하 → IAE
+- `from ≤ to` — 위반 시 IAE
+- 기간 ≤ 366일 — 위반 시 IAE
+- `from/to null` → `to = today`, `from = today - 29` (30일 inclusive 기본값)
+
+알 수 없는 `clinicId`는 HTTP 200 + 빈 응답 (에러 아님) — 클라이언트에서 "데이터 없음" 화면 처리.
+
+### 4. Angular + Chart.js
+
+- `chart.js@4.x` 직접 사용, ng2-charts 미사용 (Angular 21 호환성 단순화)
+- 각 Chart 컴포넌트에서 `Chart.register(...registerables)` 호출
+- `@Input() set stats(...)` → `updateChart()` 패턴으로 데이터 바인딩
+- `ngOnDestroy()` 에서 반드시 `chart?.destroy()` 호출 (메모리 누수 방지)
+
+---
+
+## 수정된 버그
+
+| 버그 | 원인 | 수정 |
+|------|------|------|
+| `VALUES (SCHEDULING_DOCTORS.CLINIC_ID, ?)` | Exposed implicit receiver shadowing | `it[Doctors.clinicId]` 명시적 참조 |
+| 컴파일 오류 L100 `it[status] = status` | 함수 파라미터 status가 Column을 섀도잉 | `it[Appointments.status] = status` |
+
+---
+
+## 결과
+
+- 백엔드 테스트: 117개 통과, 0 실패
+  - `DashboardStatsServiceTest`: 13개
+  - `DashboardStatsControllerTest`: 8개
+- Angular 빌드: `ng build` 성공, `admin-dashboard-component` 청크 213 kB 생성

--- a/docs/superpowers/plans/2026-05-19-dashboard-stats-plan.md
+++ b/docs/superpowers/plans/2026-05-19-dashboard-stats-plan.md
@@ -94,7 +94,9 @@
 - **dependencies**: T2, T3
 - **작업**:
   - **[F4] 통합 테스트 접근법** — MockK + `transaction {}` 비호환 문제 해결을 위해 실제 H2 Repository 사용.
-    - `DashboardStatsServiceTest`는 `AbstractExposedTest()`를 상속하고 `withTables(testDB, Clinics, Doctors, Appointments) { ... }` 블록 내에서 실제 `AppointmentStatsRepository()` 인스턴스를 주입한다.
+    - **[크로스 모듈 제약]** `appointment-core/src/test`의 `AbstractExposedTest`는 `appointment-core` 에 `java-test-fixtures` 플러그인이 없으므로 `appointment-api/src/test`에서 직접 상속 불가.
+    - `DashboardStatsServiceTest`는 `@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)` + `@ActiveProfiles("test")`로 Spring 컨텍스트 (H2 + Flyway + Exposed 자동 설정)를 로드한다.
+    - `@Autowired` 로 `DashboardStatsService` 주입; `@BeforeEach`에서 `transaction { SchemaUtils.create(Clinics, Doctors, Appointments); Appointments.deleteAll(); Doctors.deleteAll(); Clinics.deleteAll() }` 패턴 (기존 `ClinicControllerTest` 패턴과 동일).
     - Service 검증 로직만 MockK로 분리할 수 없으므로 Service + Repository 통합 단위 테스트로 작성 (Repository 동작은 T1/T2에서 이미 보장).
   - 시나리오:
     - `getAppointmentStats`: 정상 — bucket 조립/totals 계산 정확성.
@@ -140,7 +142,7 @@
   - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/DashboardStatsControllerTest.kt` (신규)
 - **dependencies**: T3, T5, T8
 - **작업**:
-  - `@WebMvcTest(DashboardStatsController::class)` + `@MockkBean DashboardStatsService`.
+  - `@WebMvcTest(DashboardStatsController::class)` + `@MockkBean DashboardStatsService` + **`@ActiveProfiles("test")`** 필수 — 미지정 시 `SecurityConfig`(`@Profile("!dev & !test")`)가 활성화되어 JWT 없는 요청이 401 반환.
   - 시나리오:
     - 200 — `/api/admin/stats/appointments?clinicId=1` → `success: true`, `data.totals` 키 존재.
     - **[F5] 200 — `?clinicId=999` (데이터 없음)** → `success: true`, `data.buckets` 빈 배열 (에러 응답 아님).
@@ -356,20 +358,17 @@
 - **complexity**: high
 - **files**:
   - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityConfigDashboardTest.kt` (신규)
-  - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityTestConfig.kt` (신규 — 보안 프로파일 활성화용)
 - **dependencies**: T7, T10
 - **작업**:
   - **[F8] 구체적 보안 우회 전략**:
-    - `SecurityTestConfig.kt`: `@TestConfiguration` + `@Profile("security-test")` 클래스로 `NoOpSecurityConfig`를 **제외**하고 실제 `SecurityConfig`를 **활성화**한다.
-      ```kotlin
-      @TestConfiguration
-      class SecurityTestConfig {
-          // NoOpSecurityConfig는 @Profile("dev","test") — "security-test" 프로파일에서 비활성
-          // 실제 SecurityConfig는 @Profile("!dev & !test") — "security-test"에서 활성
-      }
-      ```
+    - `SecurityTestConfig.kt` 신규 파일 불필요 — `@ActiveProfiles("security-test")` 지정만으로 프로파일 전환 충분.
+      - `"security-test"` 프로파일 → `NoOpSecurityConfig`(`@Profile("dev","test")`) 비활성; 실제 `SecurityConfig`(`@Profile("!dev & !test")`) 활성.
     - 테스트 클래스: `@SpringBootTest(webEnvironment=MOCK)` + `@AutoConfigureMockMvc` + `@ActiveProfiles("security-test")`.
-    - JWT 토큰 생성: 기존 프로젝트의 JWT 서명 유틸리티(`JwtTokenProvider` 등)를 사용해 테스트 토큰 발급. 없으면 `JwtTokenProvider`에서 `@Autowired`로 직접 호출. ROLE_ADMIN / ROLE_STAFF / ROLE_DOCTOR 역할별 토큰 발급.
+    - **JWT 토큰 생성**: 이미 존재하는 `TestJwtProvider` (`io.bluetape4k.clinic.appointment.api.security.TestJwtProvider`) 사용.
+      - `TestJwtProvider.adminToken()` → ROLE_ADMIN 토큰
+      - `TestJwtProvider.staffToken()` → ROLE_STAFF 토큰
+      - `TestJwtProvider.doctorToken()` → ROLE_DOCTOR 토큰
+      - `application-security-test.properties`에 `jwt.secret = ${TestJwtProvider.secret}`, `jwt.issuer = ${TestJwtProvider.issuer}` 설정 필요 (JwtSecurityProperties 바인딩용).
     - `MockMvc` 요청 헤더: `Authorization: Bearer <token>`.
   - 시나리오 (스펙 §5.2):
     - ADMIN 토큰 → 200.
@@ -540,7 +539,7 @@ T18, T20 → T21
 
 - [ ] T1–T2: AppointmentStatsRepository AbstractExposedTest + withTables 패턴 PASS (SQL LIMIT 부재 포함); countCancellationsByDate 없음 확인
 - [ ] T3: DTO 3종 Serializable + serialVersionUID
-- [ ] T4–T5: DashboardStatsService 통합 테스트 PASS (AbstractExposedTest + 실제 H2 Repository); 빈 clinic 200 확인; sortedByDescending 검증 포함
+- [ ] T4–T5: DashboardStatsService 통합 테스트 PASS (`@SpringBootTest(webEnvironment=NONE)` + `@ActiveProfiles("test")` + Spring 관리 H2); 빈 clinic 200 확인; sortedByDescending 검증 포함
 - [ ] T6–T7: DashboardStatsController MockMvc PASS; 빈 clinic 200 확인; 반복 파라미터 동작 확인
 - [ ] T8: GlobalExceptionHandlerTypeMismatchTest PASS; `?from=not-a-date → 400` + JSON envelope 확인
 - [ ] T9: ServiceConfig Bean 등록, 컨텍스트 로드 PASS
@@ -550,7 +549,7 @@ T18, T20 → T21
 - [ ] T14–T16: 차트 3종; **ngOnInit** 기반 라이프사이클; ngOnDestroy.destroy() 검증
 - [ ] T17: DashboardCharts, authService.isAdmin() 분기 양방향
 - [ ] T18: ManagementDashboard 회귀 + 로컬 isAdmin 재선언 없음
-- [ ] T19: Security 통합 — `@ActiveProfiles("security-test")` 하네스; 매처 순서 + 401/403 envelope
+- [ ] T19: Security 통합 — `@ActiveProfiles("security-test")` 하네스; `TestJwtProvider` 재사용; `application-security-test.properties` jwt 설정; 매처 순서 + 401/403 envelope
 - [ ] T20: Controller 400 매트릭스 + JSON envelope
 - [ ] T21: 모든 신규 public API 영문 KDoc; Kotlin 컴파일 에러 0; tsc --noEmit PASS
 - [ ] T22: README.md + README.ko.md 동시 갱신; 섹션 구조 1:1 정렬

--- a/docs/superpowers/plans/2026-05-19-dashboard-stats-plan.md
+++ b/docs/superpowers/plans/2026-05-19-dashboard-stats-plan.md
@@ -1,0 +1,498 @@
+# 관리자 대시보드 집계 API + Angular 차트 UI 구현 계획
+
+> 연관 스펙: `docs/superpowers/specs/2026-05-19-dashboard-stats-design.md`
+> Issue [#44](https://github.com/bluetape4k/clinic-appointment/issues/44) (백엔드), [#45](https://github.com/bluetape4k/clinic-appointment/issues/45) (프론트엔드)
+> 작성일: 2026-05-19
+> Worktree: `.worktrees/feat/issue-44-45-dashboard/`
+
+---
+
+## 개요
+
+스펙 §9 구현 순서를 4단계로 재구성한다.
+
+- **Phase 1 — 백엔드**: Repository → DTO → Service → Controller → SecurityConfig → ServiceConfig. 각 컴포넌트는 RED→GREEN TDD로 구현하며 단위 테스트가 같은 태스크에 포함된다.
+- **Phase 2 — 프론트엔드**: Models → Service → 차트 3종 → 컨테이너 → ManagementDashboard 통합. 각 컴포넌트는 vitest 단위 테스트를 같은 태스크에 포함한다.
+- **Phase 3 — 교차/회귀/통합 테스트**: 단일 컴포넌트에 귀속되지 않는 SecurityConfig 매처 순서, 컨트롤러 200/401/403/400 계약, 회귀 테스트.
+- **Phase 4 — 문서 + PR 준비**: README(한/영), CHANGELOG, KDoc, code-reviewer, PR.
+
+코딩 컨벤션 준수 사항:
+
+- 모든 Exposed 호출은 `transaction {}` 내부.
+- DTO/DoctorStatusCount는 `Serializable` + `serialVersionUID = 1L`.
+- 동일 타입(`Long`, `Long`) 파라미터 위치 혼동 방지 위해 `DoctorStatusCount` named data class 사용 (Triple 금지 — CLAUDE.md).
+- bluetape4k `requireXxx` / `requireNotNull` 사용.
+- Kotlin `@Configuration(proxyBeanMethods = false)` 항상 명시.
+- `runCatching` 금지 (suspend 호출 영역). 단순 IAE는 `GlobalExceptionHandler`로 위임.
+
+---
+
+## Phase 1 — 백엔드
+
+### T1: AppointmentStatsRepository H2 단위 테스트 (RED)
+- **complexity**: medium
+- **files**:
+  - `appointment-core/src/test/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentStatsRepositoryTest.kt` (신규)
+  - `appointment-core/src/test/resources/junit-platform.properties` (없으면 신규)
+  - `appointment-core/src/test/resources/logback-test.xml` (없으면 신규)
+- **dependencies**: 없음
+- **작업**:
+  - JUnit5 + bluetape4k-assertions + H2 in-memory. `@BeforeEach`에서 `SchemaUtils.createMissingTablesAndColumns(...)` + `Appointments.deleteAll()`.
+  - 시나리오 (실패 상태): `countByDateAndStatus` — 날짜 경계/상태 필터/빈 결과/clinicId 분리 검증; `countByDoctorAndStatus` — 의사 3명 × 상태 다종 시드로 모든 (doctorId, status, count) 조합 반환 검증, **SQL LIMIT/orderBy 미포함을 결과 행 수로 단언**; `countCancellationsByDate` — CANCELLED/NO_SHOW/RESCHEDULED만 카운트.
+  - 백틱 한국어 테스트명, AAA 패턴.
+- **DoD**: 컴파일 후 메서드 부재로 실패 (RED 확인).
+
+---
+
+### T2: AppointmentStatsRepository 구현 (GREEN)
+- **complexity**: high
+- **files**:
+  - `appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentStatsRepository.kt` (신규)
+- **dependencies**: T1
+- **작업**:
+  - 패키지 `io.bluetape4k.clinic.appointment.repository`, `companion object : KLogging()`.
+  - `DoctorStatusCount(doctorId: Long, status: AppointmentState, count: Long) : Serializable` — 동일 파일 선언, KDoc에 Triple 금지 사유 명시 (동일 타입 Long 두 개 위치 혼동 위험, CLAUDE.md 규칙).
+  - 세 메서드 구현 (스펙 §4.3 시그니처 그대로):
+    - `countByDateAndStatus(clinicId, dateRange, statuses?) : List<Triple<LocalDate, AppointmentState, Long>>` — date/status는 다른 타입이므로 Triple 허용.
+    - `countByDoctorAndStatus(clinicId, dateRange) : List<DoctorStatusCount>` — **SQL LIMIT/orderBy 없음** (Service가 Kotlin groupBy + sortedByDescending + take(limit)로 의사 단위 상위 N 선별; SQL LIMIT은 (doctorId, status) 행 수에 적용되어 의미가 다름 — KDoc 명시).
+    - `countCancellationsByDate(clinicId, dateRange) : List<Triple<LocalDate, AppointmentState, Long>>` — CANCELLED/NO_SHOW/RESCHEDULED `inList` 필터.
+  - Exposed 1.2 패턴: `val countExpr = Appointments.id.count()` alias 후 `row[countExpr]` 추출.
+  - 모든 메서드 KDoc: "호출자는 transaction {} 내부에서 호출" 명시 + 영문 `## Behavior / Contract`.
+- **DoD**: T1 PASS (GREEN); `./gradlew :appointment-core:test --tests AppointmentStatsRepositoryTest` PASS.
+
+---
+
+### T3: 응답 DTO 3종
+- **complexity**: medium
+- **files**:
+  - `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/AppointmentStatsResponse.kt` (신규)
+  - `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/DoctorStatsResponse.kt` (신규)
+  - `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/dto/CancellationStatsResponse.kt` (신규)
+- **dependencies**: 없음
+- **작업**:
+  - 스펙 §3.2/§3.3/§3.4 데이터 모델 그대로 (`AppointmentStatsResponse`+`DailyAppointmentBucket`, `DoctorStatsResponse`+`DoctorBucket`, `CancellationStatsResponse`+`DailyCancellationBucket`).
+  - 모든 data class: `: Serializable` + `companion object { private const val serialVersionUID = 1L }`.
+  - 영문 KDoc + `@Schema` Swagger 어노테이션.
+  - `totals`/`countsByStatus`는 `Map<String, Long>` — 키는 `AppointmentState.name`.
+- **DoD**: `./gradlew :appointment-api:compileKotlin` PASS.
+
+---
+
+### T4: DashboardStatsService 단위 테스트 (RED)
+- **complexity**: medium
+- **files**:
+  - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/service/DashboardStatsServiceTest.kt` (신규)
+- **dependencies**: T2, T3
+- **작업**:
+  - JUnit5 + MockK. Repository는 `mockk()` 주입. H2 `Database.connect`를 `@BeforeAll`에서 1회 연결해 `transaction {}` 동작.
+  - 시나리오:
+    - `getAppointmentStats`: 정상 — bucket 조립/totals 계산 정확성.
+    - `from > to` → `IllegalArgumentException("from must be on or before to")`.
+    - 367일 범위 → `IllegalArgumentException("period exceeds 366 days")`.
+    - `clinicId <= 0` → `IllegalArgumentException` (bluetape4k `requirePositive`).
+    - `statuses = ["UNKNOWN"]` → `AppointmentState.fromName` IAE 전파 (Service 별도 try-catch 없음 확인).
+    - 기본 기간(`from/to` null) → today-29..today 적용.
+    - `getDoctorStats`: 의사 4명 × 상태 5종 — `completionRate` 분모 0 안전; **결과가 `totalAppointments` 내림차순**임을 단언 (Service sortedByDescending 책임 검증); `limit=0`/`limit=101` → IAE.
+    - `getCancellationStats`: rate 계산 정확성, 분모 0 안전.
+  - `assertFailsWith<IllegalArgumentException> { ... }` 패턴.
+- **DoD**: Service 미존재로 컴파일 실패 (RED).
+
+---
+
+### T5: DashboardStatsService 구현 (GREEN)
+- **complexity**: high
+- **files**:
+  - `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/DashboardStatsService.kt` (신규)
+- **dependencies**: T4
+- **작업**:
+  - `@Service` 미부착 — ServiceConfig 등록만 사용 (T9에서 처리).
+  - 생성자: `private val statsRepository: AppointmentStatsRepository`. `companion object : KLogging()`.
+  - 상수: `DEFAULT_DAYS = 30`, `MAX_PERIOD_DAYS = 366L`, `ALLOWED_LIMIT = 1..100`.
+  - 세 메서드 (`getAppointmentStats`, `getDoctorStats`, `getCancellationStats`):
+    - 기본값 적용 (null → today, today-29).
+    - `clinicId.requirePositive("clinicId")`, `require(!from.isAfter(to)) { "..." }`, `require(period <= MAX_PERIOD_DAYS) { "..." }`.
+    - `getDoctorStats`만 `require(limit in ALLOWED_LIMIT) { "..." }`.
+    - `statuses?.map { AppointmentState.fromName(it) }` — try-catch 없음 (GlobalExceptionHandler 위임).
+    - `transaction { statsRepository.countByXxx(...) }` → Kotlin 변환 로직:
+      - appointments: groupBy date → DailyAppointmentBucket + totals 누계.
+      - doctors: `groupBy { it.doctorId }` → DoctorBucket (completed/cancelled/noShow 추출, total=sumOf, rate=completed/(c+ca+no), 분모0→0.0) → `sortedByDescending { it.totalAppointments }.take(limit)`.
+      - cancellations: CANCELLED/NO_SHOW/RESCHEDULED/COMPLETED 포함 단일 `countByDateAndStatus` 호출 → 집계.
+  - `runCatching` 금지.
+- **DoD**: T4 PASS; `./gradlew :appointment-api:test --tests DashboardStatsServiceTest` PASS.
+
+---
+
+### T6: DashboardStatsController 단위 테스트 (RED)
+- **complexity**: medium
+- **files**:
+  - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/DashboardStatsControllerTest.kt` (신규)
+- **dependencies**: T3, T5, T8
+- **작업**:
+  - `@WebMvcTest(DashboardStatsController::class)` + `@MockkBean DashboardStatsService`.
+  - 시나리오:
+    - 200 — `/api/admin/stats/appointments?clinicId=1` → `success: true`, `data.totals` 키 존재.
+    - 200 — `?statuses=CONFIRMED&statuses=CANCELLED` 반복 파라미터 → Service에 `listOf("CONFIRMED","CANCELLED")` 전달 verify.
+    - 200 — `/doctors?clinicId=1&limit=5` → DoctorStatsResponse JSON.
+    - 200 — `/cancellations?clinicId=1` → `cancellationRate` double 직렬화.
+    - 400 — `?from=not-a-date` (T8 핸들러 의존).
+    - 400 — Service IAE(`from > to`) → `ApiResponse.error("from must be on or before to")`.
+    - 기본 기간 미지정 시 Service에 null 전달 verify.
+- **DoD**: Controller 미존재로 컴파일 실패 (RED).
+
+---
+
+### T7: DashboardStatsController 구현 (GREEN)
+- **complexity**: medium
+- **files**:
+  - `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/DashboardStatsController.kt` (신규)
+- **dependencies**: T6
+- **작업**:
+  - `@RestController`, `@RequestMapping("/api/admin/stats")`, `@Tag(name = "Dashboard Stats")`.
+  - 생성자: `private val dashboardStatsService: DashboardStatsService`.
+  - 세 GET 엔드포인트:
+    - `/appointments`: `clinicId: Long`, `@DateTimeFormat(iso=DATE) from: LocalDate?`, `to: LocalDate?`, `@RequestParam(required=false) statuses: List<String>?` — 반복 파라미터 자동 바인딩.
+    - `/doctors`: + `@RequestParam(defaultValue="20") limit: Int`.
+    - `/cancellations`: clinicId + from/to.
+  - 모두 `ResponseEntity<ApiResponse<XxxResponse>>` — `ApiResponse.ok(...)`.
+  - `@Operation` + `@ApiResponses(200/400/401/403)`.
+  - `companion object : KLogging()` + debug 로그.
+- **DoD**: T6 PASS (T8과 통합 후 400 케이스 포함 GREEN); IDE 진단 0.
+
+---
+
+### T8: GlobalExceptionHandler MethodArgumentTypeMismatchException 핸들러 추가
+- **complexity**: low
+- **files**:
+  - `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/GlobalExceptionHandler.kt` (수정)
+- **dependencies**: 없음
+- **작업**:
+  - `@ExceptionHandler(MethodArgumentTypeMismatchException::class)` 추가 → 400 + `ApiResponse.error("Invalid parameter: ${ex.name}")`.
+  - `log.warn(ex) { "Type mismatch: name=${ex.name}, requiredType=${ex.requiredType?.simpleName}" }`.
+  - 테스트: `DashboardStatsControllerTest` T6의 `?from=not-a-date→400` 케이스로 검증.
+- **DoD**: T6 400 케이스 PASS.
+
+---
+
+### T9: ServiceConfig Bean 등록
+- **complexity**: low
+- **files**:
+  - `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt` (수정)
+- **dependencies**: T2, T5
+- **작업**:
+  - `@Bean fun appointmentStatsRepository(): AppointmentStatsRepository = AppointmentStatsRepository()`.
+  - `@Bean fun dashboardStatsService(appointmentStatsRepository: AppointmentStatsRepository): DashboardStatsService = DashboardStatsService(appointmentStatsRepository)`.
+- **DoD**: `@SpringBootTest` 컨텍스트 로드 PASS.
+
+---
+
+### T10: SecurityConfig 매처 추가 + 인증/인가 핸들러
+- **complexity**: high
+- **files**:
+  - `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityConfig.kt` (수정)
+- **dependencies**: T9
+- **작업**:
+  - 생성자에 `objectMapper: ObjectMapper` 추가 (injection).
+  - `authorizeHttpRequests` 블록: 기존 `permitAll` 다음, `GET /api/**` 매처 **앞**에 `.requestMatchers("/api/admin/**").hasRole(SchedulingRole.ADMIN)` 추가. 순서 주석 필수.
+  - `.exceptionHandling { ... }` 블록:
+    - `authenticationEntryPoint` → 401 + `objectMapper.writeValueAsString(ApiResponse.error<Nothing>("Unauthorized"))`.
+    - `accessDeniedHandler` → 403 + `objectMapper.writeValueAsString(ApiResponse.error<Nothing>("Forbidden"))`.
+  - `NoOpSecurityConfig` 변경 없음.
+- **DoD**: 컴파일 PASS; T19 통합 테스트로 검증.
+
+---
+
+## Phase 2 — 프론트엔드
+
+### T11: dashboard-stats 모델 타입 + export
+- **complexity**: low
+- **files**:
+  - `frontend/appointment-frontend/src/app/core/models/dashboard-stats.model.ts` (신규)
+  - `frontend/appointment-frontend/src/app/core/models/index.ts` (수정)
+- **dependencies**: T3
+- **작업**:
+  - 백엔드 DTO와 정확히 일치하는 TypeScript 인터페이스:
+    - `DailyAppointmentBucket`, `AppointmentStatsResponse`, `DoctorBucket`, `DoctorStatsResponse`, `DailyCancellationBucket`, `CancellationStatsResponse`.
+  - `models/index.ts`에 `export * from './dashboard-stats.model';`.
+- **DoD**: `npx tsc --noEmit` 타입 오류 0.
+
+---
+
+### T12: chart.js 의존성 추가
+- **complexity**: low
+- **files**:
+  - `frontend/appointment-frontend/package.json` (수정)
+- **dependencies**: 없음
+- **작업**:
+  - `"chart.js": "^4.5.0"` 추가 후 `npm install`.
+  - `npm view chart.js peerDependencies` 확인.
+  - `ng build` 호환 검증.
+- **DoD**: `ng build` PASS; 0 peer-dep conflicts.
+
+---
+
+### T13: DashboardStatsService vitest + 구현 + export
+- **complexity**: medium
+- **files**:
+  - `frontend/appointment-frontend/src/app/core/services/dashboard-stats.service.spec.ts` (신규)
+  - `frontend/appointment-frontend/src/app/core/services/dashboard-stats.service.ts` (신규)
+  - `frontend/appointment-frontend/src/app/core/services/index.ts` (수정)
+- **dependencies**: T11
+- **작업**:
+  - **RED**: `provideHttpClient` + `provideHttpClientTesting` + `HttpTestingController`.
+    - `loadAppointmentStats` — URL, params, **`r.params.getAll('statuses')` 반복 파라미터 검증**.
+    - `loadDoctorStats`, `loadCancellationStats` — params 검증 + signal 갱신.
+    - 403 → silent fallback (signal `null`), throw 없음.
+  - **GREEN**: `@Injectable({ providedIn: 'root' })`, private signals (`_appointments`, `_doctors`, `_cancellations`, `loading`), 3개 async 메서드, 반복 파라미터 송신 (`params.append('statuses', s)` 반복).
+  - `services/index.ts`에 export 추가.
+- **DoD**: vitest PASS.
+
+---
+
+### T14: AppointmentTrendChartComponent (vitest + 구현)
+- **complexity**: high
+- **files**:
+  - `frontend/appointment-frontend/src/app/features/management/dashboard/charts/appointment-trend-chart.component.spec.ts` (신규)
+  - `frontend/appointment-frontend/src/app/features/management/dashboard/charts/appointment-trend-chart.component.ts` (신규)
+- **dependencies**: T12, T13
+- **작업**:
+  - **RED**: Chart.js 모킹 (§7.2 패턴):
+    ```ts
+    const destroyFn = vi.fn(); const updateFn = vi.fn();
+    vi.mock('chart.js', () => ({ Chart: vi.fn().mockImplementation(() => ({ destroy: destroyFn, update: updateFn, data: { labels: [], datasets: [] } })), registerables: [] }));
+    ```
+    시나리오: 데이터 주입 → Chart 생성자 호출; 데이터 변경 → `update()` 호출; `ngOnDestroy()` → `destroyFn` 호출.
+  - **GREEN**: standalone, `input.required<AppointmentStatsResponse | null>()`, `@ViewChild('canvas')` ElementRef, `afterNextRender(() => initChart())`, `effect(() => rebuild())`, `ngOnDestroy: chart?.destroy()`.
+  - Chart.js `type: 'bar'`, stacked x/y, 상태별 색상 const map.
+- **DoD**: vitest PASS; `ng build` PASS.
+
+---
+
+### T15: DoctorWorkloadChartComponent (vitest + 구현)
+- **complexity**: high
+- **files**:
+  - `frontend/appointment-frontend/src/app/features/management/dashboard/charts/doctor-workload-chart.component.spec.ts` (신규)
+  - `frontend/appointment-frontend/src/app/features/management/dashboard/charts/doctor-workload-chart.component.ts` (신규)
+- **dependencies**: T14
+- **작업**:
+  - T14 동일 라이프사이클 패턴.
+  - inputs: `data = input.required<DoctorStatsResponse | null>()`, `doctorNameLookup = input<(id: number) => string>()`.
+  - Chart.js `type: 'bar'` + `options: { indexAxis: 'y' }` (수평 막대).
+  - datasets: totalAppointments (회색) + completed (녹색).
+- **DoD**: vitest PASS.
+
+---
+
+### T16: CancellationTrendChartComponent (vitest + 구현)
+- **complexity**: high
+- **files**:
+  - `frontend/appointment-frontend/src/app/features/management/dashboard/charts/cancellation-trend-chart.component.spec.ts` (신규)
+  - `frontend/appointment-frontend/src/app/features/management/dashboard/charts/cancellation-trend-chart.component.ts` (신규)
+- **dependencies**: T14
+- **작업**:
+  - T14 동일 라이프사이클.
+  - Chart.js `type: 'line'` 멀티시리즈: cancelled(빨강), noShow(주황), rescheduled(파랑).
+  - KPI 카드: `cancellationRate`, `noShowRate` — Material `<mat-card>`, `(rate * 100).toFixed(1) + '%'`.
+- **DoD**: vitest PASS.
+
+---
+
+### T17: DashboardChartsComponent 컨테이너 (vitest + 구현)
+- **complexity**: medium
+- **files**:
+  - `frontend/appointment-frontend/src/app/features/management/dashboard/dashboard-charts.component.spec.ts` (신규)
+  - `frontend/appointment-frontend/src/app/features/management/dashboard/dashboard-charts.component.ts` (신규)
+- **dependencies**: T13, T14, T15, T16
+- **작업**:
+  - **RED**: `authService.isAdmin()=false` → 차트 3개 미렌더링; `isAdmin()=true` → 자식 3개 렌더링; clinicId 변경 → `loadXxx` 호출.
+  - **GREEN**: `inject(AuthService)`, `inject(DashboardStatsService)`, `inject(DoctorService)`. `effect(() => { if (authService.isAdmin()) loadAll(); })`. template: `@if (authService.isAdmin()) { <section class="charts-grid"> ... </section> }`.
+- **DoD**: vitest PASS — ADMIN 분기 양방향 검증.
+
+---
+
+### T18: ManagementDashboardComponent 통합 + 회귀
+- **complexity**: medium
+- **files**:
+  - `frontend/appointment-frontend/src/app/features/management/dashboard/management-dashboard.component.ts` (수정)
+  - `frontend/appointment-frontend/src/app/features/management/dashboard/management-dashboard.component.spec.ts` (신규 또는 기존 확장)
+- **dependencies**: T17
+- **작업**:
+  - `imports`에 `DashboardChartsComponent` 추가.
+  - **`authService.isAdmin()` 직접 사용** — 로컬 `isAdmin` computed 재선언 금지 (DRY, 스펙 §2.4).
+  - template: 기존 카드 섹션 아래에 `@if (authService.isAdmin()) { <h2>운영 통계</h2> <app-dashboard-charts /> }` 추가.
+  - 기존 `todayCount`/`pendingCount`/`doctorCount` 카드 **그대로 유지**.
+  - 회귀 테스트: 기존 3개 카드 유지; ADMIN 시 `app-dashboard-charts` 존재; 비-ADMIN 시 부재.
+  - `doctorCount.set(0)` 기존 버그 — 본 PR 범위 밖, 회귀 테스트만.
+- **DoD**: vitest PASS; `ng build` PASS.
+
+---
+
+## Phase 3 — 교차/통합 테스트
+
+### T19: SecurityConfig 통합 테스트 — 매처 순서 + envelope
+- **complexity**: high
+- **files**:
+  - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityConfigDashboardTest.kt` (신규)
+- **dependencies**: T7, T10
+- **작업**:
+  - `@SpringBootTest(webEnvironment=MOCK)` + `@AutoConfigureMockMvc` + prod 프로파일 또는 SecurityConfig 직접 import.
+  - 시나리오 (스펙 §5.2):
+    - ADMIN → 200.
+    - STAFF → **403** + body `{"success":false,"data":null,"error":"Forbidden"}`.
+    - DOCTOR → 403.
+    - 토큰 없음 → **401** + body `{"success":false,"data":null,"error":"Unauthorized"}`.
+    - **매처 순서 회귀**: STAFF가 `GET /api/admin/stats/appointments` 호출 시 200이 아닌 403 — `/api/admin/**`이 `GET /api/**`보다 앞에 있음 검증.
+- **DoD**: `./gradlew :appointment-api:test --tests SecurityConfigDashboardTest` PASS.
+
+---
+
+### T20: Controller 계약 400 매트릭스
+- **complexity**: medium
+- **files**:
+  - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/DashboardStatsControllerContractTest.kt` (신규)
+- **dependencies**: T7, T8
+- **작업**:
+  - `@WebMvcTest` + `@MockkBean DashboardStatsService`.
+  - 시나리오:
+    - `?from=2026-99-99` → 400 (MethodArgumentTypeMismatchException → T8).
+    - `?from=2026-05-01&to=2026-04-01` → 400 + "from must be on or before to".
+    - 367일 범위 → 400.
+    - `?clinicId=-1` → 400.
+    - `?limit=0` / `?limit=101` (doctors) → 400.
+    - `?statuses=UNKNOWN_STATE` → 400 + "Unknown appointment status: UNKNOWN_STATE".
+    - `clinicId` 미지정 → 400.
+    - **반복 파라미터**: `?statuses=CONFIRMED&statuses=CANCELLED` → Service에 `listOf("CONFIRMED","CANCELLED")` verify.
+  - 모든 400 응답이 `ApiResponse.error(...)` JSON 형태임을 단언.
+- **DoD**: PASS.
+
+---
+
+## Phase 4 — 문서 + PR 준비
+
+### T21: KDoc·JSDoc 영문 검증 및 보강
+- **complexity**: low
+- **files**: T2/T3/T5/T7 신규 Kotlin 파일; T13/T14/T15/T16/T17 신규 TypeScript 파일
+- **dependencies**: T18, T20
+- **작업**:
+  - 모든 신규 public 클래스/함수: 영문 one-line summary + `## Behavior / Contract`.
+  - `ide_diagnostics` deprecation 0 확인.
+- **DoD**: 모든 신규 public symbol 영문 KDoc; IDE 에러 0.
+
+---
+
+### T22: README 업데이트 (한/영 동시)
+- **complexity**: low
+- **files**:
+  - `README.md` (수정)
+  - `README.ko.md` (수정)
+- **dependencies**: T18
+- **작업**:
+  - 두 파일 구조 동일 유지 (clinic-appointment CLAUDE.md 규칙).
+  - 섹션 추가: 3 API endpoints + ADMIN role + Mermaid 아키텍처 다이어그램.
+  - curl 예시 포함.
+- **DoD**: 두 파일 갱신; 구조 정렬 유지.
+
+---
+
+### T23: CHANGELOG + PR 본문 초안
+- **complexity**: low
+- **files**:
+  - `CHANGELOG.md` (수정)
+- **dependencies**: T22
+- **작업**:
+  - CHANGELOG 항목 (영문):
+    ```
+    ## [Unreleased]
+    ### Added
+    - Dashboard stats REST API: GET /api/admin/stats/{appointments,doctors,cancellations} (ADMIN only).
+    - Angular dashboard charts: appointment trend (stacked bar), doctor workload (horizontal bar), cancellation trend (line + KPI).
+    - MethodArgumentTypeMismatchException → 400 handler in GlobalExceptionHandler.
+    - SecurityConfig /api/admin/** matcher + JSON ApiResponse envelope for 401/403.
+    ```
+  - PR 본문 초안: Summary + scope + ADR 요약 + test plan + `Closes #44 Closes #45`.
+- **DoD**: CHANGELOG 갱신.
+
+---
+
+### T24: 전체 테스트 실행 + code-reviewer
+- **complexity**: medium
+- **files**: 없음 (검증 태스크)
+- **dependencies**: T19, T20, T21, T22, T23
+- **작업**:
+  - `./gradlew :appointment-core:test --tests "*AppointmentStats*"` — PASS + 시간.
+  - `./gradlew :appointment-api:test --tests "*Dashboard*" --tests "*GlobalException*" --tests "*SecurityConfigDashboard*"` — PASS + 시간.
+  - `cd frontend/appointment-frontend && npm run test -- --run` 관련 스펙들 — PASS + count.
+  - `ng build` — PASS.
+  - `./gradlew :appointment-core:build :appointment-api:build` 회귀 안전망.
+  - `oh-my-claudecode:code-reviewer` + `oh-my-claudecode:security-reviewer` — HIGH/CRITICAL 0.
+- **DoD**: 모든 PASS; code-reviewer/security-reviewer HIGH+ 0.
+
+---
+
+### T25: PR 생성 (develop 대상)
+- **complexity**: low
+- **files**: 없음
+- **dependencies**: T24
+- **작업**:
+  - 브랜치 `feat/issue-44-45-dashboard` → develop.
+  - PR 제목: `feat: dashboard stats API + Angular charts (closes #44, closes #45)`.
+  - PR 본문: T24 테스트 결과 + 보안 검증 + `Closes #44 Closes #45`.
+- **DoD**: PR open; CI 통과.
+
+---
+
+## 의존성 그래프
+
+```
+T1 → T2 → T4 → T5 → T6 → T7
+          T3 ────────────→ T6
+          T8 ──────────────→ T6 (400 case)
+T2, T5 → T9 → T10
+T7, T10 → T19
+T7, T8 → T20
+
+T3 → T11 → T13
+T12 → T14, T15, T16
+T13, T14, T15, T16 → T17 → T18
+
+T18 → T22 → T23
+T19, T20, T21, T22, T23 → T24 → T25
+T18, T20 → T21
+```
+
+---
+
+## 검증 매트릭스
+
+- [ ] T1–T2: AppointmentStatsRepository H2 테스트 PASS (SQL LIMIT 부재 포함)
+- [ ] T3: DTO 3종 Serializable + serialVersionUID
+- [ ] T4–T5: DashboardStatsService MockK 테스트 PASS (sortedByDescending 검증 포함)
+- [ ] T6–T7: DashboardStatsController MockMvc PASS, 반복 파라미터 동작 확인
+- [ ] T8: MethodArgumentTypeMismatchException → 400
+- [ ] T9: ServiceConfig Bean 등록, 컨텍스트 로드 PASS
+- [ ] T10: SecurityConfig 매처 + ObjectMapper 핸들러
+- [ ] T11–T13: 프론트엔드 모델/서비스, 반복 파라미터 송신 확인
+- [ ] T12: chart.js ^4.5.0, ng build PASS
+- [ ] T14–T16: 차트 3종, afterNextRender + ngOnDestroy.destroy() 검증
+- [ ] T17: DashboardCharts, authService.isAdmin() 분기 양방향
+- [ ] T18: ManagementDashboard 회귀 + 로컬 isAdmin 재선언 없음
+- [ ] T19: Security 통합 — 매처 순서 + 401/403 envelope
+- [ ] T20: Controller 400 매트릭스 + JSON envelope
+- [ ] T21: 모든 신규 public API 영문 KDoc
+- [ ] T22: README 한/영 갱신
+- [ ] T23: CHANGELOG 영문
+- [ ] T24: 모든 모듈 PASS, code-reviewer HIGH+ 0
+- [ ] T25: develop 대상 PR open, CI 통과
+
+---
+
+## 참조
+
+- 스펙: `docs/superpowers/specs/2026-05-19-dashboard-stats-design.md`
+- 기존 Repository: `appointment-core/src/main/kotlin/io/bluetape4k/clinic/appointment/repository/AppointmentRepository.kt`
+- 기존 Service: `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/service/AppointmentService.kt`
+- 기존 Controller: `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/controller/AppointmentController.kt`
+- 기존 SecurityConfig: `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityConfig.kt`
+- 기존 GlobalExceptionHandler: `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/GlobalExceptionHandler.kt`
+- 기존 ServiceConfig: `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/ServiceConfig.kt`
+- 기존 AuthService: `frontend/appointment-frontend/src/app/core/services/auth.service.ts`
+- 기존 ManagementDashboard: `frontend/appointment-frontend/src/app/features/management/dashboard/management-dashboard.component.ts`

--- a/docs/superpowers/plans/2026-05-19-dashboard-stats-plan.md
+++ b/docs/superpowers/plans/2026-05-19-dashboard-stats-plan.md
@@ -25,6 +25,8 @@
 - Kotlin `@Configuration(proxyBeanMethods = false)` 항상 명시.
 - `runCatching` 금지 (suspend 호출 영역). 단순 IAE는 `GlobalExceptionHandler`로 위임.
 
+> **[F1] 커밋 경계 주의**: 각 태스크의 RED/GREEN 단계는 하나의 커밋 단위이다. RED(컴파일 실패/테스트 실패)를 독립 커밋으로 push하지 말 것 — RED는 동일 태스크 내 구현 시작 전 확인 단계이며, GREEN(PASS)에서만 커밋한다. Phase 단위 중간 커밋(예: T2 완료 후, T5 완료 후, T10 완료 후, T18 완료 후)을 권장한다.
+
 ---
 
 ## Phase 1 — 백엔드
@@ -37,8 +39,15 @@
   - `appointment-core/src/test/resources/logback-test.xml` (없으면 신규)
 - **dependencies**: 없음
 - **작업**:
-  - JUnit5 + bluetape4k-assertions + H2 in-memory. `@BeforeEach`에서 `SchemaUtils.createMissingTablesAndColumns(...)` + `Appointments.deleteAll()`.
-  - 시나리오 (실패 상태): `countByDateAndStatus` — 날짜 경계/상태 필터/빈 결과/clinicId 분리 검증; `countByDoctorAndStatus` — 의사 3명 × 상태 다종 시드로 모든 (doctorId, status, count) 조합 반환 검증, **SQL LIMIT/orderBy 미포함을 결과 행 수로 단언**; `countCancellationsByDate` — CANCELLED/NO_SHOW/RESCHEDULED만 카운트.
+  - **[F2] AbstractExposedTest 패턴** — `EquipmentUnavailabilityRepositoryTest.kt`를 canonical 참조로 사용.
+    - `AppointmentStatsRepositoryTest : AbstractExposedTest()` 상속.
+    - 각 테스트는 `withTables(testDB, Clinics, Doctors, Appointments) { ... }` 블록 안에서 실행.
+    - `@ParameterizedTest @MethodSource(ENABLE_DIALECTS_METHOD)` per test.
+    - **`@BeforeEach SchemaUtils + deleteAll` 패턴 사용 금지** (CLAUDE.md Module Gotchas와 달리 appointment-core 실제 패턴은 AbstractExposedTest이다).
+  - 시나리오 (실패 상태):
+    - `countByDateAndStatus` — 날짜 경계/상태 필터/빈 결과/clinicId 분리 검증.
+    - `countByDoctorAndStatus` — 의사 3명 × 상태 다종 시드로 모든 (doctorId, status, count) 조합 반환 검증; **SQL LIMIT/orderBy 미포함을 결과 행 수로 단언**.
+    - (**[F3]** `countCancellationsByDate` 테스트 제외 — 해당 메서드는 리포지토리에 존재하지 않는다; 취소 집계는 Service가 `countByDateAndStatus`로 처리).
   - 백틱 한국어 테스트명, AAA 패턴.
 - **DoD**: 컴파일 후 메서드 부재로 실패 (RED 확인).
 
@@ -52,10 +61,10 @@
 - **작업**:
   - 패키지 `io.bluetape4k.clinic.appointment.repository`, `companion object : KLogging()`.
   - `DoctorStatusCount(doctorId: Long, status: AppointmentState, count: Long) : Serializable` — 동일 파일 선언, KDoc에 Triple 금지 사유 명시 (동일 타입 Long 두 개 위치 혼동 위험, CLAUDE.md 규칙).
-  - 세 메서드 구현 (스펙 §4.3 시그니처 그대로):
+  - **[F3] 두 메서드만 구현** (`countCancellationsByDate` 삭제 — dead code):
     - `countByDateAndStatus(clinicId, dateRange, statuses?) : List<Triple<LocalDate, AppointmentState, Long>>` — date/status는 다른 타입이므로 Triple 허용.
     - `countByDoctorAndStatus(clinicId, dateRange) : List<DoctorStatusCount>` — **SQL LIMIT/orderBy 없음** (Service가 Kotlin groupBy + sortedByDescending + take(limit)로 의사 단위 상위 N 선별; SQL LIMIT은 (doctorId, status) 행 수에 적용되어 의미가 다름 — KDoc 명시).
-    - `countCancellationsByDate(clinicId, dateRange) : List<Triple<LocalDate, AppointmentState, Long>>` — CANCELLED/NO_SHOW/RESCHEDULED `inList` 필터.
+  - `countCancellationsByDate` 메서드를 별도로 추가하지 않는다. 취소 집계는 Service T5에서 `countByDateAndStatus(clinicId, dateRange, listOf(CANCELLED, NO_SHOW, RESCHEDULED, COMPLETED))` 호출로 처리한다.
   - Exposed 1.2 패턴: `val countExpr = Appointments.id.count()` alias 후 `row[countExpr]` 추출.
   - 모든 메서드 KDoc: "호출자는 transaction {} 내부에서 호출" 명시 + 영문 `## Behavior / Contract`.
 - **DoD**: T1 PASS (GREEN); `./gradlew :appointment-core:test --tests AppointmentStatsRepositoryTest` PASS.
@@ -78,15 +87,18 @@
 
 ---
 
-### T4: DashboardStatsService 단위 테스트 (RED)
+### T4: DashboardStatsService 통합 테스트 (RED)
 - **complexity**: medium
 - **files**:
   - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/service/DashboardStatsServiceTest.kt` (신규)
 - **dependencies**: T2, T3
 - **작업**:
-  - JUnit5 + MockK. Repository는 `mockk()` 주입. H2 `Database.connect`를 `@BeforeAll`에서 1회 연결해 `transaction {}` 동작.
+  - **[F4] 통합 테스트 접근법** — MockK + `transaction {}` 비호환 문제 해결을 위해 실제 H2 Repository 사용.
+    - `DashboardStatsServiceTest`는 `AbstractExposedTest()`를 상속하고 `withTables(testDB, Clinics, Doctors, Appointments) { ... }` 블록 내에서 실제 `AppointmentStatsRepository()` 인스턴스를 주입한다.
+    - Service 검증 로직만 MockK로 분리할 수 없으므로 Service + Repository 통합 단위 테스트로 작성 (Repository 동작은 T1/T2에서 이미 보장).
   - 시나리오:
     - `getAppointmentStats`: 정상 — bucket 조립/totals 계산 정확성.
+    - **[F5] 빈 clinic**: `clinicId=999` (데이터 없음) → `data.buckets.isEmpty()`, `data.totals` 모두 0L, HTTP 200 (에러 아님).
     - `from > to` → `IllegalArgumentException("from must be on or before to")`.
     - 367일 범위 → `IllegalArgumentException("period exceeds 366 days")`.
     - `clinicId <= 0` → `IllegalArgumentException` (bluetape4k `requirePositive`).
@@ -131,10 +143,11 @@
   - `@WebMvcTest(DashboardStatsController::class)` + `@MockkBean DashboardStatsService`.
   - 시나리오:
     - 200 — `/api/admin/stats/appointments?clinicId=1` → `success: true`, `data.totals` 키 존재.
+    - **[F5] 200 — `?clinicId=999` (데이터 없음)** → `success: true`, `data.buckets` 빈 배열 (에러 응답 아님).
     - 200 — `?statuses=CONFIRMED&statuses=CANCELLED` 반복 파라미터 → Service에 `listOf("CONFIRMED","CANCELLED")` 전달 verify.
     - 200 — `/doctors?clinicId=1&limit=5` → DoctorStatsResponse JSON.
     - 200 — `/cancellations?clinicId=1` → `cancellationRate` double 직렬화.
-    - 400 — `?from=not-a-date` (T8 핸들러 의존).
+    - **[F6] `?from=not-a-date → 400` 케이스는 이 태스크에서 제외** — T8 RED 단계에서 검증 (T8이 T6보다 먼저 작성되어야 해당 케이스가 통과됨).
     - 400 — Service IAE(`from > to`) → `ApiResponse.error("from must be on or before to")`.
     - 기본 기간 미지정 시 Service에 null 전달 verify.
 - **DoD**: Controller 미존재로 컴파일 실패 (RED).
@@ -164,12 +177,15 @@
 - **complexity**: low
 - **files**:
   - `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/config/GlobalExceptionHandler.kt` (수정)
+  - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/config/GlobalExceptionHandlerTypeMismatchTest.kt` (신규)
 - **dependencies**: 없음
 - **작업**:
-  - `@ExceptionHandler(MethodArgumentTypeMismatchException::class)` 추가 → 400 + `ApiResponse.error("Invalid parameter: ${ex.name}")`.
+  - **[F6] RED 단계**: `GlobalExceptionHandlerTypeMismatchTest` 작성 — `@WebMvcTest(DashboardStatsController::class)` + `@MockkBean DashboardStatsService`.
+    - `GET /api/admin/stats/appointments?clinicId=1&from=not-a-date` → 400 + `{"success":false,"error":"Invalid parameter: from"}` 단언.
+    - 컴파일은 되지만 핸들러 미존재로 실패 (RED 확인).
+  - **GREEN 단계**: `@ExceptionHandler(MethodArgumentTypeMismatchException::class)` 추가 → 400 + `ApiResponse.error("Invalid parameter: ${ex.name}")`.
   - `log.warn(ex) { "Type mismatch: name=${ex.name}, requiredType=${ex.requiredType?.simpleName}" }`.
-  - 테스트: `DashboardStatsControllerTest` T6의 `?from=not-a-date→400` 케이스로 검증.
-- **DoD**: T6 400 케이스 PASS.
+- **DoD**: `GlobalExceptionHandlerTypeMismatchTest` PASS (GREEN); T6의 400 케이스도 이 시점 이후 PASS.
 
 ---
 
@@ -189,9 +205,14 @@
 - **complexity**: high
 - **files**:
   - `appointment-api/src/main/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityConfig.kt` (수정)
-- **dependencies**: T9
+- **dependencies**: T7
 - **작업**:
-  - 생성자에 `objectMapper: ObjectMapper` 추가 (injection).
+  - **[F7] 의존성 수정**: T9(ServiceConfig)는 이 태스크의 전제 조건이 아님 — T7(Controller 구현)이 완료되면 SecurityConfig 매처 추가가 가능하다. T9는 별도로 진행.
+  - **[F7] ObjectMapper 주입 방식**: 기존 `SecurityConfig`는 zero-arg 생성자 + `@Bean` 메서드 파라미터 패턴을 사용한다. 따라서 생성자에 ObjectMapper를 추가하지 말고, `filterChain(@Bean 메서드)` 파라미터로 `objectMapper: ObjectMapper` 를 받는다:
+    ```kotlin
+    @Bean
+    fun filterChain(http: HttpSecurity, objectMapper: ObjectMapper): SecurityFilterChain { ... }
+    ```
   - `authorizeHttpRequests` 블록: 기존 `permitAll` 다음, `GET /api/**` 매처 **앞**에 `.requestMatchers("/api/admin/**").hasRole(SchedulingRole.ADMIN)` 추가. 순서 주석 필수.
   - `.exceptionHandling { ... }` 블록:
     - `authenticationEntryPoint` → 401 + `objectMapper.writeValueAsString(ApiResponse.error<Nothing>("Unauthorized"))`.
@@ -261,7 +282,10 @@
     vi.mock('chart.js', () => ({ Chart: vi.fn().mockImplementation(() => ({ destroy: destroyFn, update: updateFn, data: { labels: [], datasets: [] } })), registerables: [] }));
     ```
     시나리오: 데이터 주입 → Chart 생성자 호출; 데이터 변경 → `update()` 호출; `ngOnDestroy()` → `destroyFn` 호출.
-  - **GREEN**: standalone, `input.required<AppointmentStatsResponse | null>()`, `@ViewChild('canvas')` ElementRef, `afterNextRender(() => initChart())`, `effect(() => rebuild())`, `ngOnDestroy: chart?.destroy()`.
+  - **[F9] 라이프사이클 방식 확정 — `ngOnInit` 사용**:
+    - `afterNextRender`는 TestBed에서 동기적으로 실행되지 않아 `chart?.destroy()` 단언이 실패한다.
+    - 대신 `ngOnInit`에서 차트를 초기화하고, `TestBed.flushEffects()` + `fixture.destroy()`로 `ngOnDestroy` 정리를 검증한다.
+  - **GREEN**: standalone, `input.required<AppointmentStatsResponse | null>()`, `@ViewChild('canvas')` ElementRef, `ngOnInit() { initChart(); }`, `effect(() => updateChart())`, `ngOnDestroy: chart?.destroy()`.
   - Chart.js `type: 'bar'`, stacked x/y, 상태별 색상 const map.
 - **DoD**: vitest PASS; `ng build` PASS.
 
@@ -274,7 +298,7 @@
   - `frontend/appointment-frontend/src/app/features/management/dashboard/charts/doctor-workload-chart.component.ts` (신규)
 - **dependencies**: T14
 - **작업**:
-  - T14 동일 라이프사이클 패턴.
+  - **[F9]** T14와 동일하게 `ngOnInit` 기반 라이프사이클 패턴 적용 (`afterNextRender` 금지).
   - inputs: `data = input.required<DoctorStatsResponse | null>()`, `doctorNameLookup = input<(id: number) => string>()`.
   - Chart.js `type: 'bar'` + `options: { indexAxis: 'y' }` (수평 막대).
   - datasets: totalAppointments (회색) + completed (녹색).
@@ -289,7 +313,7 @@
   - `frontend/appointment-frontend/src/app/features/management/dashboard/charts/cancellation-trend-chart.component.ts` (신규)
 - **dependencies**: T14
 - **작업**:
-  - T14 동일 라이프사이클.
+  - **[F9]** T14와 동일하게 `ngOnInit` 기반 라이프사이클 패턴 적용 (`afterNextRender` 금지).
   - Chart.js `type: 'line'` 멀티시리즈: cancelled(빨강), noShow(주황), rescheduled(파랑).
   - KPI 카드: `cancellationRate`, `noShowRate` — Material `<mat-card>`, `(rate * 100).toFixed(1) + '%'`.
 - **DoD**: vitest PASS.
@@ -332,14 +356,26 @@
 - **complexity**: high
 - **files**:
   - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityConfigDashboardTest.kt` (신규)
+  - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/security/SecurityTestConfig.kt` (신규 — 보안 프로파일 활성화용)
 - **dependencies**: T7, T10
 - **작업**:
-  - `@SpringBootTest(webEnvironment=MOCK)` + `@AutoConfigureMockMvc` + prod 프로파일 또는 SecurityConfig 직접 import.
+  - **[F8] 구체적 보안 우회 전략**:
+    - `SecurityTestConfig.kt`: `@TestConfiguration` + `@Profile("security-test")` 클래스로 `NoOpSecurityConfig`를 **제외**하고 실제 `SecurityConfig`를 **활성화**한다.
+      ```kotlin
+      @TestConfiguration
+      class SecurityTestConfig {
+          // NoOpSecurityConfig는 @Profile("dev","test") — "security-test" 프로파일에서 비활성
+          // 실제 SecurityConfig는 @Profile("!dev & !test") — "security-test"에서 활성
+      }
+      ```
+    - 테스트 클래스: `@SpringBootTest(webEnvironment=MOCK)` + `@AutoConfigureMockMvc` + `@ActiveProfiles("security-test")`.
+    - JWT 토큰 생성: 기존 프로젝트의 JWT 서명 유틸리티(`JwtTokenProvider` 등)를 사용해 테스트 토큰 발급. 없으면 `JwtTokenProvider`에서 `@Autowired`로 직접 호출. ROLE_ADMIN / ROLE_STAFF / ROLE_DOCTOR 역할별 토큰 발급.
+    - `MockMvc` 요청 헤더: `Authorization: Bearer <token>`.
   - 시나리오 (스펙 §5.2):
-    - ADMIN → 200.
-    - STAFF → **403** + body `{"success":false,"data":null,"error":"Forbidden"}`.
-    - DOCTOR → 403.
-    - 토큰 없음 → **401** + body `{"success":false,"data":null,"error":"Unauthorized"}`.
+    - ADMIN 토큰 → 200.
+    - STAFF 토큰 → **403** + `{"success":false,"data":null,"error":"Forbidden"}` JSON 단언.
+    - DOCTOR 토큰 → 403.
+    - 토큰 없음 → **401** + `{"success":false,"data":null,"error":"Unauthorized"}` JSON 단언.
     - **매처 순서 회귀**: STAFF가 `GET /api/admin/stats/appointments` 호출 시 200이 아닌 403 — `/api/admin/**`이 `GET /api/**`보다 앞에 있음 검증.
 - **DoD**: `./gradlew :appointment-api:test --tests SecurityConfigDashboardTest` PASS.
 
@@ -370,26 +406,46 @@
 
 ### T21: KDoc·JSDoc 영문 검증 및 보강
 - **complexity**: low
-- **files**: T2/T3/T5/T7 신규 Kotlin 파일; T13/T14/T15/T16/T17 신규 TypeScript 파일
+- **files**:
+  - `appointment-core/src/main/kotlin/.../repository/AppointmentStatsRepository.kt` (KDoc 보강)
+  - `appointment-core/src/main/kotlin/.../repository/DoctorStatusCount.kt` 또는 동일 파일 내 (KDoc)
+  - `appointment-api/src/main/kotlin/.../dto/AppointmentStatsResponse.kt` (KDoc + @Schema)
+  - `appointment-api/src/main/kotlin/.../dto/DoctorStatsResponse.kt` (KDoc + @Schema)
+  - `appointment-api/src/main/kotlin/.../dto/CancellationStatsResponse.kt` (KDoc + @Schema)
+  - `appointment-api/src/main/kotlin/.../service/DashboardStatsService.kt` (KDoc)
+  - `appointment-api/src/main/kotlin/.../controller/DashboardStatsController.kt` (KDoc + @Operation)
+  - `frontend/.../services/dashboard-stats.service.ts` (JSDoc)
+  - `frontend/.../charts/appointment-trend-chart.component.ts` (JSDoc)
+  - `frontend/.../charts/doctor-workload-chart.component.ts` (JSDoc)
+  - `frontend/.../charts/cancellation-trend-chart.component.ts` (JSDoc)
+  - `frontend/.../dashboard-charts.component.ts` (JSDoc)
 - **dependencies**: T18, T20
 - **작업**:
-  - 모든 신규 public 클래스/함수: 영문 one-line summary + `## Behavior / Contract`.
-  - `ide_diagnostics` deprecation 0 확인.
-- **DoD**: 모든 신규 public symbol 영문 KDoc; IDE 에러 0.
+  - **[F11]** 모든 신규 public 클래스/함수: 영문 one-line summary + `## Behavior / Contract` 섹션.
+  - Kotlin IDE 진단 단계:
+    1. `./gradlew :appointment-core:compileKotlin :appointment-api:compileKotlin` — 에러 0 확인.
+    2. `ide_diagnostics` (또는 `./gradlew :appointment-api:build`) — unresolved deprecation 0 확인.
+    3. `ide_optimize_imports` 실행 후 재확인.
+  - TypeScript: `npx tsc --noEmit` — 타입 오류 0 확인.
+- **DoD**: 모든 신규 public symbol 영문 KDoc/JSDoc 완료; Kotlin IDE 에러 0; `tsc --noEmit` PASS.
 
 ---
 
 ### T22: README 업데이트 (한/영 동시)
 - **complexity**: low
 - **files**:
-  - `README.md` (수정)
-  - `README.ko.md` (수정)
+  - `README.md` (수정 — 영문)
+  - `README.ko.md` (수정 — 한국어)
 - **dependencies**: T18
 - **작업**:
-  - 두 파일 구조 동일 유지 (clinic-appointment CLAUDE.md 규칙).
-  - 섹션 추가: 3 API endpoints + ADMIN role + Mermaid 아키텍처 다이어그램.
-  - curl 예시 포함.
-- **DoD**: 두 파일 갱신; 구조 정렬 유지.
+  - **[F12] 두 파일 명시적 작업**:
+    - `README.md`: 영문 섹션 추가 — "Dashboard Stats API" 섹션에 3개 엔드포인트 + ADMIN 역할 요건 + Mermaid 아키텍처 다이어그램 + curl 예시.
+    - `README.ko.md`: 동일 내용을 한국어로 추가 — "대시보드 통계 API" 섹션.
+    - 두 파일의 **섹션 순서, 헤딩 레벨, 다이어그램** 구조가 정렬됨을 단언.
+  - Mermaid 다이어그램: Angular `DashboardChartsComponent` → HTTP → Spring Controller → Service → Repository → DB 흐름.
+  - curl 예시 (`Authorization: Bearer <ADMIN_TOKEN>` 포함).
+  - **구조 정렬 DoD**: `README.md`와 `README.ko.md`의 `##` 섹션 헤딩 목록이 1:1 대응 확인.
+- **DoD**: 두 파일 모두 갱신; 섹션 구조 정렬 완료.
 
 ---
 
@@ -428,10 +484,28 @@
 
 ---
 
-### T25: PR 생성 (develop 대상)
+### T25: docs/lessons 작성 + 커밋 (PR 생성 전 필수)
+- **complexity**: low
+- **files**:
+  - `docs/lessons/2026-05-19-dashboard-stats.md` (신규)
+- **dependencies**: T24
+- **작업**:
+  - **[F10] bluetape4k-workflow Step 7 필수 단계** — PR 생성 전 lessons 커밋.
+  - 문서 내용:
+    - 설계 결정 근거: `countCancellationsByDate` 삭제(dead code) + `countByDateAndStatus` 단일화 이유.
+    - MockK + Exposed `transaction {}` 비호환 교훈 — Service 테스트를 `AbstractExposedTest` 통합 테스트로 전환한 이유.
+    - 보안 프로파일 하네스 — `@ActiveProfiles("security-test")`로 `NoOpSecurityConfig` 우회 + 실제 `SecurityConfig` 활성화 패턴.
+    - `afterNextRender` vs `ngOnInit` — TestBed 동기 실행 불가로 `ngOnInit` 선택.
+    - SQL LIMIT 의미 차이 — `(doctorId, status)` 행 기준 LIMIT vs 의사 단위 상위 N; Kotlin 집계로 해결.
+  - `git add docs/lessons/2026-05-19-dashboard-stats.md && git commit -m "docs: add lessons from dashboard stats implementation"`.
+- **DoD**: lessons 파일 커밋됨; `git log --oneline -1` 확인.
+
+---
+
+### T26: PR 생성 (develop 대상)
 - **complexity**: low
 - **files**: 없음
-- **dependencies**: T24
+- **dependencies**: T25
 - **작업**:
   - 브랜치 `feat/issue-44-45-dashboard` → develop.
   - PR 제목: `feat: dashboard stats API + Angular charts (closes #44, closes #45)`.
@@ -445,8 +519,9 @@
 ```
 T1 → T2 → T4 → T5 → T6 → T7
           T3 ────────────→ T6
-          T8 ──────────────→ T6 (400 case)
-T2, T5 → T9 → T10
+          T8 ──────────────→ T6 (400 case RED doD)
+T2, T5 → T9
+T7 → T10                         [F7: T10 depends on T7, not T9]
 T7, T10 → T19
 T7, T8 → T20
 
@@ -455,7 +530,7 @@ T12 → T14, T15, T16
 T13, T14, T15, T16 → T17 → T18
 
 T18 → T22 → T23
-T19, T20, T21, T22, T23 → T24 → T25
+T19, T20, T21, T22, T23 → T24 → T25 → T26
 T18, T20 → T21
 ```
 
@@ -463,25 +538,26 @@ T18, T20 → T21
 
 ## 검증 매트릭스
 
-- [ ] T1–T2: AppointmentStatsRepository H2 테스트 PASS (SQL LIMIT 부재 포함)
+- [ ] T1–T2: AppointmentStatsRepository AbstractExposedTest + withTables 패턴 PASS (SQL LIMIT 부재 포함); countCancellationsByDate 없음 확인
 - [ ] T3: DTO 3종 Serializable + serialVersionUID
-- [ ] T4–T5: DashboardStatsService MockK 테스트 PASS (sortedByDescending 검증 포함)
-- [ ] T6–T7: DashboardStatsController MockMvc PASS, 반복 파라미터 동작 확인
-- [ ] T8: MethodArgumentTypeMismatchException → 400
+- [ ] T4–T5: DashboardStatsService 통합 테스트 PASS (AbstractExposedTest + 실제 H2 Repository); 빈 clinic 200 확인; sortedByDescending 검증 포함
+- [ ] T6–T7: DashboardStatsController MockMvc PASS; 빈 clinic 200 확인; 반복 파라미터 동작 확인
+- [ ] T8: GlobalExceptionHandlerTypeMismatchTest PASS; `?from=not-a-date → 400` + JSON envelope 확인
 - [ ] T9: ServiceConfig Bean 등록, 컨텍스트 로드 PASS
-- [ ] T10: SecurityConfig 매처 + ObjectMapper 핸들러
-- [ ] T11–T13: 프론트엔드 모델/서비스, 반복 파라미터 송신 확인
+- [ ] T10: SecurityConfig 매처 + ObjectMapper @Bean 메서드 파라미터 패턴; T7 의존 확인
+- [ ] T11–T13: 프론트엔드 모델/서비스; 반복 파라미터 송신 확인
 - [ ] T12: chart.js ^4.5.0, ng build PASS
-- [ ] T14–T16: 차트 3종, afterNextRender + ngOnDestroy.destroy() 검증
+- [ ] T14–T16: 차트 3종; **ngOnInit** 기반 라이프사이클; ngOnDestroy.destroy() 검증
 - [ ] T17: DashboardCharts, authService.isAdmin() 분기 양방향
 - [ ] T18: ManagementDashboard 회귀 + 로컬 isAdmin 재선언 없음
-- [ ] T19: Security 통합 — 매처 순서 + 401/403 envelope
+- [ ] T19: Security 통합 — `@ActiveProfiles("security-test")` 하네스; 매처 순서 + 401/403 envelope
 - [ ] T20: Controller 400 매트릭스 + JSON envelope
-- [ ] T21: 모든 신규 public API 영문 KDoc
-- [ ] T22: README 한/영 갱신
+- [ ] T21: 모든 신규 public API 영문 KDoc; Kotlin 컴파일 에러 0; tsc --noEmit PASS
+- [ ] T22: README.md + README.ko.md 동시 갱신; 섹션 구조 1:1 정렬
 - [ ] T23: CHANGELOG 영문
 - [ ] T24: 모든 모듈 PASS, code-reviewer HIGH+ 0
-- [ ] T25: develop 대상 PR open, CI 통과
+- [ ] T25: docs/lessons/2026-05-19-dashboard-stats.md 커밋 완료
+- [ ] T26: develop 대상 PR open, CI 통과
 
 ---
 

--- a/docs/superpowers/plans/2026-05-19-dashboard-stats-plan.md
+++ b/docs/superpowers/plans/2026-05-19-dashboard-stats-plan.md
@@ -142,7 +142,9 @@
   - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/DashboardStatsControllerTest.kt` (신규)
 - **dependencies**: T3, T5, T8
 - **작업**:
-  - `@WebMvcTest(DashboardStatsController::class)` + `@MockkBean DashboardStatsService` + **`@ActiveProfiles("test")`** 필수 — 미지정 시 `SecurityConfig`(`@Profile("!dev & !test")`)가 활성화되어 JWT 없는 요청이 401 반환.
+  - `@WebMvcTest(DashboardStatsController::class)` + `@MockkBean DashboardStatsService` + **`@Import(NoOpSecurityConfig::class)`** 필수.
+    - `@WebMvcTest`는 `@Configuration` 클래스를 자동 스캔하지 않으므로 `@ActiveProfiles("test")` 단독으로는 `NoOpSecurityConfig` 로드 불가.
+    - `@Import(NoOpSecurityConfig::class)` 로 명시 로드 → 모든 요청 permitAll → JWT 없이 MockMvc 테스트 가능.
   - 시나리오:
     - 200 — `/api/admin/stats/appointments?clinicId=1` → `success: true`, `data.totals` 키 존재.
     - **[F5] 200 — `?clinicId=999` (데이터 없음)** → `success: true`, `data.buckets` 빈 배열 (에러 응답 아님).
@@ -386,7 +388,8 @@
   - `appointment-api/src/test/kotlin/io/bluetape4k/clinic/appointment/api/controller/DashboardStatsControllerContractTest.kt` (신규)
 - **dependencies**: T7, T8
 - **작업**:
-  - `@WebMvcTest` + `@MockkBean DashboardStatsService`.
+  - `@WebMvcTest(DashboardStatsController::class)` + `@MockkBean DashboardStatsService` + `@Import(NoOpSecurityConfig::class)` 필수.
+  - **[T6와 동일한 제약]** `@WebMvcTest`는 `@Configuration` 클래스를 자동 스캔하지 않으므로 `@ActiveProfiles("test")` 단독으로는 `NoOpSecurityConfig` 로드 불가. `@Import(NoOpSecurityConfig::class)`로 명시 로드 → 모든 요청 `permitAll()` → JWT 없이 MockMvc 400 매트릭스 테스트 가능.
   - 시나리오:
     - `?from=2026-99-99` → 400 (MethodArgumentTypeMismatchException → T8).
     - `?from=2026-05-01&to=2026-04-01` → 400 + "from must be on or before to".

--- a/docs/superpowers/specs/2026-05-19-dashboard-stats-design.md
+++ b/docs/superpowers/specs/2026-05-19-dashboard-stats-design.md
@@ -1,0 +1,608 @@
+# 관리자 대시보드 집계 API + Angular 차트 UI 설계 명세
+
+> Issue [#44](https://github.com/bluetape4k/clinic-appointment/issues/44) (백엔드 집계 API)
+> Issue [#45](https://github.com/bluetape4k/clinic-appointment/issues/45) (Angular 차트 UI)
+> 작성일: 2026-05-19
+> 상태: 초안 (Step 1-S — Spec, 구현 전 critic 리뷰 대상)
+
+---
+
+## 1. 개요
+
+### 1.1 목적
+
+관리자(ADMIN)가 병원의 예약 운영 현황을 한 화면에서 파악할 수 있도록
+**예약 집계 REST API**(`/api/admin/stats/**`)와 **Angular 대시보드 차트 UI**를 제공한다.
+
+핵심 가치:
+
+- 운영 KPI(예약 수, 의사 가동률, 취소 패턴)를 시각화하여 의사결정 가속화
+- 기존 인덱스(`idx_appointments_clinic_date_status`, `idx_appointments_doctor_date`,
+  `idx_appointments_date_status`)를 활용해 추가 인덱스 도입 없이 집계 성능 보장
+- ADMIN 전용 보호 — 민감 운영 데이터를 일반 STAFF/DOCTOR 시야에서 격리
+
+### 1.2 범위
+
+| 포함 | 제외 |
+|------|------|
+| `GET /api/admin/stats/appointments` (일자별·상태별 집계) | 환자(PATIENT) 통계, 매출 통계 |
+| `GET /api/admin/stats/doctors` (의사별 예약 수·완료율) | 의사 KPI 평가 시스템 |
+| `GET /api/admin/stats/cancellations` (취소 추세·사유 집계) | 취소 사유 텍스트 마이닝 |
+| `ManagementDashboardComponent` 차트 영역 신규 추가 | 차트 PDF/이미지 익스포트 |
+| `AppointmentStatsRepository` (appointment-core) | DB materialized view, 캐싱 도입 |
+| `DashboardStatsService` + `DashboardStatsController` (appointment-api) | OLAP, 시간대(timezone) 변환 |
+| SecurityConfig `/api/admin/**` 매처 추가 | `@EnableMethodSecurity` 전환 |
+| 백엔드 JUnit 5 + MockK + H2 통합 테스트 | Gatling 부하 테스트(추후 별도 이슈) |
+| 프론트엔드 vitest 단위 테스트 | E2E (Playwright) |
+
+### 1.3 비목표
+
+- 실시간 스트리밍 통계(SSE/WebSocket) — 추후 별도 이슈
+- 시간대(timezone) 변환 — 모든 집계는 병원 로컬 `LocalDate` 기준(naive)
+- 데이터 영구 보존(웨어하우징) — 운영 DB 직접 집계만
+
+---
+
+## 2. 아키텍처 결정 사항 (ADR)
+
+### 2.1 백엔드 레이어 — 결정 C: `appointment-core`에 `AppointmentStatsRepository` 신규 추가
+
+리서치에서 제시된 옵션 1/2가 아닌 **제3의 선택**을 채택한다.
+
+| 후보 | 채택 여부 | 이유 |
+|------|----------|------|
+| 옵션 1: `AppointmentRepository` 확장 | 불가 | 단일 책임 위반 — Repository가 비대화, 집계와 CRUD가 혼재 |
+| 옵션 2: `appointment-api`에 `StatsRepository` 신규 | 불가 | 모듈 경계 위반 — `Appointments` 테이블은 `appointment-core`가 전담, API 계층은 어떤 테이블에도 직접 접근하지 않음 |
+| **옵션 3: `appointment-core/repository/AppointmentStatsRepository` 신규 (채택)** | **채택** | • `Appointments` 접근은 모두 core에서 발생 (`AppointmentRepository.countOverlapping` 등 선례 일치)<br>• 집계 쿼리는 도메인 로직, API 관심사 아님<br>• `AppointmentRepository` 비대화 방지<br>• transaction 경계는 `appointment-api` 서비스 계층이 동일하게 유지 |
+
+bluetape4k 패턴 정합: 핵심 도메인 테이블의 read는 core repository, write/orchestration은 api service.
+
+### 2.2 보안 경계 — 결정 B: 경로 기반 매처 (`/api/admin/**`)
+
+| 후보 | 채택 여부 | 이유 |
+|------|----------|------|
+| 옵션 1: `/api/admin/**` 경로 매처 | **채택** | • 현재 `SecurityConfig`가 모두 path-based로 통일됨<br>• `@EnableMethodSecurity` 미활성화 → 옵션 2는 추가 설정 필요<br>• 단일 위치에서 권한 정책 가시성 확보 |
+| 옵션 2: `@PreAuthorize` | 불가 | 현재 코드베이스에 메서드 시큐리티 활성화 없음, 일관성 깨짐 |
+
+**매처 순서(중요)**: Spring Security는 first-match-wins. 새 매처는 **반드시** 기존 `GET /api/**` 규칙 **앞**에 위치.
+
+```
+1. /swagger-ui/**, /v3/api-docs/**, /actuator/**  → permitAll
+2. /api/admin/**                                  → hasRole(ADMIN)   [신규, GET보다 앞]
+3. GET /api/**                                    → authenticated()
+4. POST/PATCH/DELETE /api/**                      → hasAnyRole(ADMIN, STAFF)
+5. anyRequest()                                   → authenticated()
+```
+
+### 2.3 차트 라이브러리 — 결정 C: Chart.js 직접 통합 (no Angular wrapper)
+
+Angular 21.2.10은 **bleeding edge**이며 `ng2-charts`/`ngx-echarts`의 Angular 21 peer-dep 호환은 transcript 시점에서 검증 불가.
+
+| 후보 | 채택 여부 | 이유 |
+|------|----------|------|
+| 옵션 1: Chart.js + `ng2-charts` | 보류 | peer-dep `^21` 지원 여부 불확실 |
+| 옵션 2: Apache ECharts + `ngx-echarts` | 보류 | 번들 크기 큼(+700KB), 동일 peer-dep 리스크 |
+| **옵션 3: Chart.js 단독 + 얇은 컴포넌트 래퍼 (채택)** | **채택** | • peer-dep 리스크 0<br>• Angular 21 standalone signal 패턴과 잘 맞음 (`afterNextRender` + `ElementRef`로 canvas 마운트)<br>• 번들 +180KB로 가장 가벼움<br>• Chart.js 4.x는 framework-agnostic |
+
+**의존성 추가** (`frontend/appointment-frontend/package.json`):
+
+```json
+{
+  "dependencies": {
+    "chart.js": "^4.5.0"
+  }
+}
+```
+
+> 검증 절차(구현 단계): `npm view chart.js peerDependencies` 후 Angular 21 + TS 5.9 환경에서 `ng build` 통과 확인.
+
+### 2.4 프론트엔드 컴포넌트 — 결정 A: 기존 `ManagementDashboardComponent` 확장
+
+| 후보 | 채택 여부 | 이유 |
+|------|----------|------|
+| **옵션 1: 기존 컴포넌트 확장 (채택)** | **채택** | 기존 라우트(`/management`)/카드 레이아웃 보존, 차트 섹션만 추가 |
+| 옵션 2: `/admin/dashboard` 신규 라우트 | 불가 | 라우트 중복, 기존 사용자(STAFF/DOCTOR) UX 파편화 |
+
+**차트 영역 권한 분기 (Decision D)**: `/management` 라우트는 `ADMIN|STAFF|DOCTOR` 가드. 차트 데이터 API는 ADMIN 전용. → **STAFF/DOCTOR는 기존 카드만 보이고, 차트 섹션은 ADMIN일 때만 렌더링**한다(클라이언트 측 조건부 + 서버 403 안전망).
+
+```typescript
+// management-dashboard.component.ts
+readonly isAdmin = computed(() => this.authService.roles().includes('ROLE_ADMIN'));
+// template
+@if (isAdmin()) { <app-dashboard-charts /> }
+```
+
+---
+
+## 3. 백엔드 API 명세
+
+### 3.1 공통 사항
+
+- Base path: `/api/admin/stats`
+- 인증: JWT (ADMIN 역할 필수, 그 외는 403)
+- 응답 envelope: `ApiResponse<T>` (기존 패턴)
+- 날짜 파라미터: `@DateTimeFormat(iso = DateTimeFormat.ISO.DATE)` (예: `2026-05-19`)
+- 기간 미지정 시 기본값: **최근 30일** (`to = today`, `from = today.minusDays(29)`)
+- 최대 조회 기간: **366일** (1년) — 초과 시 400 + `"period exceeds 366 days"` 메시지
+- `from > to` 시 400 + `"from must be on or before to"` 메시지
+- 시간대: clinic-naive `LocalDate`만 사용 (timezone 변환 없음)
+- 상태 키는 `AppointmentState.name` 문자열 (sealed class 기반, enum 아님)
+
+### 3.2 `GET /api/admin/stats/appointments`
+
+**용도**: 일자별·상태별 예약 추세 (스택형 막대/라인 차트 데이터 소스).
+
+**Query Parameters**:
+
+| 이름 | 타입 | 필수 | 기본값 | 설명 |
+|------|------|------|--------|------|
+| `clinicId` | Long | yes | — | 병원 ID |
+| `from` | LocalDate (ISO) | no | `today - 29` | 조회 시작일 |
+| `to` | LocalDate (ISO) | no | `today` | 조회 종료일 |
+| `statuses` | List\<String\> | no | 전체 | 필터링할 상태 (CSV) |
+
+**응답 스키마**:
+
+```kotlin
+data class AppointmentStatsResponse(
+    val clinicId: Long,
+    val from: LocalDate,
+    val to: LocalDate,
+    val totals: Map<String, Long>,            // 상태별 총합: { "CONFIRMED": 120, "CANCELLED": 18, ... }
+    val daily: List<DailyAppointmentBucket>,  // 일자별 시계열
+) : Serializable
+
+data class DailyAppointmentBucket(
+    val date: LocalDate,
+    val countsByStatus: Map<String, Long>,    // { "CONFIRMED": 5, "REQUESTED": 2 }
+    val total: Long,
+) : Serializable
+```
+
+**사용 인덱스**: `idx_appointments_clinic_date_status` (clinicId, appointmentDate, status)
+
+**Exposed 쿼리 형태**:
+
+```kotlin
+Appointments
+    .select(Appointments.appointmentDate, Appointments.status, Appointments.id.count())
+    .where { (Appointments.clinicId eq clinicId) and (Appointments.appointmentDate.between(from, to)) }
+    .groupBy(Appointments.appointmentDate, Appointments.status)
+    .map { ... }
+```
+
+### 3.3 `GET /api/admin/stats/doctors`
+
+**용도**: 의사별 예약 수 + 완료율 (수평 막대 차트).
+
+**Query Parameters**:
+
+| 이름 | 타입 | 필수 | 기본값 | 설명 |
+|------|------|------|--------|------|
+| `clinicId` | Long | yes | — | 병원 ID |
+| `from` | LocalDate | no | `today - 29` | 조회 시작일 |
+| `to` | LocalDate | no | `today` | 조회 종료일 |
+| `limit` | Int | no | 20 | 상위 N명 (1..100) |
+
+**응답 스키마**:
+
+```kotlin
+data class DoctorStatsResponse(
+    val clinicId: Long,
+    val from: LocalDate,
+    val to: LocalDate,
+    val doctors: List<DoctorBucket>,
+) : Serializable
+
+data class DoctorBucket(
+    val doctorId: Long,
+    val totalAppointments: Long,
+    val completed: Long,
+    val cancelled: Long,
+    val noShow: Long,
+    val completionRate: Double,    // completed / (completed + cancelled + noShow), 분모 0이면 0.0
+) : Serializable
+```
+
+> 참고: `doctorName`은 본 API에서 반환하지 않는다 — 프론트엔드가 기존 `DoctorService` 캐시로 ID→이름 매핑.
+
+**사용 인덱스**: `idx_appointments_doctor_date` (doctorId, appointmentDate)
+
+> **P1 — 인덱스 효율 주의 (Step 2-R 피드백)**: 현재 인덱스는 `(doctorId, appointmentDate)` 컬럼 순서이며 `clinicId` 조건이 포함되지 않는다. 단일 병원 환경(이 예제 앱)에서는 테이블 전체가 하나의 병원에 속하므로 인덱스 효율이 충분하다. 다중 병원 환경으로 확장할 경우 `(clinicId, doctorId, appointmentDate)` 인덱스로 교체해야 `clinicId` 필터가 인덱스 스캔 내에서 처리된다. 이 변경은 Flyway 마이그레이션 별도 이슈로 남긴다.
+
+### 3.4 `GET /api/admin/stats/cancellations`
+
+**용도**: 취소·노쇼 추세 (일자별 라인 차트 + 비율 KPI).
+
+**Query Parameters**:
+
+| 이름 | 타입 | 필수 | 기본값 | 설명 |
+|------|------|------|--------|------|
+| `clinicId` | Long | yes | — | 병원 ID |
+| `from` | LocalDate | no | `today - 29` | 조회 시작일 |
+| `to` | LocalDate | no | `today` | 조회 종료일 |
+
+**응답 스키마**:
+
+```kotlin
+data class CancellationStatsResponse(
+    val clinicId: Long,
+    val from: LocalDate,
+    val to: LocalDate,
+    val totalCancelled: Long,
+    val totalNoShow: Long,
+    val totalRescheduled: Long,
+    val totalCompleted: Long,
+    val cancellationRate: Double,   // CANCELLED / (CANCELLED + COMPLETED + NO_SHOW + RESCHEDULED), 분모 0이면 0.0
+    val noShowRate: Double,         // NO_SHOW / (CANCELLED + COMPLETED + NO_SHOW + RESCHEDULED)
+    val daily: List<DailyCancellationBucket>,
+) : Serializable
+
+data class DailyCancellationBucket(
+    val date: LocalDate,
+    val cancelled: Long,
+    val noShow: Long,
+    val rescheduled: Long,
+) : Serializable
+```
+
+**분모 결정**: 완결된(CANCELLED + COMPLETED + NO_SHOW + RESCHEDULED) 예약만 분모. REQUESTED/CONFIRMED 등 진행 중 상태는 제외 → 노이즈 감소.
+
+**사용 인덱스**: `idx_appointments_date_status` (appointmentDate, status) + clinicId 조건은 `idx_appointments_clinic_date_status`로 커버 가능. 실제 옵티마이저가 후자를 선택할 가능성이 높다.
+
+### 3.5 에러 응답
+
+| HTTP | 시나리오 | 응답 |
+|------|---------|------|
+| 400 | 파라미터 부재/형식 오류 | `ApiResponse.error("…")` |
+| 401 | JWT 없음/만료 | `ApiResponse.error("Unauthorized")` |
+| 403 | ADMIN 아님 | `ApiResponse.error("Forbidden")` |
+| 500 | DB 오류 | `ApiResponse.error("Internal error")` |
+
+---
+
+## 4. 백엔드 구현 컴포넌트
+
+### 4.1 신규 파일
+
+| 경로 | 책임 | 비고 |
+|------|------|------|
+| `appointment-core/.../repository/AppointmentStatsRepository.kt` | 3개 집계 쿼리(`groupBy` + `count`) | `KLogging`, 모든 메서드는 호출자가 `transaction {}` 내부에서 호출 |
+| `appointment-api/.../dto/AppointmentStatsResponse.kt` | 3.2 DTO | `Serializable`, `serialVersionUID` |
+| `appointment-api/.../dto/DoctorStatsResponse.kt` | 3.3 DTO | 위 동일 |
+| `appointment-api/.../dto/CancellationStatsResponse.kt` | 3.4 DTO | 위 동일 |
+| `appointment-api/.../service/DashboardStatsService.kt` | 파라미터 검증(`requireXxx`) + `transaction {}` 경계 + Repository 호출 + 비율 계산 | bluetape4k `requireNotNull`/`require` 확장 사용 |
+| `appointment-api/.../controller/DashboardStatsController.kt` | REST 엔드포인트 3개, OpenAPI 어노테이션 | `@RequestMapping("/api/admin/stats")` |
+
+### 4.2 수정 파일
+
+| 경로 | 변경 내용 |
+|------|----------|
+| `appointment-api/.../security/SecurityConfig.kt` | `/api/admin/**` → `hasRole(ADMIN)` 매처 추가 (GET 규칙 **앞**에) |
+| `appointment-api/.../config/ServiceConfig.kt` | `AppointmentStatsRepository`, `DashboardStatsService` Bean 등록 |
+
+### 4.3 인터페이스 스케치
+
+```kotlin
+// AppointmentStatsRepository.kt
+class AppointmentStatsRepository {
+    companion object : KLogging()
+
+    /** 일자별·상태별 카운트. 호출자는 transaction 내부에서 호출. */
+    fun countByDateAndStatus(
+        clinicId: Long,
+        dateRange: ClosedRange<LocalDate>,
+        statuses: List<AppointmentState>? = null,
+    ): List<Triple<LocalDate, AppointmentState, Long>>
+
+    /** 의사별 상태별 카운트. */
+    fun countByDoctorAndStatus(
+        clinicId: Long,
+        dateRange: ClosedRange<LocalDate>,
+        limit: Int = 20,
+    ): List<Triple<Long, AppointmentState, Long>>  // doctorId, status, count
+
+    /** 일자별 취소/노쇼/재배정 카운트. */
+    fun countCancellationsByDate(
+        clinicId: Long,
+        dateRange: ClosedRange<LocalDate>,
+    ): List<Triple<LocalDate, AppointmentState, Long>>
+}
+
+// DashboardStatsService.kt
+class DashboardStatsService(
+    private val statsRepository: AppointmentStatsRepository,
+) {
+    fun getAppointmentStats(
+        clinicId: Long,
+        from: LocalDate,
+        to: LocalDate,
+        statuses: List<String>?,
+    ): AppointmentStatsResponse {
+        clinicId.requirePositive("clinicId")
+        require(!from.isAfter(to)) { "from must be on or before to" }
+        require(ChronoUnit.DAYS.between(from, to) <= 366) { "period exceeds 366 days" }
+
+        // P1: AppointmentState.fromName()은 미지원 상태명에서 IllegalArgumentException 발생
+        // (실제 API: `else -> throw IllegalArgumentException("Unknown appointment status: $name")`)
+        // Service는 이를 잡아 ApiResponse.error() 400으로 변환
+        val statusEnums = statuses?.map { AppointmentState.fromName(it) }
+        // 호출부에서 try-catch로 IllegalArgumentException → 400 변환 처리
+        return transaction {
+            val rows = statsRepository.countByDateAndStatus(clinicId, from..to, statusEnums)
+            // ... bucket 조립
+        }
+    }
+    // 나머지 2개 메서드 유사
+}
+```
+
+---
+
+## 5. 보안 정책
+
+### 5.1 적용 방식
+
+- `SecurityConfig.securityFilterChain` 내 매처 추가 — 4.2 참조
+- prod/staging 프로파일: ADMIN 토큰만 200, STAFF/DOCTOR 토큰은 **403 Forbidden**
+- dev/test 프로파일: `NoOpSecurityConfig`가 모두 허용 → 통합 테스트는 별도 프로파일 또는 SecurityConfig 직접 import로 검증
+
+### 5.2 테스트 시나리오
+
+| 케이스 | 기대 결과 |
+|--------|----------|
+| ADMIN 토큰 + 유효 파라미터 | 200 OK |
+| STAFF 토큰 | 403 Forbidden |
+| DOCTOR 토큰 | 403 Forbidden |
+| 토큰 없음 | 401 Unauthorized |
+| ADMIN 토큰 + `from > to` | 400 |
+| ADMIN 토큰 + 367일 범위 | 400 |
+| ADMIN 토큰 + 빈 결과 병원 | 200, `totals = {}`, `daily = []` |
+
+### 5.3 clinicId 소유권(IDOR) 정책
+
+> **P1 — 명시적 정책 문서화 (Step 2-R 피드백, 실제 코드 검증 후 업데이트)**
+
+**실제 확인된 사실**:
+
+- `SchedulingUserPrincipal`은 `clinicId: Long?` 필드를 보유 — JWT 토큰에 clinicId 클레임이 존재한다.
+- 그러나 기존 컨트롤러(`AppointmentController`, `RescheduleController` 등)는 `principal.clinicId` vs 파라미터 `clinicId`를 비교하지 않는다. `@RequestParam clinicId`를 그대로 서비스에 전달한다.
+
+**채택 정책 (기존 패턴 일치)**:
+
+이 대시보드 API도 기존 컨트롤러 패턴과 동일하게 `principal.clinicId` 소유권 검증을 수행하지 않는다.
+ADMIN role 보유자가 어떤 clinicId든 통계 조회 가능. Path-based `hasRole(ADMIN)` 체크가 유일한 권한 경계다.
+
+**기술 부채 인식**:
+
+```kotlin
+// 미래 다중 병원 환경으로 전환 시 추가 필요 (별도 이슈)
+val principal = SecurityContextHolder.getContext().authentication.principal as SchedulingUserPrincipal
+require(principal.clinicId == null || principal.clinicId == clinicId) {
+    "Access to clinic $clinicId is not authorized"
+}
+```
+
+**위험 수용 근거**: 기존 모든 API가 동일한 패턴을 따르고 있어 통일성 유지. 다중 병원 환경 전환 시 이 주석이 구현 위치 식별자 역할을 한다.
+
+### 5.4 오류 전파 정책
+
+> **P1 — Transaction/Service 오류 처리 경계 명세 (Step 2-R 피드백)**
+
+| 오류 유형 | 발생 위치 | 변환 책임 | HTTP 응답 |
+|----------|----------|----------|----------|
+| `IllegalArgumentException` — `AppointmentState.fromName()` 미지원 상태명 | Service | **`GlobalExceptionHandler.handleIllegalArgument`** 자동 처리 → 400 | 400 |
+| `IllegalArgumentException` — 기간 초과, from > to (Service `require(...)`) | Service | 위 동일, `GlobalExceptionHandler` 자동 처리 | 400 |
+| DB 오류 (Transaction 내부) | Repository | `GlobalExceptionHandler.handleGeneral` → 500 | 500 |
+| `ExposedSQLException` | Repository | 위 동일 | 500 |
+
+**검증된 사실**: `GlobalExceptionHandler` (`appointment-api/.../config/GlobalExceptionHandler.kt`)는 이미 존재하며 `@ExceptionHandler(IllegalArgumentException::class)` → 400 변환을 처리한다. Service 계층에서 별도 try-catch 불필요.
+
+**오류 메시지 보안**: `AppointmentState.fromName(name)`은 `"Unknown appointment status: $name"` 메시지를 던진다. 입력 상태명은 포함되나 내부 sealed class 서브클래스 전체 목록은 노출하지 않는다. 허용 상태명은 Swagger 스키마에만 문서화한다.
+
+---
+
+## 6. 프론트엔드 컴포넌트
+
+### 6.1 신규 파일
+
+| 경로 | 책임 |
+|------|------|
+| `frontend/appointment-frontend/src/app/core/services/dashboard-stats.service.ts` | 3개 API HTTP 클라이언트, `signal` 상태 |
+| `frontend/appointment-frontend/src/app/core/models/dashboard-stats.model.ts` | 백엔드 DTO 미러 TypeScript 타입 |
+| `frontend/appointment-frontend/src/app/features/management/dashboard/charts/appointment-trend-chart.component.ts` | 일자별 스택형 막대 차트 (Chart.js) |
+| `frontend/appointment-frontend/src/app/features/management/dashboard/charts/doctor-workload-chart.component.ts` | 의사별 수평 막대 차트 |
+| `frontend/appointment-frontend/src/app/features/management/dashboard/charts/cancellation-trend-chart.component.ts` | 취소율 라인 차트 + KPI 카드 |
+| `frontend/appointment-frontend/src/app/features/management/dashboard/dashboard-charts.component.ts` | 위 3개를 묶는 컨테이너, ADMIN 가시성 분기 |
+| 각 `.spec.ts` 파일 (vitest) | 컴포넌트/서비스 단위 테스트 |
+
+### 6.2 수정 파일
+
+| 경로 | 변경 |
+|------|------|
+| `frontend/appointment-frontend/src/app/features/management/dashboard/management-dashboard.component.ts` | `<app-dashboard-charts />` 섹션 추가, `isAdmin` computed signal |
+| `frontend/appointment-frontend/src/app/core/services/index.ts` | `DashboardStatsService` export |
+| `frontend/appointment-frontend/package.json` | `chart.js: ^4.5.0` 추가 |
+| `frontend/appointment-frontend/src/app/core/models/index.ts` | dashboard-stats 모델 export |
+
+### 6.3 차트 유형 매핑
+
+| 차트 컴포넌트 | API | Chart.js type | 데이터 흐름 |
+|--------------|-----|--------------|------------|
+| `AppointmentTrendChart` | `/stats/appointments` | `bar` (stacked) | x: date, y: count, stack: status |
+| `DoctorWorkloadChart` | `/stats/doctors` | `bar` (horizontal) | y: doctorName, x: total / completed |
+| `CancellationTrendChart` | `/stats/cancellations` | `line` (multi-series) + KPI 카드 | x: date, y: cancelled / noShow / rescheduled |
+
+### 6.4 데이터 흐름
+
+```
+Component ngOnInit (or afterNextRender)
+  → DashboardStatsService.loadXxx(clinicId, from, to)
+    → HttpClient GET /api/admin/stats/xxx
+    → signal<XxxResponse | null> 갱신
+  → effect/computed로 Chart.js 데이터 변환
+  → ElementRef<HTMLCanvasElement>에 new Chart(...)
+컴포넌트 destroy 시 chart.destroy() 호출
+```
+
+### 6.5 컴포넌트 라이프사이클 (Chart.js + signals)
+
+- `afterNextRender(() => { ... })`에서 canvas 마운트 (Angular 21 SSR-safe)
+- `effect(() => { rebuildChart(data()) })`로 signal 변화에 반응 — `untracked()`로 chart 인스턴스 메모리화
+- `ngOnDestroy`에서 `chart?.destroy()`
+
+---
+
+## 7. 테스트 전략
+
+### 7.1 백엔드 (JUnit 5 + MockK + H2)
+
+| 레벨 | 대상 | 케이스 |
+|------|------|--------|
+| Repository (실제 H2) | `AppointmentStatsRepository` | 시드 데이터 → `groupBy` 결과 검증, 빈 결과, 날짜 경계, 상태 필터 |
+| Service (MockK) | `DashboardStatsService` | 파라미터 검증, 비율 계산(분모 0 포함), 기본 날짜 범위, 미지원 상태명 → 400 |
+| Controller (MockMvc) | `DashboardStatsController` | ADMIN 200, STAFF 403, DOCTOR 403, 토큰 없음 401, from>to 400, 기간 초과 400, JSON 직렬화 |
+| SecurityConfig 통합 | 매처 순서 | ADMIN 200, STAFF 403, DOCTOR 403, anon 401, GET `/api/admin/...`이 GET `/api/**`보다 먼저 매칭 |
+
+- H2: 기존 패턴 따름 (`SchemaUtils.createMissingTablesAndColumns`, `@BeforeEach deleteAll`)
+- Testcontainers 미사용 (스펙 제약)
+
+### 7.2 프론트엔드 (vitest)
+
+| 대상 | 케이스 |
+|------|--------|
+| `DashboardStatsService` | 3개 메서드 HTTP 모킹, 성공/에러 응답 처리 |
+| `AppointmentTrendChartComponent` | signal 변경 시 chart `update()` 호출 확인 (Chart.js 모킹) |
+| `DashboardChartsComponent` | `isAdmin` false → 차트 미렌더링; true → 3개 차트 자식 컴포넌트 존재 |
+| `ManagementDashboardComponent` (regression) | 기존 카드 섹션 유지 |
+
+**Chart.js 모킹 전략** (P1 — `chart.destroy()` 검증 방법 명세):
+
+```typescript
+// vitest에서 Chart.js 모킹 — 생성자 + 인스턴스 메서드 스파이
+const destroyFn = vi.fn();
+const updateFn = vi.fn();
+vi.mock('chart.js', () => ({
+  Chart: vi.fn().mockImplementation(() => ({
+    destroy: destroyFn,
+    update: updateFn,
+    data: { labels: [], datasets: [] },
+  })),
+  registerables: [],
+}));
+
+// ngOnDestroy 호출 후 destroy() 검증
+it('컴포넌트 파괴 시 Chart 인스턴스를 destroy한다', () => {
+  fixture.detectChanges(); // afterNextRender 트리거 (존재한다면 TestBed.flushEffects())
+  component.ngOnDestroy();
+  expect(destroyFn).toHaveBeenCalledOnce();
+});
+```
+
+> `afterNextRender`는 TestBed 환경에서 자동 실행되지 않을 수 있다. 생성자나 `ngOnInit`으로 canvas 초기화를 이동하거나, `TestBed.flushEffects()`를 활용하는 두 가지 접근 모두 구현 단계에서 검증한다. 테스트가 안정적으로 통과하는 방식을 선택하되 명세를 벗어나지 않는다.
+
+---
+
+## 8. 위험 요소 + 완화 방안
+
+| 위험 | 가능성 | 영향 | 완화 |
+|------|-------|------|------|
+| Angular 21 ↔ Chart.js 4 호환성 미검증 | 중 | 중 | Chart.js 단독(no Angular wrapper) 채택, 구현 단계에서 `ng build` 통과 확인 |
+| `/api/admin/**` 매처 순서 오류로 우회 가능 | 저 | 고 | SecurityConfig 통합 테스트로 first-match-wins 명시 검증 |
+| 대용량 병원에서 `groupBy` 풀스캔 | 중 | 중 | 기존 인덱스 활용, `to-from ≤ 366일` 강제, 추후 Materialized View는 별도 이슈 |
+| `AppointmentState.fromName` 미지원 상태 입력 → 500 | 저 | 저 | Service에서 catch → 400 응답으로 변환 |
+| Chart.js 인스턴스 누수 (컴포넌트 재마운트) | 저 | 저 | `ngOnDestroy`에서 `destroy()` + effect cleanup |
+| 프론트 ADMIN 분기 우회 시 403 받지만 콘솔 에러 노이즈 | 저 | 저 | HttpInterceptor에서 `/api/admin/stats`에 한해 403을 silent fallback (signal `null` 유지) |
+| `ManagementDashboardComponent`의 기존 `doctorCount.set(0)` 로직 — 비동기 결과 사용 안 함 (기존 버그) | 저 | 저 | 본 이슈 범위 밖, 별도 PR에서 수정. 본 스펙에서는 회귀 테스트만 추가 |
+| 시간대 무시로 자정 부근 통계 오해 | 중 | 저 | 응답에 `from`/`to`(LocalDate, clinic-naive) 명시, README/Swagger에 표기 |
+| 캐시 미적용 — 동일 ADMIN이 새로고침 반복 시 매번 집계 | 저 | 중 | 본 이슈에서는 캐시 없음(YAGNI). p95 측정 후 별도 이슈로 Spring Cache 적용 검토 |
+
+---
+
+## 9. 구현 순서 권장 (Plan 단계용 힌트)
+
+1. `AppointmentStatsRepository` + H2 단위 테스트 (RED→GREEN)
+2. DTO 3종 + `Serializable`/`serialVersionUID`
+3. `DashboardStatsService` + MockK 단위 테스트
+4. `DashboardStatsController` + MockMvc 통합 테스트
+5. `SecurityConfig` 매처 추가 + 보안 통합 테스트
+6. `ServiceConfig` Bean 등록 + Swagger 확인
+7. 프론트엔드 `DashboardStatsService` + vitest
+8. Chart.js 의존성 추가 + 3개 차트 컴포넌트 + vitest
+9. `ManagementDashboardComponent` 통합 + 회귀 테스트
+10. README 업데이트 (한/영), CHANGELOG 항목
+
+---
+
+## 10. Definition of Done (DoD)
+
+### 10.1 백엔드
+
+- [ ] `AppointmentStatsRepository` 구현 + H2 단위 테스트 (빈 결과/경계/필터 포함) 통과
+- [ ] DTO 3종이 `Serializable` 구현 + `serialVersionUID = 1L` 보유
+- [ ] `DashboardStatsService` 파라미터 검증 (bluetape4k `requireXxx`) + 비율 계산 (분모 0 안전) 단위 테스트 통과
+- [ ] `DashboardStatsController` MockMvc 통합 테스트 200/400 통과
+- [ ] SecurityConfig: ADMIN 200, STAFF/DOCTOR 403, anon 401 통합 테스트 통과
+- [ ] 모든 Exposed 쿼리가 `transaction {}` 내부에서 실행됨 (코드 리뷰 확인)
+- [ ] OpenAPI(Swagger) 페이지에서 3개 엔드포인트 가시 + 응답 스키마 정확
+- [ ] `./gradlew :appointment-core:test :appointment-api:test` PASS, 소요 시간 보고
+- [ ] IDE diagnostics: 에러 0, 미해결 deprecation 0
+- [ ] 새/변경 public API에 영문 KDoc 작성
+
+### 10.2 프론트엔드
+
+- [ ] `package.json`에 `chart.js: ^4.5.0` 추가, `npm install` 후 `ng build` 통과
+- [ ] `DashboardStatsService` vitest spec 통과 (3개 메서드, 에러 케이스 포함)
+- [ ] 3개 차트 컴포넌트 + 컨테이너 컴포넌트 vitest spec 통과
+- [ ] `ManagementDashboardComponent` 회귀 테스트 통과 (기존 카드 유지)
+- [ ] ADMIN role일 때만 차트 영역 렌더링 — 단위 테스트로 검증
+- [ ] Chart.js 인스턴스 `ngOnDestroy`에서 `destroy()` 호출 (메모리 누수 방지)
+- [ ] `npm run test`, `npm run build` 모두 PASS
+
+### 10.3 문서/PR
+
+- [ ] `README.md` + `README.ko.md`에 대시보드 섹션 추가 (구조 정렬 유지)
+- [ ] `CHANGELOG.md`에 항목 추가 (영문)
+- [ ] PR 제목/본문 영문, 테스트 결과 및 보안 검증 명시
+- [ ] `oh-my-claudecode:code-reviewer` 실행, HIGH/CRITICAL 해결 후 푸시
+- [ ] worktree `.worktrees/feat/issue-44-45-dashboard/`에서 작업, develop 대상 PR 생성
+
+---
+
+## 12. Appendix — Step 2-R Iteration Log
+
+### Round 1 (2026-05-19)
+
+| Reviewer | P0 | P1 | P2 | P3 |
+|----------|----|----|----|----|
+| Phase 1: Architect | 0 | 2 | 2 | 0 |
+| Phase 1: Security | 0 | 2 | 1 | 0 |
+| Phase 1: Silent-Failure | 0 | 1 | 2 | 1 |
+| Phase 1: Type-Design | 0 | 1 | 1 | 0 |
+| **통합 합계** | **0** | **6** | **6** | **1** |
+
+**Round 1 적용 항목** (spec 개정, 이 커밋):
+
+1. [P1-Security] IDOR — clinicId 소유권 정책 명문화 → §5.3 신규 추가
+2. [P1-Security/Arch] 오류 전파 경계 — Service 계층이 400 변환 담당 → §5.4 신규 추가
+3. [P1-Test] DOCTOR 403 케이스 — §7.1 Controller 테스트 표에 명시
+4. [P1-Test] chart.destroy() 검증 — §7.2 Chart.js 모킹 전략 섹션 추가
+5. [P1-Performance] idx_appointments_doctor_date 멀티클리닉 갭 — §3.3 주의 노트 추가
+6. [P1-Arch] AppointmentState.fromName() — §4.3 실제 API 확인 후 정확한 사용법 명세
+
+### Round 2 목표
+
+Claude Code 6-tier advisor + Phase 3 Codex 리뷰 후 P0/P1 = 0 달성 여부 확인.
+
+---
+
+## 11. 참조
+
+- 기존 Repository 패턴: `appointment-core/.../repository/AppointmentRepository.kt`
+- 기존 Controller 패턴: `appointment-api/.../controller/AppointmentController.kt`
+- 기존 SecurityConfig: `appointment-api/.../security/SecurityConfig.kt`
+- 기존 ApiResponse envelope: `appointment-api/.../dto/ApiResponse.kt`
+- 기존 ManagementDashboardComponent: `frontend/appointment-frontend/src/app/features/management/dashboard/management-dashboard.component.ts`
+- AppointmentState (sealed class): `appointment-core/.../statemachine/AppointmentState.kt`
+- 기존 인덱스: `appointment-core/.../model/tables/Appointments.kt`
+- 선례 Spec: `docs/superpowers/specs/2026-05-06-spring-cache-refactor-design.md`

--- a/docs/superpowers/specs/2026-05-19-dashboard-stats-design.md
+++ b/docs/superpowers/specs/2026-05-19-dashboard-stats-design.md
@@ -107,9 +107,9 @@ Angular 21.2.10은 **bleeding edge**이며 `ng2-charts`/`ngx-echarts`의 Angular
 
 ```typescript
 // management-dashboard.component.ts
-readonly isAdmin = computed(() => this.authService.roles().includes('ROLE_ADMIN'));
-// template
-@if (isAdmin()) { <app-dashboard-charts /> }
+// AuthService.isAdmin 이미 computed signal로 선언됨 — 로컬 재선언 금지 (DRY)
+private readonly authService = inject(AuthService);
+// template: @if (authService.isAdmin()) { <app-dashboard-charts /> }
 ```
 
 ---
@@ -139,7 +139,7 @@ readonly isAdmin = computed(() => this.authService.roles().includes('ROLE_ADMIN'
 | `clinicId` | Long | yes | — | 병원 ID |
 | `from` | LocalDate (ISO) | no | `today - 29` | 조회 시작일 |
 | `to` | LocalDate (ISO) | no | `today` | 조회 종료일 |
-| `statuses` | List\<String\> | no | 전체 | 필터링할 상태 (CSV) |
+| `statuses` | List\<String\> | no | 전체 | 필터링할 상태 — **반복 파라미터** 방식 사용 (`?statuses=CONFIRMED&statuses=CANCELLED`), CSV 단일값 방식 불가 |
 
 **응답 스키마**:
 
@@ -292,16 +292,17 @@ data class DailyCancellationBucket(
 
 > **SecurityConfig 401/403 envelope**: Spring Security의 `AccessDeniedException`/`AuthenticationException`은 필터 체인에서 발생하므로 `@RestControllerAdvice`가 처리하지 못한다. `SecurityConfig`에 아래를 추가해야 `ApiResponse` 형태 JSON이 반환된다:
 > ```kotlin
+> // SecurityConfig constructor에 ObjectMapper 주입 — 하드코딩 금지, ApiResponse 직렬화 일관성 유지
 > exceptionHandling {
 >     authenticationEntryPoint { _, response, _ ->
 >         response.status = 401
 >         response.contentType = "application/json"
->         response.writer.write("""{"success":false,"data":null,"error":"Unauthorized"}""")
+>         response.writer.write(objectMapper.writeValueAsString(ApiResponse.error<Nothing>("Unauthorized")))
 >     }
 >     accessDeniedHandler { _, response, _ ->
 >         response.status = 403
 >         response.contentType = "application/json"
->         response.writer.write("""{"success":false,"data":null,"error":"Forbidden"}""")
+>         response.writer.write(objectMapper.writeValueAsString(ApiResponse.error<Nothing>("Forbidden")))
 >     }
 > }
 > ```
@@ -335,15 +336,18 @@ class AppointmentStatsRepository {
     ): List<Triple<LocalDate, AppointmentState, Long>>
 
     /**
-     * 의사별 상태별 카운트. 결과는 **총 예약 수 내림차순** 정렬 (`orderBy(count DESC) LIMIT limit`).
+     * 의사별 상태별 카운트 전체 결과. LIMIT 미적용 — 호출자(Service)가 top-N 선별.
+     *
+     * **왜 LIMIT을 여기에 두지 않는가**: 각 행은 (doctorId, status, count) 조합이므로
+     * SQL `LIMIT N`을 이 레벨에 적용하면 "상위 N명의 의사" 의미가 아닌
+     * "N개 (doctorId, status) 행"이 된다. Service에서 그룹핑 후 상위 N명을 선별한다.
      *
      * doctorId와 count가 모두 Long이므로 named class DoctorStatusCount 사용 (CLAUDE.md: 동일 타입 파라미터 규칙).
      */
     fun countByDoctorAndStatus(
         clinicId: Long,
         dateRange: ClosedRange<LocalDate>,
-        limit: Int = 20,
-    ): List<DoctorStatusCount>
+    ): List<DoctorStatusCount>  // 모든 doctorId × status 조합 반환; Service가 top-N 선별
 
     /**
      * 일자별 취소/노쇼/재배정 카운트. 호출자는 transaction 내부에서 호출.
@@ -383,7 +387,31 @@ class DashboardStatsService(
         require(!from.isAfter(to)) { "from must be on or before to" }
         require(ChronoUnit.DAYS.between(from, to) <= 366) { "period exceeds 366 days" }
         require(limit in 1..100) { "limit must be between 1 and 100" }
-        // ... 동일 패턴
+
+        return transaction {
+            val rows = statsRepository.countByDoctorAndStatus(clinicId, from..to)
+            // Kotlin groupBy: (doctorId, status, count) → per-doctor DoctorBucket → 상위 limit명 선별
+            val byDoctor = rows.groupBy { it.doctorId }
+            val topDoctors = byDoctor
+                .map { (doctorId, statusCounts) ->
+                    val completed = statusCounts.find { it.status == AppointmentState.COMPLETED }?.count ?: 0L
+                    val cancelled = statusCounts.find { it.status == AppointmentState.CANCELLED }?.count ?: 0L
+                    val noShow = statusCounts.find { it.status == AppointmentState.NO_SHOW }?.count ?: 0L
+                    val total = statusCounts.sumOf { it.count }
+                    val denom = completed + cancelled + noShow
+                    DoctorBucket(
+                        doctorId = doctorId,
+                        totalAppointments = total,
+                        completed = completed,
+                        cancelled = cancelled,
+                        noShow = noShow,
+                        completionRate = if (denom > 0) completed.toDouble() / denom else 0.0,
+                    )
+                }
+                .sortedByDescending { it.totalAppointments }
+                .take(limit)
+            DoctorStatsResponse(clinicId, from, to, topDoctors)
+        }
     }
 }
 ```
@@ -561,7 +589,7 @@ it('컴포넌트 파괴 시 Chart 인스턴스를 destroy한다', () => {
 | Angular 21 ↔ Chart.js 4 호환성 미검증 | 중 | 중 | Chart.js 단독(no Angular wrapper) 채택, 구현 단계에서 `ng build` 통과 확인 |
 | `/api/admin/**` 매처 순서 오류로 우회 가능 | 저 | 고 | SecurityConfig 통합 테스트로 first-match-wins 명시 검증 |
 | 대용량 병원에서 `groupBy` 풀스캔 | 중 | 중 | 기존 인덱스 활용, `to-from ≤ 366일` 강제, 추후 Materialized View는 별도 이슈 |
-| `AppointmentState.fromName` 미지원 상태 입력 → 500 | 저 | 저 | Service에서 catch → 400 응답으로 변환 |
+| `AppointmentState.fromName` 미지원 상태 입력 → IllegalArgumentException | 저 | 저 | `GlobalExceptionHandler.handleIllegalArgument`가 자동으로 400 변환 — Service 별도 try-catch 불필요 |
 | Chart.js 인스턴스 누수 (컴포넌트 재마운트) | 저 | 저 | `ngOnDestroy`에서 `destroy()` + effect cleanup |
 | 프론트 ADMIN 분기 우회 시 403 받지만 콘솔 에러 노이즈 | 저 | 저 | HttpInterceptor에서 `/api/admin/stats`에 한해 403을 silent fallback (signal `null` 유지) |
 | `ManagementDashboardComponent`의 기존 `doctorCount.set(0)` 로직 — 비동기 결과 사용 안 함 (기존 버그) | 저 | 저 | 본 이슈 범위 밖, 별도 PR에서 수정. 본 스펙에서는 회귀 테스트만 추가 |
@@ -658,9 +686,25 @@ it('컴포넌트 파괴 시 Chart 인스턴스를 destroy한다', () => {
 4. [P2-T4] `limit in 1..100` 검증 → §4.3 getDoctorStats 스케치
 5. [P2-T6] Exposed `countExpr` alias 패턴 명시 → §3.2
 
-### Round 3 목표
+### Round 3 (2026-05-19)
 
-Phase 3 독립 리뷰 후 P0/P1 = 0 달성 여부 확인.
+| Reviewer | P0 | P1 | P2 | P3 |
+|----------|----|----|----|----|
+| Phase 3 독립 Critic | 0 | 1 | 2 | 2 |
+| **통합 합계** | **0** | **1** | **2** | **2** |
+
+**Round 3 P1 적용 항목**:
+1. [P1] `countByDoctorAndStatus` LIMIT 의미 오류 — SQL LIMIT을 (doctorId, status) 행 수준에 적용하면 "상위 N명 의사" 달성 불가. 수정: 리포지토리에서 LIMIT 제거, Service에서 Kotlin groupBy + sortedByDescending + take(limit) (§4.3)
+
+**Round 3 P2/P3 적용 항목**:
+1. [P2] `isAdmin` 중복 computed — AuthService.isAdmin 기존 signal 직접 사용 (§2.4)
+2. [P2] SecurityConfig 핸들러 JSON 하드코딩 → ObjectMapper 주입으로 ApiResponse 직렬화 (§4.2)
+3. [P3] statuses CSV 바인딩 방식 명시 → 반복 파라미터 방식으로 확정 (§3.2)
+4. [P3] §8과 §5.4 `fromName` 처리 방식 충돌 → §8 수정으로 일관성 확보
+
+**누적 수렴 현황**: Round 1 P1=6 → Round 2 P1=1 → Round 3 P1=1 → Round 3 적용 후 P1=0
+
+**수렴 선언 조건**: 모든 reviewer 통합 P0/P1=0 → Round 3 완료 후 수렴 선언 가능.
 
 ---
 

--- a/docs/superpowers/specs/2026-05-19-dashboard-stats-design.md
+++ b/docs/superpowers/specs/2026-05-19-dashboard-stats-design.md
@@ -164,11 +164,19 @@ data class DailyAppointmentBucket(
 **Exposed 쿼리 형태**:
 
 ```kotlin
+// Exposed 1.2+: count() 결과를 별칭으로 저장 후 row에서 추출
+val countExpr = Appointments.id.count()
 Appointments
-    .select(Appointments.appointmentDate, Appointments.status, Appointments.id.count())
+    .select(Appointments.appointmentDate, Appointments.status, countExpr)
     .where { (Appointments.clinicId eq clinicId) and (Appointments.appointmentDate.between(from, to)) }
     .groupBy(Appointments.appointmentDate, Appointments.status)
-    .map { ... }
+    .map { row ->
+        Triple(
+            row[Appointments.appointmentDate],
+            row[Appointments.status],  // AppointmentStateColumnType 매핑
+            row[countExpr],
+        )
+    }
 ```
 
 ### 3.3 `GET /api/admin/stats/doctors`
@@ -278,31 +286,70 @@ data class DailyCancellationBucket(
 
 | 경로 | 변경 내용 |
 |------|----------|
-| `appointment-api/.../security/SecurityConfig.kt` | `/api/admin/**` → `hasRole(ADMIN)` 매처 추가 (GET 규칙 **앞**에) |
+| `appointment-api/.../security/SecurityConfig.kt` | `/api/admin/**` → `hasRole(ADMIN)` 매처 추가 (GET 규칙 **앞**에); `authenticationEntryPoint` + `accessDeniedHandler` 등록 (ApiResponse 형태 JSON 반환) |
+| `appointment-api/.../config/GlobalExceptionHandler.kt` | `@ExceptionHandler(MethodArgumentTypeMismatchException::class)` → 400 핸들러 추가 |
 | `appointment-api/.../config/ServiceConfig.kt` | `AppointmentStatsRepository`, `DashboardStatsService` Bean 등록 |
+
+> **SecurityConfig 401/403 envelope**: Spring Security의 `AccessDeniedException`/`AuthenticationException`은 필터 체인에서 발생하므로 `@RestControllerAdvice`가 처리하지 못한다. `SecurityConfig`에 아래를 추가해야 `ApiResponse` 형태 JSON이 반환된다:
+> ```kotlin
+> exceptionHandling {
+>     authenticationEntryPoint { _, response, _ ->
+>         response.status = 401
+>         response.contentType = "application/json"
+>         response.writer.write("""{"success":false,"data":null,"error":"Unauthorized"}""")
+>     }
+>     accessDeniedHandler { _, response, _ ->
+>         response.status = 403
+>         response.contentType = "application/json"
+>         response.writer.write("""{"success":false,"data":null,"error":"Forbidden"}""")
+>     }
+> }
+> ```
+>
+> **MethodArgumentTypeMismatchException**: `?from=not-a-date` 같은 날짜 파싱 실패는 현재 `GlobalExceptionHandler`에서 처리되지 않아 500이 반환된다. `GlobalExceptionHandler`에 `MethodArgumentTypeMismatchException::class` 핸들러를 추가해야 §3.5의 400 계약을 충족한다.
 
 ### 4.3 인터페이스 스케치
 
 ```kotlin
 // AppointmentStatsRepository.kt
+
+/** 의사별 상태-카운트 행. Triple<Long, AppointmentState, Long> 사용 금지 — 동일 타입 위치 혼동 위험 (CLAUDE.md 규칙). */
+data class DoctorStatusCount(
+    val doctorId: Long,
+    val status: AppointmentState,
+    val count: Long,
+)
+
 class AppointmentStatsRepository {
     companion object : KLogging()
 
-    /** 일자별·상태별 카운트. 호출자는 transaction 내부에서 호출. */
+    /**
+     * 일자별·상태별 카운트. 호출자는 transaction 내부에서 호출.
+     *
+     * @return (date, status, count) 쌍 — date/count는 다른 타입이므로 Triple 허용
+     */
     fun countByDateAndStatus(
         clinicId: Long,
         dateRange: ClosedRange<LocalDate>,
         statuses: List<AppointmentState>? = null,
     ): List<Triple<LocalDate, AppointmentState, Long>>
 
-    /** 의사별 상태별 카운트. */
+    /**
+     * 의사별 상태별 카운트. 결과는 **총 예약 수 내림차순** 정렬 (`orderBy(count DESC) LIMIT limit`).
+     *
+     * doctorId와 count가 모두 Long이므로 named class DoctorStatusCount 사용 (CLAUDE.md: 동일 타입 파라미터 규칙).
+     */
     fun countByDoctorAndStatus(
         clinicId: Long,
         dateRange: ClosedRange<LocalDate>,
         limit: Int = 20,
-    ): List<Triple<Long, AppointmentState, Long>>  // doctorId, status, count
+    ): List<DoctorStatusCount>
 
-    /** 일자별 취소/노쇼/재배정 카운트. */
+    /**
+     * 일자별 취소/노쇼/재배정 카운트. 호출자는 transaction 내부에서 호출.
+     *
+     * @return (date, status, count) 쌍
+     */
     fun countCancellationsByDate(
         clinicId: Long,
         dateRange: ClosedRange<LocalDate>,
@@ -323,17 +370,21 @@ class DashboardStatsService(
         require(!from.isAfter(to)) { "from must be on or before to" }
         require(ChronoUnit.DAYS.between(from, to) <= 366) { "period exceeds 366 days" }
 
-        // P1: AppointmentState.fromName()은 미지원 상태명에서 IllegalArgumentException 발생
-        // (실제 API: `else -> throw IllegalArgumentException("Unknown appointment status: $name")`)
-        // Service는 이를 잡아 ApiResponse.error() 400으로 변환
+        // fromName() throws IAE on unknown name → GlobalExceptionHandler → 400 (자동)
         val statusEnums = statuses?.map { AppointmentState.fromName(it) }
-        // 호출부에서 try-catch로 IllegalArgumentException → 400 변환 처리
         return transaction {
             val rows = statsRepository.countByDateAndStatus(clinicId, from..to, statusEnums)
             // ... bucket 조립
         }
     }
-    // 나머지 2개 메서드 유사
+
+    fun getDoctorStats(clinicId: Long, from: LocalDate, to: LocalDate, limit: Int): DoctorStatsResponse {
+        clinicId.requirePositive("clinicId")
+        require(!from.isAfter(to)) { "from must be on or before to" }
+        require(ChronoUnit.DAYS.between(from, to) <= 366) { "period exceeds 366 days" }
+        require(limit in 1..100) { "limit must be between 1 and 100" }
+        // ... 동일 패턴
+    }
 }
 ```
 
@@ -461,7 +512,7 @@ Component ngOnInit (or afterNextRender)
 |------|------|--------|
 | Repository (실제 H2) | `AppointmentStatsRepository` | 시드 데이터 → `groupBy` 결과 검증, 빈 결과, 날짜 경계, 상태 필터 |
 | Service (MockK) | `DashboardStatsService` | 파라미터 검증, 비율 계산(분모 0 포함), 기본 날짜 범위, 미지원 상태명 → 400 |
-| Controller (MockMvc) | `DashboardStatsController` | ADMIN 200, STAFF 403, DOCTOR 403, 토큰 없음 401, from>to 400, 기간 초과 400, JSON 직렬화 |
+| Controller (MockMvc) | `DashboardStatsController` | ADMIN 200, STAFF 403, DOCTOR 403, 토큰 없음 401, from>to 400, 기간 초과 400, `?from=not-a-date` 400, JSON 직렬화 |
 | SecurityConfig 통합 | 매처 순서 | ADMIN 200, STAFF 403, DOCTOR 403, anon 401, GET `/api/admin/...`이 GET `/api/**`보다 먼저 매칭 |
 
 - H2: 기존 패턴 따름 (`SchemaUtils.createMissingTablesAndColumns`, `@BeforeEach deleteAll`)
@@ -590,9 +641,26 @@ it('컴포넌트 파괴 시 Chart 인스턴스를 destroy한다', () => {
 5. [P1-Performance] idx_appointments_doctor_date 멀티클리닉 갭 — §3.3 주의 노트 추가
 6. [P1-Arch] AppointmentState.fromName() — §4.3 실제 API 확인 후 정확한 사용법 명세
 
-### Round 2 목표
+### Round 2 (2026-05-19)
 
-Claude Code 6-tier advisor + Phase 3 Codex 리뷰 후 P0/P1 = 0 달성 여부 확인.
+| Reviewer | P0 | P1 | P2 | P3 |
+|----------|----|----|----|----|
+| Claude Code 6-tier advisor | 0 | 1 | 7 | 3 |
+| **통합 합계** | **0** | **1** | **7** | **3** |
+
+**Round 2 P1 적용 항목**:
+1. [P1-T4] `Triple<Long, AppointmentState, Long>` → `DoctorStatusCount` named data class (§4.3)
+
+**Round 2 P2 적용 항목** (spec에 반영):
+1. [P2-T1/T2] SecurityConfig에 `accessDeniedHandler`/`authenticationEntryPoint` 등록 → §4.2 추가
+2. [P2-T2/T5] `MethodArgumentTypeMismatchException` → 400 핸들러 추가 → §4.2 + §7.1 test case 추가
+3. [P2-T4] `countByDoctorAndStatus` `orderBy(count DESC)` 계약 명시 → §4.3
+4. [P2-T4] `limit in 1..100` 검증 → §4.3 getDoctorStats 스케치
+5. [P2-T6] Exposed `countExpr` alias 패턴 명시 → §3.2
+
+### Round 3 목표
+
+Phase 3 독립 리뷰 후 P0/P1 = 0 달성 여부 확인.
 
 ---
 

--- a/frontend/appointment-frontend/package-lock.json
+++ b/frontend/appointment-frontend/package-lock.json
@@ -17,6 +17,7 @@
         "@angular/material": "^21.2.8",
         "@angular/platform-browser": "^21.2.10",
         "@angular/router": "^21.2.10",
+        "chart.js": "^4.5.1",
         "hono": "^4.12.16",
         "rxjs": "~7.8.0",
         "tslib": "^2.3.0"
@@ -2106,6 +2107,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {
       "version": "3.0.5",
@@ -4514,6 +4521,18 @@
       "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/chart.js": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
+      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
     },
     "node_modules/chokidar": {
       "version": "5.0.0",

--- a/frontend/appointment-frontend/package.json
+++ b/frontend/appointment-frontend/package.json
@@ -20,6 +20,7 @@
     "@angular/material": "^21.2.8",
     "@angular/platform-browser": "^21.2.10",
     "@angular/router": "^21.2.10",
+    "chart.js": "^4.5.1",
     "hono": "^4.12.16",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0"

--- a/frontend/appointment-frontend/src/app/core/models/dashboard-stats.model.ts
+++ b/frontend/appointment-frontend/src/app/core/models/dashboard-stats.model.ts
@@ -1,0 +1,55 @@
+/** Daily appointment counts for one date, broken down by status. */
+export interface DailyAppointmentBucket {
+  date: string;
+  countsByStatus: Record<string, number>;
+  total: number;
+}
+
+/** GET /api/admin/stats/appointments response. */
+export interface AppointmentStatsResponse {
+  clinicId: number;
+  from: string;
+  to: string;
+  totals: Record<string, number>;
+  daily: DailyAppointmentBucket[];
+}
+
+/** Appointment metrics for a single doctor. */
+export interface DoctorBucket {
+  doctorId: number;
+  totalAppointments: number;
+  completed: number;
+  cancelled: number;
+  noShow: number;
+  completionRate: number;
+}
+
+/** GET /api/admin/stats/doctors response. */
+export interface DoctorStatsResponse {
+  clinicId: number;
+  from: string;
+  to: string;
+  doctors: DoctorBucket[];
+}
+
+/** GET /api/admin/stats/cancellations response. */
+export interface CancellationStatsResponse {
+  clinicId: number;
+  from: string;
+  to: string;
+  totalCancelled: number;
+  totalNoShow: number;
+  totalRescheduled: number;
+  totalCompleted: number;
+  cancellationRate: number;
+  noShowRate: number;
+  daily: DailyCancellationBucket[];
+}
+
+/** Per-day cancellation breakdown. */
+export interface DailyCancellationBucket {
+  date: string;
+  cancelled: number;
+  noShow: number;
+  rescheduled: number;
+}

--- a/frontend/appointment-frontend/src/app/core/models/index.ts
+++ b/frontend/appointment-frontend/src/app/core/models/index.ts
@@ -8,3 +8,4 @@ export * from './equipment.model';
 export * from './reschedule-candidate.model';
 export * from './reschedule-progress.model';
 export * from './equipment-unavailability.model';
+export * from './dashboard-stats.model';

--- a/frontend/appointment-frontend/src/app/core/services/dashboard-stats.service.ts
+++ b/frontend/appointment-frontend/src/app/core/services/dashboard-stats.service.ts
@@ -1,0 +1,76 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { firstValueFrom } from 'rxjs';
+import {
+  ApiResponse,
+  AppointmentStatsResponse,
+  CancellationStatsResponse,
+  DoctorStatsResponse,
+} from '../models';
+import { environment } from '../../../environments/environment';
+
+@Injectable({ providedIn: 'root' })
+export class DashboardStatsService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = `${environment.apiUrl}/admin/stats`;
+
+  async getAppointmentStats(
+    clinicId: number,
+    from: string,
+    to: string,
+    statuses?: string[],
+  ): Promise<AppointmentStatsResponse> {
+    let params = new HttpParams()
+      .set('clinicId', clinicId)
+      .set('from', from)
+      .set('to', to);
+    if (statuses?.length) {
+      statuses.forEach(s => { params = params.append('statuses', s); });
+    }
+    const res = await firstValueFrom(
+      this.http.get<ApiResponse<AppointmentStatsResponse>>(
+        `${this.baseUrl}/appointments`,
+        { params },
+      ),
+    );
+    return res.data!;
+  }
+
+  async getDoctorStats(
+    clinicId: number,
+    from: string,
+    to: string,
+    limit = 20,
+  ): Promise<DoctorStatsResponse> {
+    const params = new HttpParams()
+      .set('clinicId', clinicId)
+      .set('from', from)
+      .set('to', to)
+      .set('limit', limit);
+    const res = await firstValueFrom(
+      this.http.get<ApiResponse<DoctorStatsResponse>>(
+        `${this.baseUrl}/doctors`,
+        { params },
+      ),
+    );
+    return res.data!;
+  }
+
+  async getCancellationStats(
+    clinicId: number,
+    from: string,
+    to: string,
+  ): Promise<CancellationStatsResponse> {
+    const params = new HttpParams()
+      .set('clinicId', clinicId)
+      .set('from', from)
+      .set('to', to);
+    const res = await firstValueFrom(
+      this.http.get<ApiResponse<CancellationStatsResponse>>(
+        `${this.baseUrl}/cancellations`,
+        { params },
+      ),
+    );
+    return res.data!;
+  }
+}

--- a/frontend/appointment-frontend/src/app/core/services/index.ts
+++ b/frontend/appointment-frontend/src/app/core/services/index.ts
@@ -8,3 +8,4 @@ export * from './equipment.service';
 export * from './calendar-state.service';
 export * from './reschedule.service';
 export * from './equipment-unavailability.service';
+export * from './dashboard-stats.service';

--- a/frontend/appointment-frontend/src/app/features/management/admin-dashboard/admin-dashboard.component.ts
+++ b/frontend/appointment-frontend/src/app/features/management/admin-dashboard/admin-dashboard.component.ts
@@ -1,0 +1,192 @@
+import { Component, inject, OnInit, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { DashboardStatsService } from '../../../core/services';
+import {
+  AppointmentStatsResponse,
+  CancellationStatsResponse,
+  DoctorStatsResponse,
+} from '../../../core/models';
+import { AppointmentStatsChartComponent } from './appointment-stats-chart.component';
+import { DoctorStatsChartComponent } from './doctor-stats-chart.component';
+import { CancellationStatsChartComponent } from './cancellation-stats-chart.component';
+
+function toIsoDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+/** Admin dashboard: loads and displays 3 stats charts for a clinic date range. */
+@Component({
+  selector: 'app-admin-dashboard',
+  standalone: true,
+  imports: [
+    FormsModule,
+    MatCardModule,
+    MatButtonModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatProgressSpinnerModule,
+    AppointmentStatsChartComponent,
+    DoctorStatsChartComponent,
+    CancellationStatsChartComponent,
+  ],
+  template: `
+    <div class="dashboard-container">
+      <h1 class="page-title">어드민 대시보드</h1>
+
+      <!-- Filter bar -->
+      <mat-card class="filter-card">
+        <mat-card-content class="filter-row">
+          <mat-form-field appearance="outline">
+            <mat-label>클리닉 ID</mat-label>
+            <input matInput type="number" [(ngModel)]="clinicId" min="1" />
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>시작일</mat-label>
+            <input matInput type="date" [(ngModel)]="from" />
+          </mat-form-field>
+
+          <mat-form-field appearance="outline">
+            <mat-label>종료일</mat-label>
+            <input matInput type="date" [(ngModel)]="to" />
+          </mat-form-field>
+
+          <button mat-raised-button color="primary" (click)="load()" [disabled]="loading()">
+            조회
+          </button>
+        </mat-card-content>
+      </mat-card>
+
+      @if (loading()) {
+        <div class="spinner-row">
+          <mat-spinner diameter="48" />
+        </div>
+      }
+
+      @if (error()) {
+        <mat-card class="error-card">
+          <mat-card-content>{{ error() }}</mat-card-content>
+        </mat-card>
+      }
+
+      <!-- Appointment stats chart -->
+      <mat-card class="chart-card">
+        <mat-card-header>
+          <mat-card-title>일별 예약 현황</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <app-appointment-stats-chart [stats]="appointmentStats()" />
+        </mat-card-content>
+      </mat-card>
+
+      <!-- Doctor stats chart -->
+      <mat-card class="chart-card">
+        <mat-card-header>
+          <mat-card-title>의사별 예약 현황</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <app-doctor-stats-chart [stats]="doctorStats()" />
+        </mat-card-content>
+      </mat-card>
+
+      <!-- Cancellation stats chart -->
+      <mat-card class="chart-card">
+        <mat-card-header>
+          <mat-card-title>취소·미방문 현황</mat-card-title>
+        </mat-card-header>
+        <mat-card-content>
+          <app-cancellation-stats-chart [stats]="cancellationStats()" />
+        </mat-card-content>
+      </mat-card>
+    </div>
+  `,
+  styles: [`
+    .dashboard-container {
+      padding: 24px;
+      max-width: 1200px;
+      margin: 0 auto;
+      display: flex;
+      flex-direction: column;
+      gap: 24px;
+    }
+
+    .page-title {
+      font-size: 1.75rem;
+      font-weight: 600;
+      margin: 0;
+      color: #1a1a1a;
+    }
+
+    .filter-card mat-card-content.filter-row {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: center;
+      gap: 16px;
+      padding: 8px 0;
+    }
+
+    .filter-row mat-form-field {
+      flex: 1 1 160px;
+    }
+
+    .spinner-row {
+      display: flex;
+      justify-content: center;
+      padding: 32px 0;
+    }
+
+    .error-card {
+      background: #ffebee;
+      color: #c62828;
+    }
+
+    .chart-card mat-card-content {
+      padding-top: 16px;
+    }
+  `],
+})
+export class AdminDashboardComponent implements OnInit {
+  private readonly statsService = inject(DashboardStatsService);
+
+  clinicId = 1;
+  from = toIsoDate(new Date(Date.now() - 29 * 24 * 60 * 60 * 1000));
+  to = toIsoDate(new Date());
+
+  readonly loading = signal(false);
+  readonly error = signal<string | null>(null);
+  readonly appointmentStats = signal<AppointmentStatsResponse | null>(null);
+  readonly doctorStats = signal<DoctorStatsResponse | null>(null);
+  readonly cancellationStats = signal<CancellationStatsResponse | null>(null);
+
+  ngOnInit(): void {
+    this.load();
+  }
+
+  async load(): Promise<void> {
+    if (this.clinicId < 1) {
+      this.error.set('클리닉 ID는 1 이상이어야 합니다.');
+      return;
+    }
+    this.loading.set(true);
+    this.error.set(null);
+    try {
+      const [appt, doctor, cancel] = await Promise.all([
+        this.statsService.getAppointmentStats(this.clinicId, this.from, this.to),
+        this.statsService.getDoctorStats(this.clinicId, this.from, this.to),
+        this.statsService.getCancellationStats(this.clinicId, this.from, this.to),
+      ]);
+      this.appointmentStats.set(appt);
+      this.doctorStats.set(doctor);
+      this.cancellationStats.set(cancel);
+    } catch {
+      this.error.set('통계 데이터를 불러오는 중 오류가 발생했습니다.');
+    } finally {
+      this.loading.set(false);
+    }
+  }
+}

--- a/frontend/appointment-frontend/src/app/features/management/admin-dashboard/appointment-stats-chart.component.ts
+++ b/frontend/appointment-frontend/src/app/features/management/admin-dashboard/appointment-stats-chart.component.ts
@@ -1,0 +1,83 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Input,
+  OnDestroy,
+  ViewChild,
+} from '@angular/core';
+import { Chart, ChartData, registerables } from 'chart.js';
+import { AppointmentStatsResponse } from '../../../core/models';
+
+Chart.register(...registerables);
+
+/** Bar chart: daily appointment counts grouped by status. */
+@Component({
+  selector: 'app-appointment-stats-chart',
+  standalone: true,
+  template: `
+    <div class="chart-wrapper">
+      <canvas #chartCanvas></canvas>
+    </div>
+  `,
+  styles: [`
+    .chart-wrapper { position: relative; height: 300px; }
+  `],
+})
+export class AppointmentStatsChartComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('chartCanvas') chartCanvas!: ElementRef<HTMLCanvasElement>;
+
+  private _stats: AppointmentStatsResponse | null = null;
+  private chart?: Chart;
+
+  @Input() set stats(value: AppointmentStatsResponse | null) {
+    this._stats = value;
+    if (this.chart) this.updateChart();
+  }
+
+  ngAfterViewInit(): void {
+    this.chart = new Chart(this.chartCanvas.nativeElement, {
+      type: 'bar',
+      data: this.buildData(),
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { position: 'top' } },
+        scales: { x: { stacked: true }, y: { stacked: true, beginAtZero: true } },
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.chart?.destroy();
+  }
+
+  private buildData(): ChartData<'bar'> {
+    const daily = this._stats?.daily ?? [];
+    const labels = daily.map(b => b.date);
+    const statuses = [...new Set(daily.flatMap(b => Object.keys(b.countsByStatus)))];
+    const STATUS_COLORS: Record<string, string> = {
+      CONFIRMED: '#1976d2',
+      COMPLETED: '#388e3c',
+      CANCELLED: '#d32f2f',
+      NO_SHOW: '#f57c00',
+      RESCHEDULED: '#7b1fa2',
+      REQUESTED: '#0288d1',
+    };
+    return {
+      labels,
+      datasets: statuses.map(status => ({
+        label: status,
+        data: daily.map(b => b.countsByStatus[status] ?? 0),
+        backgroundColor: STATUS_COLORS[status] ?? '#90a4ae',
+      })),
+    };
+  }
+
+  private updateChart(): void {
+    if (!this.chart) return;
+    const data = this.buildData();
+    this.chart.data = data;
+    this.chart.update();
+  }
+}

--- a/frontend/appointment-frontend/src/app/features/management/admin-dashboard/cancellation-stats-chart.component.ts
+++ b/frontend/appointment-frontend/src/app/features/management/admin-dashboard/cancellation-stats-chart.component.ts
@@ -1,0 +1,77 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Input,
+  OnDestroy,
+  ViewChild,
+} from '@angular/core';
+import { Chart, ChartData, registerables } from 'chart.js';
+import { CancellationStatsResponse } from '../../../core/models';
+
+Chart.register(...registerables);
+
+/** Doughnut chart: cancellation vs no-show vs completed ratio. */
+@Component({
+  selector: 'app-cancellation-stats-chart',
+  standalone: true,
+  template: `
+    <div class="chart-wrapper">
+      <canvas #chartCanvas></canvas>
+    </div>
+  `,
+  styles: [`
+    .chart-wrapper { position: relative; height: 300px; }
+  `],
+})
+export class CancellationStatsChartComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('chartCanvas') chartCanvas!: ElementRef<HTMLCanvasElement>;
+
+  private _stats: CancellationStatsResponse | null = null;
+  private chart?: Chart;
+
+  @Input() set stats(value: CancellationStatsResponse | null) {
+    this._stats = value;
+    if (this.chart) this.updateChart();
+  }
+
+  ngAfterViewInit(): void {
+    this.chart = new Chart(this.chartCanvas.nativeElement, {
+      type: 'doughnut',
+      data: this.buildData(),
+      options: {
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { position: 'right' } },
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.chart?.destroy();
+  }
+
+  private buildData(): ChartData<'doughnut'> {
+    const s = this._stats;
+    return {
+      labels: ['완료', '취소', '미방문', '재배정'],
+      datasets: [
+        {
+          data: [
+            s?.totalCompleted ?? 0,
+            s?.totalCancelled ?? 0,
+            s?.totalNoShow ?? 0,
+            s?.totalRescheduled ?? 0,
+          ],
+          backgroundColor: ['#388e3c', '#d32f2f', '#f57c00', '#7b1fa2'],
+        },
+      ],
+    };
+  }
+
+  private updateChart(): void {
+    if (!this.chart) return;
+    this.chart.data = this.buildData();
+    this.chart.update();
+  }
+}

--- a/frontend/appointment-frontend/src/app/features/management/admin-dashboard/doctor-stats-chart.component.ts
+++ b/frontend/appointment-frontend/src/app/features/management/admin-dashboard/doctor-stats-chart.component.ts
@@ -1,0 +1,85 @@
+import {
+  AfterViewInit,
+  Component,
+  ElementRef,
+  Input,
+  OnDestroy,
+  ViewChild,
+} from '@angular/core';
+import { Chart, ChartData, registerables } from 'chart.js';
+import { DoctorStatsResponse } from '../../../core/models';
+
+Chart.register(...registerables);
+
+/** Horizontal bar chart: top-N doctors by total appointments. */
+@Component({
+  selector: 'app-doctor-stats-chart',
+  standalone: true,
+  template: `
+    <div class="chart-wrapper">
+      <canvas #chartCanvas></canvas>
+    </div>
+  `,
+  styles: [`
+    .chart-wrapper { position: relative; height: 300px; }
+  `],
+})
+export class DoctorStatsChartComponent implements AfterViewInit, OnDestroy {
+  @ViewChild('chartCanvas') chartCanvas!: ElementRef<HTMLCanvasElement>;
+
+  private _stats: DoctorStatsResponse | null = null;
+  private chart?: Chart;
+
+  @Input() set stats(value: DoctorStatsResponse | null) {
+    this._stats = value;
+    if (this.chart) this.updateChart();
+  }
+
+  ngAfterViewInit(): void {
+    this.chart = new Chart(this.chartCanvas.nativeElement, {
+      type: 'bar',
+      data: this.buildData(),
+      options: {
+        indexAxis: 'y',
+        responsive: true,
+        maintainAspectRatio: false,
+        plugins: { legend: { position: 'top' } },
+        scales: { x: { beginAtZero: true } },
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.chart?.destroy();
+  }
+
+  private buildData(): ChartData<'bar'> {
+    const doctors = this._stats?.doctors ?? [];
+    return {
+      labels: doctors.map(d => `의사 #${d.doctorId}`),
+      datasets: [
+        {
+          label: '완료',
+          data: doctors.map(d => d.completed),
+          backgroundColor: '#388e3c',
+        },
+        {
+          label: '취소',
+          data: doctors.map(d => d.cancelled),
+          backgroundColor: '#d32f2f',
+        },
+        {
+          label: '미방문',
+          data: doctors.map(d => d.noShow),
+          backgroundColor: '#f57c00',
+        },
+      ],
+    };
+  }
+
+  private updateChart(): void {
+    if (!this.chart) return;
+    this.chart.data = this.buildData();
+    this.chart.update();
+  }
+}

--- a/frontend/appointment-frontend/src/app/features/management/dashboard/management-dashboard.component.ts
+++ b/frontend/appointment-frontend/src/app/features/management/dashboard/management-dashboard.component.ts
@@ -108,6 +108,17 @@ import { AppointmentService, DoctorService } from '../../../core/services';
             <button mat-button color="primary" routerLink="/management/equipment-unavailability">바로가기</button>
           </mat-card-actions>
         </mat-card>
+
+        <mat-card class="nav-card" routerLink="/management/admin-dashboard">
+          <mat-card-content>
+            <mat-icon class="nav-icon">bar_chart</mat-icon>
+            <h3>통계 대시보드</h3>
+            <p>예약 현황, 의사별 실적, 취소율 차트를 조회합니다.</p>
+          </mat-card-content>
+          <mat-card-actions>
+            <button mat-button color="primary" routerLink="/management/admin-dashboard">바로가기</button>
+          </mat-card-actions>
+        </mat-card>
       </section>
     </div>
   `,

--- a/frontend/appointment-frontend/src/app/features/management/management.routes.ts
+++ b/frontend/appointment-frontend/src/app/features/management/management.routes.ts
@@ -43,4 +43,11 @@ export const MANAGEMENT_ROUTES: Routes = [
         m => m.EquipmentUnavailabilityListComponent
       ),
   },
+  {
+    path: 'admin-dashboard',
+    loadComponent: () =>
+      import('./admin-dashboard/admin-dashboard.component').then(
+        m => m.AdminDashboardComponent
+      ),
+  },
 ];


### PR DESCRIPTION
## Summary

Closes #44, closes #45

Implements admin dashboard statistics: a backend aggregate API (issue #44) and an Angular frontend with Chart.js charts (issue #45).

---

## Backend changes (`:appointment-api`)

### New files
| File | Description |
|------|-------------|
| `AppointmentStatsRepository` | Exposed `groupBy/count` queries for date+status and doctor+status aggregation |
| `DashboardStatsService` | Business logic: `getAppointmentStats`, `getDoctorStats`, `getCancellationStats` with full input validation |
| `DashboardStatsController` | `GET /api/admin/stats/appointments`, `/doctors`, `/cancellations` |
| `DashboardStatsServiceTest` | 13 unit/integration tests (real H2 DB) |
| `DashboardStatsControllerTest` | 8 HTTP integration tests |

### Modified files
| File | Change |
|------|--------|
| `ServiceConfig` | Register `AppointmentStatsRepository` + `DashboardStatsService` beans |
| `GlobalExceptionHandler` | Add `MethodArgumentTypeMismatchException` → HTTP 400 handler |
| `SecurityConfig` | Add `/api/admin/**` → `hasRole(ADMIN)` rule (prod profile only) |

## Frontend changes (`:frontend:appointment-frontend`)

### New files
| File | Description |
|------|-------------|
| `dashboard-stats.model.ts` | TypeScript interfaces for all 3 response types |
| `DashboardStatsService` | HTTP calls to the 3 backend endpoints |
| `AppointmentStatsChartComponent` | Stacked bar chart — daily counts by status |
| `DoctorStatsChartComponent` | Horizontal bar chart — top-N doctors |
| `CancellationStatsChartComponent` | Doughnut chart — cancelled/noShow/completed ratio |
| `AdminDashboardComponent` | Container: clinicId + date-range filter + 3 charts |

## Test results

```
:appointment-api:test
  DashboardStatsServiceTest    13 tests  0 failures  0 errors
  DashboardStatsControllerTest  8 tests  0 failures  0 errors
  All other tests              96 tests  0 failures  0 errors
  Total:                      117 tests  0 failures  0 errors  ✅

Angular build: ng build — SUCCESS
  admin-dashboard-component chunk: 213 kB ✅
```

## Verification commands

```bash
./gradlew :appointment-api:test
cd frontend/appointment-frontend && npm run build
```