### PR TITLE
[build] Upgrade appointment solver to Timefold 2.1

### DIFF
--- a/appointment-solver/build.gradle.kts
+++ b/appointment-solver/build.gradle.kts
@@ -8,7 +8,6 @@ dependencies {
     implementation(libs.exposed.jdbc)
     implementation(libs.jetbrains.exposed.jdbc)
 
-    testImplementation(libs.timefold.solver.test)
     testImplementation(libs.bluetape4k.junit5)
     testImplementation(libs.h2.v2)
 }

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/HardConstraints.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/HardConstraints.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.clinic.appointment.solver.constraint
 
-import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore
+import ai.timefold.solver.core.api.score.HardSoftScore
 import ai.timefold.solver.core.api.score.stream.Constraint
 import ai.timefold.solver.core.api.score.stream.ConstraintFactory
 import ai.timefold.solver.core.api.score.stream.Joiners
@@ -50,7 +50,7 @@ object HardConstraints {
                 },
             )
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H1: withinOperatingHours")
+            .asConstraint("H1 withinOperatingHours")
 
     // ----------------------------------------------------------------
     // H2: 예약 시간이 의사 근무 스케줄 내에 있어야 함
@@ -73,7 +73,7 @@ object HardConstraints {
                 },
             )
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H2: withinDoctorSchedule")
+            .asConstraint("H2 withinDoctorSchedule")
 
     // ----------------------------------------------------------------
     // H3: 의사 부재 기간과 겹치지 않아야 함
@@ -101,7 +101,7 @@ object HardConstraints {
                 },
             )
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H3: noDoctorAbsenceConflict")
+            .asConstraint("H3 noDoctorAbsenceConflict")
 
     // ----------------------------------------------------------------
     // H4a: 요일별 휴식시간과 겹치지 않아야 함
@@ -120,7 +120,7 @@ object HardConstraints {
                 },
             )
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H4a: noBreakTimeConflict")
+            .asConstraint("H4a noBreakTimeConflict")
 
     // ----------------------------------------------------------------
     // H4b: 기본 휴식시간과 겹치지 않아야 함
@@ -135,7 +135,7 @@ object HardConstraints {
                 },
             )
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H4b: noDefaultBreakTimeConflict")
+            .asConstraint("H4b noDefaultBreakTimeConflict")
 
     // ----------------------------------------------------------------
     // H5: 임시휴진(전일 또는 부분)과 겹치지 않아야 함
@@ -158,7 +158,7 @@ object HardConstraints {
                 },
             )
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H5: noClinicClosureConflict")
+            .asConstraint("H5 noClinicClosureConflict")
 
     // ----------------------------------------------------------------
     // H6: 공휴일에 예약 불가 (clinic.openOnHolidays=false인 경우)
@@ -176,7 +176,7 @@ object HardConstraints {
                 ),
             )
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H6: noHolidayConflict")
+            .asConstraint("H6 noHolidayConflict")
 
     // ----------------------------------------------------------------
     // H7: 같은 의사의 동시 환자 수 제한
@@ -234,7 +234,7 @@ object HardConstraints {
                 maxConcurrent < 2
             }
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H7: maxConcurrentPatientsPerDoctor")
+            .asConstraint("H7 maxConcurrentPatientsPerDoctor")
 
     // ----------------------------------------------------------------
     // H8: 같은 시간에 장비 사용 수가 quantity 이하
@@ -282,7 +282,7 @@ object HardConstraints {
                 equipment.quantity < 2
             }
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H8: equipmentAvailability")
+            .asConstraint("H8 equipmentAvailability")
 
     // ----------------------------------------------------------------
     // H9: 의사의 providerType이 진료의 requiredProviderType과 일치
@@ -301,7 +301,7 @@ object HardConstraints {
                 appt.requiredProviderType != doctor.providerType
             }
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H9: providerTypeMatch")
+            .asConstraint("H9 providerTypeMatch")
 
     // ----------------------------------------------------------------
     // H10: 할당된 의사가 해당 클리닉 소속
@@ -320,7 +320,7 @@ object HardConstraints {
                 appt.clinicId != doctor.clinicId
             }
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H10: doctorBelongsToClinic")
+            .asConstraint("H10 doctorBelongsToClinic")
 
     // ----------------------------------------------------------------
     // H11: 장비 사용불가 기간 중 예약 배정 금지
@@ -339,7 +339,7 @@ object HardConstraints {
                 appt.startTime!! < fact.endTime && fact.startTime < appt.endTime!!
             }
             .penalize(HardSoftScore.ONE_HARD)
