### PR TITLE
docs: record dependencies 1.1.1 sync lesson

### DIFF
--- a/docs/lessons/2026-05-23-dependencies-1-1-1-sync.md
+++ b/docs/lessons/2026-05-23-dependencies-1-1-1-sync.md
@@ -1,0 +1,31 @@
+# Dependencies 1.1.1 Sync
+
+## Context
+
+`bluetape4k-dependencies` 1.1.0 was superseded by 1.1.1 after the artifact
+availability audit found generated aliases for non-published mock web
+application modules. This application consumes the shared catalog and should
+stay aligned with the release train.
+
+## Decision
+
+Consume `bluetape4k-dependencies = "1.1.1"` through the standard shared-version
+sync path. Do not add application-local overrides for artifacts that the central
+catalog has already removed.
+
+## Outcome
+
+PR #130 aligned this repository to the 1.1.1 catalog and merged after CI passed.
+
+## Verification
+
+- GitHub PR #130 status checks passed before merge.
+- Workspace-level `scripts/sync-shared-versions.py --workspace .. --check --summary`
+  passed after the downstream PRs were merged.
+
+## Future Guidance
+
+When the shared catalog patch fixes publication availability, wait until Maven
+Central `repo1` resolves the new version before rerunning downstream CI. Keep
+application dependency drift fixes in the catalog whenever they affect multiple
+bluetape4k repositories.


### PR DESCRIPTION
## Summary
- Add a lesson for consuming bluetape4k-dependencies 1.1.1.
- Capture why the app follows the shared catalog instead of local exclusions.
- Record the Central repo1 visibility rule for future sync work.

## Verification
- git diff --check HEAD~1..HEAD

## Notes
- Documentation-only change; Gradle tests were not run.