### PR TITLE
build: consume dependencies 1.1.3 in clinic example

### DIFF
--- a/docs/lessons/2026-05-24-dependencies-1-1-3-sync.md
+++ b/docs/lessons/2026-05-24-dependencies-1-1-3-sync.md
@@ -1,0 +1,27 @@
+# Dependencies 1.1.3 Sync
+
+## Context
+
+`clinic-appointment` was still consuming `bluetape4k-dependencies = "1.1.1"`.
+The published release tag `bluetape4k-dependencies` `1.1.3` is the catalog
+baseline for downstream sync; the local post-release branch may already carry
+the next development version.
+
+## Decision
+
+Keep `bluetape4k-dependencies` as the only bluetape4k BOM source and update the
+catalog version to `1.1.3`. Do not add direct `bluetape4k-bom` or
+`bluetape4k-exposed-bom` imports.
+
+## Outcome
+
+The local catalog now resolves bluetape4k and bluetape4k-exposed versions
+through `io.github.bluetape4k:bluetape4k-dependencies:1.1.3`.
+
+- `git show 1.1.3:gradle/libs.versions.toml` confirmed the tag catalog declares
+  `bluetape4k-dependencies = "1.1.3"`.
+- `./gradlew -q :appointment-core:dependencyInsight --configuration compileClasspath --dependency io.github.bluetape4k:bluetape4k-dependencies`
+  resolved `io.github.bluetape4k:bluetape4k-dependencies:1.1.3`.
+- `rg` over Gradle files found no direct `libs.jetbrains.exposed.bom`,
+  `libs.bluetape4k.bom`, `bluetape4k-bom`, or `bluetape4k-exposed-bom` usage.
+- `./gradlew compileTestKotlin --no-daemon` passed.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@
 
 [versions]
 # ── BOM (source of truth) ──────────────────────────────────────────────────
-bluetape4k-dependencies = "1.1.1"
+bluetape4k-dependencies = "1.1.3"
 
 # ── Plugin versions (always required) ─────────────────────────────────────
 kotlin = "2.3.21"


### PR DESCRIPTION
## Summary
- update the clinic example catalog to `bluetape4k-dependencies` 1.1.3
- keep bluetape4k and Exposed versions governed by the shared dependencies BOM
- document the dependency governance decision in `docs/lessons`

## Verification
- `./gradlew compileTestKotlin --no-daemon`
- dependencyInsight for `bluetape4k-dependencies`
- forbidden-reference `rg` check for direct BOM imports
- `git diff --check`

## Notes
- Code review is intentionally deferred to a separate step by request.
- Nightly CI will be triggered manually after PR creation.