-            .asConstraint("H11: equipmentUnavailabilityConflict")
+            .asConstraint("H11 equipmentUnavailabilityConflict")
 
     /**
      * 3-level cascade로 maxConcurrent 값을 결정합니다.

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/SoftConstraints.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/SoftConstraints.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.clinic.appointment.solver.constraint
 
-import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore
+import ai.timefold.solver.core.api.score.HardSoftScore
 import ai.timefold.solver.core.api.score.stream.Constraint
 import ai.timefold.solver.core.api.score.stream.ConstraintFactory
 import ai.timefold.solver.core.api.score.stream.Joiners
@@ -23,7 +23,7 @@ object SoftConstraints {
                 Joiners.lessThan(AppointmentPlanning::id),
             )
             .penalize(HardSoftScore.ofSoft(100))
-            .asConstraint("S1: doctorLoadBalance")
+            .asConstraint("S1 doctorLoadBalance")
 
     /**
      * S2: 의사별 하루 스케줄의 빈 시간 간격 최소화 (LOW weight=10).
@@ -53,14 +53,14 @@ object SoftConstraints {
                 val bEnd = b.endTime
                 val aStart = a.startTime
                 if (aEnd != null && bStart != null && aEnd <= bStart) {
-                    ChronoUnit.MINUTES.between(aEnd, bStart).toInt()
+                    ChronoUnit.MINUTES.between(aEnd, bStart)
                 } else if (bEnd != null && aStart != null && bEnd <= aStart) {
-                    ChronoUnit.MINUTES.between(bEnd, aStart).toInt()
+                    ChronoUnit.MINUTES.between(bEnd, aStart)
                 } else {
-                    0
+                    0L
                 }
             }
-            .asConstraint("S2: minimizeGaps")
+            .asConstraint("S2 minimizeGaps")
 
     /**
      * S3: 재스케줄 시 원래 의사 유지 (HIGH weight=1000).
@@ -72,7 +72,7 @@ object SoftConstraints {
         factory.forEach(AppointmentPlanning::class.java)
             .filter { a -> a.originalDoctorId != null && a.doctorId != a.originalDoctorId }
             .penalize(HardSoftScore.ofSoft(1000))
-            .asConstraint("S3: preferOriginalDoctor")
+            .asConstraint("S3 preferOriginalDoctor")
 
     /**
      * S4: PENDING_RESCHEDULE 예약은 빠른 날짜/시간 선호 (LOW weight=10).
@@ -85,9 +85,9 @@ object SoftConstraints {
             .filter { a -> a.requestedDate != null && a.appointmentDate != null }
             .penalize(HardSoftScore.ofSoft(10)) { a ->
                 val days = ChronoUnit.DAYS.between(a.requestedDate, a.appointmentDate)
-                maxOf(0, days.toInt())
+                maxOf(0L, days)
             }
-            .asConstraint("S4: preferEarlySlot")
+            .asConstraint("S4 preferEarlySlot")
 
     /**
      * S5: 장비 사용 시간대를 연속 배치 (LOW weight=5).
@@ -118,14 +118,14 @@ object SoftConstraints {
                 val bEnd = b.endTime
                 val aStart = a.startTime
                 if (aEnd != null && bStart != null && aEnd <= bStart) {
-                    ChronoUnit.MINUTES.between(aEnd, bStart).toInt()
+                    ChronoUnit.MINUTES.between(aEnd, bStart)
                 } else if (bEnd != null && aStart != null && bEnd <= aStart) {
-                    ChronoUnit.MINUTES.between(bEnd, aStart).toInt()
+                    ChronoUnit.MINUTES.between(bEnd, aStart)
                 } else {
-                    0
+                    0L
                 }
             }
-            .asConstraint("S5: equipmentUtilization")
+            .asConstraint("S5 equipmentUtilization")
 
     /**
      * S6: 환자가 요청한 날짜에 가까울수록 선호 (HIGH weight=500).
@@ -137,7 +137,7 @@ object SoftConstraints {
         factory.forEach(AppointmentPlanning::class.java)
             .filter { a -> a.requestedDate != null && a.appointmentDate != null }
             .penalize(HardSoftScore.ofSoft(500)) { a ->
-                Math.abs(ChronoUnit.DAYS.between(a.requestedDate, a.appointmentDate)).toInt()
+                Math.abs(ChronoUnit.DAYS.between(a.requestedDate, a.appointmentDate))
             }
-            .asConstraint("S6: preferRequestedDate")
+            .asConstraint("S6 preferRequestedDate")
 }

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/ScheduleSolution.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/domain/ScheduleSolution.kt
@@ -6,7 +6,7 @@ import ai.timefold.solver.core.api.domain.solution.PlanningSolution
 import ai.timefold.solver.core.api.domain.solution.ProblemFactCollectionProperty
 import ai.timefold.solver.core.api.domain.solution.ProblemFactProperty
 import ai.timefold.solver.core.api.domain.valuerange.ValueRangeProvider
-import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore
+import ai.timefold.solver.core.api.score.HardSoftScore
 import io.bluetape4k.clinic.appointment.model.dto.BreakTimeRecord
 import io.bluetape4k.clinic.appointment.model.dto.ClinicClosureRecord
 import io.bluetape4k.clinic.appointment.model.dto.ClinicDefaultBreakTimeRecord

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/move/AppointmentMoveFilter.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/move/AppointmentMoveFilter.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.clinic.appointment.solver.move
 
-import ai.timefold.solver.core.api.score.director.ScoreDirector
-import ai.timefold.solver.core.impl.heuristic.move.Move
+import ai.timefold.solver.core.impl.score.director.ScoreDirector
+import ai.timefold.solver.core.preview.api.move.Move
 import ai.timefold.solver.core.impl.heuristic.selector.common.decorator.SelectionFilter
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.clinic.appointment.solver.domain.AppointmentPlanning

--- a/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/service/SolverResult.kt
+++ b/appointment-solver/src/main/kotlin/io/bluetape4k/clinic/appointment/solver/service/SolverResult.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.clinic.appointment.solver.service
 
-import ai.timefold.solver.core.api.score.buildin.hardsoft.HardSoftScore
+import ai.timefold.solver.core.api.score.HardSoftScore
 import io.bluetape4k.clinic.appointment.model.dto.AppointmentRecord
 import java.io.Serializable
 

--- a/appointment-solver/src/test/kotlin/io/bluetape4k/clinic/appointment/solver/benchmark/BenchmarkTest.kt
+++ b/appointment-solver/src/test/kotlin/io/bluetape4k/clinic/appointment/solver/benchmark/BenchmarkTest.kt
@@ -41,9 +41,9 @@ class BenchmarkTest {
         private const val LARGE_MAX_TIME_MS = 40_000L
 
         // 베이스라인: 소프트 스코어 최소 기대값 (높을수록 좋음, 0이면 위반 없음)
-        private const val SMALL_MIN_SOFT_SCORE = -100
-        private const val MEDIUM_MIN_SOFT_SCORE = -500
-        private const val LARGE_MIN_SOFT_SCORE = -2000
+        private const val SMALL_MIN_SOFT_SCORE = -100L
+        private const val MEDIUM_MIN_SOFT_SCORE = -500L
+        private const val LARGE_MIN_SOFT_SCORE = -2000L
     }
 
     @Test

--- a/appointment-solver/src/test/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/ConstraintVerifierTest.kt
+++ b/appointment-solver/src/test/kotlin/io/bluetape4k/clinic/appointment/solver/constraint/ConstraintVerifierTest.kt
@@ -1,6 +1,6 @@
 package io.bluetape4k.clinic.appointment.solver.constraint
 
-import ai.timefold.solver.test.api.score.stream.ConstraintVerifier
+import ai.timefold.solver.core.api.score.stream.test.ConstraintVerifier
 import io.bluetape4k.logging.KLogging
 import io.bluetape4k.clinic.appointment.model.dto.ClinicClosureRecord
 import io.bluetape4k.clinic.appointment.model.dto.DoctorAbsenceRecord

--- a/appointment-solver/src/test/kotlin/io/bluetape4k/clinic/appointment/solver/move/AppointmentMoveFilterTest.kt
+++ b/appointment-solver/src/test/kotlin/io/bluetape4k/clinic/appointment/solver/move/AppointmentMoveFilterTest.kt
@@ -1,7 +1,7 @@
 package io.bluetape4k.clinic.appointment.solver.move
 
-import ai.timefold.solver.core.api.score.director.ScoreDirector
-import ai.timefold.solver.core.impl.heuristic.move.Move
+import ai.timefold.solver.core.impl.score.director.ScoreDirector
+import ai.timefold.solver.core.preview.api.move.Move
 import io.bluetape4k.clinic.appointment.model.dto.ClinicClosureRecord
 import io.bluetape4k.clinic.appointment.model.dto.DoctorAbsenceRecord
 import io.bluetape4k.clinic.appointment.model.dto.HolidayRecord
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
+import java.util.SequencedCollection
 
 class AppointmentMoveFilterTest {
 
@@ -46,8 +47,16 @@ class AppointmentMoveFilterTest {
 
         sd = mockk()
         move = mockk()
-        every { move.planningEntities } returns listOf(entity)
+        every { move.planningEntities } returns sequencedEntities(entity)
     }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun sequencedEntities(vararg entities: Any): SequencedCollection<Any> =
+        ArrayList(entities.asList()) as SequencedCollection<Any>
+
+    @Suppress("UNCHECKED_CAST")
+    private fun sequencedValues(vararg values: Any?): SequencedCollection<Any?> =
+        ArrayList(values.asList()) as SequencedCollection<Any?>
 
     private fun solutionWith(
         closures: List<ClinicClosureRecord> = emptyList(),
@@ -69,7 +78,7 @@ class AppointmentMoveFilterTest {
     fun `accept returns true for valid date and doctor`() {
         val solution = solutionWith()
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns listOf(monday, doctorId)
+        every { move.planningValues } returns sequencedValues(monday, doctorId)
 
         filter.accept(sd, move).shouldBeTrue()
     }
@@ -79,7 +88,7 @@ class AppointmentMoveFilterTest {
         val closure = ClinicClosureRecord(clinicId = clinicId, closureDate = monday, isFullDay = true)
         val solution = solutionWith(closures = listOf(closure))
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns listOf(monday, doctorId)
+        every { move.planningValues } returns sequencedValues(monday, doctorId)
 
         filter.accept(sd, move).shouldBeFalse()
     }
@@ -89,7 +98,7 @@ class AppointmentMoveFilterTest {
         val closure = ClinicClosureRecord(clinicId = clinicId, closureDate = monday, isFullDay = false, startTime = LocalTime.of(14, 0))
         val solution = solutionWith(closures = listOf(closure))
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns listOf(monday, doctorId)
+        every { move.planningValues } returns sequencedValues(monday, doctorId)
 
         filter.accept(sd, move).shouldBeTrue()
     }
@@ -98,7 +107,7 @@ class AppointmentMoveFilterTest {
     fun `accept returns false when no operating hours for day of week`() {
         val solution = solutionWith(operatingHoursList = emptyList())
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns listOf(monday, doctorId)
+        every { move.planningValues } returns sequencedValues(monday, doctorId)
 
         filter.accept(sd, move).shouldBeFalse()
     }
@@ -108,7 +117,7 @@ class AppointmentMoveFilterTest {
         val holiday = HolidayRecord(holidayDate = monday, name = "Holiday")
         val solution = solutionWith(holidays = listOf(holiday), openOnHolidays = false)
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns listOf(monday, doctorId)
+        every { move.planningValues } returns sequencedValues(monday, doctorId)
 
         filter.accept(sd, move).shouldBeFalse()
     }
@@ -118,7 +127,7 @@ class AppointmentMoveFilterTest {
         val holiday = HolidayRecord(holidayDate = monday, name = "Holiday")
         val solution = solutionWith(holidays = listOf(holiday), openOnHolidays = true)
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns listOf(monday, doctorId)
+        every { move.planningValues } returns sequencedValues(monday, doctorId)
 
         filter.accept(sd, move).shouldBeTrue()
     }
@@ -128,7 +137,7 @@ class AppointmentMoveFilterTest {
         val absence = DoctorAbsenceRecord(doctorId = doctorId, absenceDate = monday, startTime = null)
         val solution = solutionWith(doctorAbsences = listOf(absence))
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns listOf(monday, doctorId)
+        every { move.planningValues } returns sequencedValues(monday, doctorId)
 
         filter.accept(sd, move).shouldBeFalse()
     }
@@ -138,7 +147,7 @@ class AppointmentMoveFilterTest {
         val absence = DoctorAbsenceRecord(doctorId = doctorId, absenceDate = monday, startTime = LocalTime.of(14, 0))
         val solution = solutionWith(doctorAbsences = listOf(absence))
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns listOf(monday, doctorId)
+        every { move.planningValues } returns sequencedValues(monday, doctorId)
 
         filter.accept(sd, move).shouldBeTrue()
     }
@@ -148,7 +157,7 @@ class AppointmentMoveFilterTest {
         val wrongClinicDoctor = DoctorFact(id = doctorId, clinicId = 999L, providerType = "DOCTOR", maxConcurrentPatients = 1)
         val solution = solutionWith(doctors = listOf(wrongClinicDoctor))
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns listOf(monday, doctorId)
+        every { move.planningValues } returns sequencedValues(monday, doctorId)
 
         filter.accept(sd, move).shouldBeFalse()
     }
@@ -158,7 +167,7 @@ class AppointmentMoveFilterTest {
         val nurseDoctor = DoctorFact(id = doctorId, clinicId = clinicId, providerType = "NURSE", maxConcurrentPatients = 1)
         val solution = solutionWith(doctors = listOf(nurseDoctor))
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns listOf(monday, doctorId)
+        every { move.planningValues } returns sequencedValues(monday, doctorId)
 
         filter.accept(sd, move).shouldBeFalse()
     }
@@ -167,7 +176,7 @@ class AppointmentMoveFilterTest {
     fun `accept returns false when doctor not found in solution`() {
         val solution = solutionWith(doctors = emptyList())
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns listOf(monday, doctorId)
+        every { move.planningValues } returns sequencedValues(monday, doctorId)
 
         filter.accept(sd, move).shouldBeFalse()
     }
@@ -178,7 +187,7 @@ class AppointmentMoveFilterTest {
         entity.appointmentDate = monday
         val solution = solutionWith()
         every { sd.workingSolution } returns solution
-        every { move.planningValues } returns emptyList<Any>()
+        every { move.planningValues } returns sequencedValues()
 
         filter.accept(sd, move).shouldBeTrue()
     }

--- a/docs/lessons/2026-05-20-timefold-solver-2-consumer.md
+++ b/docs/lessons/2026-05-20-timefold-solver-2-consumer.md
@@ -1,0 +1,26 @@
+# Timefold Solver 2 Consumer Migration
+
+## Context
+
+The appointment solver consumes Timefold score, constraint-verifier, score
+director, and move APIs. Timefold Solver 2.1 moved or changed all of these
+surfaces.
+
+## Decision
+
+Migrate directly to the 2.1 API and keep the local solver behavior unchanged.
+
+## Outcome
+
+- Score imports now use `ai.timefold.solver.core.api.score.*`.
+- Constraint weights return `Long` values for `HardSoftScore`.
+- `ConstraintVerifier` is imported from the core artifact.
+- Move filtering tests use the preview `Move` API and `SequencedCollection`
+  return types.
+- Constraint ids no longer include `:` because Timefold 2 rejects ids outside
+  its allowed character set.
+
+## Verification
+
+- `./gradlew :appointment-solver:compileTestKotlin --no-daemon`
+- `./gradlew :appointment-solver:test --no-daemon`

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,7 @@ kotlinx-coroutines = "1.11.0" # https://mvnrepository.com/artifact/org.jetbrains
 # ── Project-local versions (NOT in any BOM) ───────────────────────────────
 springdoc-openapi = "3.0.3"   # https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
 jjwt = "0.13.0"               # https://mvnrepository.com/artifact/io.jsonwebtoken/jjwt-api
-timefold-solver = "1.33.0"    # https://mvnrepository.com/artifact/ai.timefold.solver/timefold-solver-bom
+timefold-solver = "2.1.0"     # https://mvnrepository.com/artifact/ai.timefold.solver/timefold-solver-bom
 lz4-java = "1.8.0"            # https://mvnrepository.com/artifact/org.lz4/lz4-java
 mockk = "1.14.9"              # https://mvnrepository.com/artifact/io.mockk/mockk
 random-beans = "3.9.0"        # https://mvnrepository.com/artifact/io.github.benas/random-beans
@@ -142,7 +142,6 @@ resilience4j-retry = { module = "io.github.resilience4j:resilience4j-retry", ver
 # ── Timefold (project-local version) ──────────────────────────────────────
 timefold-solver-bom = { module = "ai.timefold.solver:timefold-solver-bom", version.ref = "timefold-solver" }
 timefold-solver-core = { module = "ai.timefold.solver:timefold-solver-core" }
-timefold-solver-test = { module = "ai.timefold.solver:timefold-solver-test" }
 timefold-solver-benchmark = { module = "ai.timefold.solver:timefold-solver-benchmark" }
 
 # ── DB (versions from spring-boot4-dependencies BOM) ──────────────────────


### PR DESCRIPTION
## Summary

Refs bluetape4k/bluetape4k-dependencies#35

- Materialize Timefold Solver 2.1.0.
- Update score, score director, move, and constraint verifier imports for Timefold 2.1.
- Use long match weights for `HardSoftScore` constraints.
- Update move-filter tests for the preview `Move` API and `SequencedCollection` values.
- Add a consumer migration lesson.

## Validation

- `./gradlew :appointment-solver:compileTestKotlin --no-daemon`