### PR TITLE
build: sync dependencies 1.1.1 catalog

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@
 
 [versions]
 # ── BOM (source of truth) ──────────────────────────────────────────────────
-bluetape4k-dependencies = "1.0.1"
+bluetape4k-dependencies = "1.1.0"
 
 # ── Plugin versions (always required) ─────────────────────────────────────
 kotlin = "2.3.21"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@
 
 [versions]
 # ── BOM (source of truth) ──────────────────────────────────────────────────
-bluetape4k-dependencies = "1.1.0"
+bluetape4k-dependencies = "1.1.1"
 
 # ── Plugin versions (always required) ─────────────────────────────────────
 kotlin = "2.3.21"


### PR DESCRIPTION
## Summary

- update `bluetape4k-dependencies` from 1.0.1 to the 1.1.1 release catalog
- consume the patched publishable BOM surface that supersedes 1.1.0

## Verification

- CI rerun on this PR branch
