### PR TITLE
chore: align bluetape4k-dependencies 1.0.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@
 
 [versions]
 # ── BOM (source of truth) ──────────────────────────────────────────────────
-bluetape4k-dependencies = "1.0.1-SNAPSHOT"
+bluetape4k-dependencies = "1.0.1"
 
 # ── Plugin versions (always required) ─────────────────────────────────────
 kotlin = "2.3.21"


### PR DESCRIPTION
## Summary
- Align shared bluetape4k-dependencies catalog version with the released 1.0.1 train.

## Verification
- ./gradlew help --no-daemon
- scripts/sync-shared-versions.py --workspace .. --check --summary from bluetape4k-dependencies

## Notes
- This is a downstream sync-only change required by the dependencies repo shared-version gate.