### PR TITLE
Adopt Exposed Gradle plugin in appointment modules

### DIFF
--- a/appointment-api/build.gradle.kts
+++ b/appointment-api/build.gradle.kts
@@ -1,7 +1,17 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
     alias(libs.plugins.spring.boot)
     alias(libs.plugins.gatling)
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.clinic.appointment.api.config"
+        databaseUrl = "jdbc:h2:mem:appointment-api-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 dependencies {

--- a/appointment-core/build.gradle.kts
+++ b/appointment-core/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.clinic.appointment.model.tables"
+        databaseUrl = "jdbc:h2:mem:appointment-core-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 dependencies {

--- a/appointment-event/build.gradle.kts
+++ b/appointment-event/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.clinic.appointment.event"
+        databaseUrl = "jdbc:h2:mem:appointment-event-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 dependencies {

--- a/appointment-notification/build.gradle.kts
+++ b/appointment-notification/build.gradle.kts
@@ -1,5 +1,15 @@
 plugins {
+    alias(libs.plugins.exposed)
     kotlin("plugin.spring")
+}
+
+exposed {
+    migrations {
+        tablesPackage = "io.bluetape4k.clinic.appointment.notification"
+        databaseUrl = "jdbc:h2:mem:appointment-notification-migrations;DB_CLOSE_DELAY=-1;MODE=PostgreSQL"
+        databaseUser = "sa"
+        databasePassword = ""
+    }
 }
 
 dependencies {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
     alias(libs.plugins.gatling) apply false
 
     alias(libs.plugins.kover)
+    alias(libs.plugins.exposed) apply false
 }
 
 val rootLibs = libs

--- a/docs/lessons/2026-05-26-exposed-gradle-plugin.md
+++ b/docs/lessons/2026-05-26-exposed-gradle-plugin.md
@@ -1,0 +1,19 @@
+## Context
+
+Adopted the JetBrains Exposed Gradle plugin for clinic appointment modules that define Exposed tables.
+
+## Decision
+
+The application stays independent from the managed `bt4k` catalog. It declares the plugin version locally and keeps `bluetape4k-dependencies` as the dependency BOM.
+
+## Outcome
+
+Core, API, event, and notification modules now expose `generateMigrations` with explicit migration settings.
+
+## Verification
+
+Ran `git diff --check`, `./gradlew -q help`, and `:appointment-core:tasks --all`.
+
+## Future Guard
+
+When an app catalog lacks an explicit JetBrains Exposed version, add a local plugin version that matches the Exposed BOM line used by `bluetape4k-dependencies`.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ kover = "0.9.8"
 test-logger = "4.0.0"
 shadow = "9.4.1"
 gatling = "3.15.0"
+exposed = "1.3.0"
 
 # ── Override versions (project uses newer than Spring Boot provides) ───────
 kotlinx-coroutines = "1.11.0" # https://mvnrepository.com/artifact/org.jetbrains.kotlinx/kotlinx-coroutines-core
@@ -55,6 +56,7 @@ test-logger = { id = "com.adarshr.test-logger", version.ref = "test-logger" }
 kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
 shadow = { id = "com.gradleup.shadow", version.ref = "shadow" }
 gatling = { id = "io.gatling.gradle", version.ref = "gatling" }
+exposed = { id = "org.jetbrains.exposed.plugin", version.ref = "exposed" }
 
 [libraries]
 jetbrains-annotations = { module = "org.jetbrains:annotations" }


### PR DESCRIPTION
## Summary
- Applies the JetBrains Exposed Gradle plugin to modules that define Exposed tables.
- Adds migration task configuration with explicit table package and H2 migration database settings where main table definitions exist.
- Keeps the app independent from the managed catalog and declares a local Exposed plugin alias that matches the BOM line.
- Adds a short lesson under docs/lessons for future catalog/plugin governance.

## Validation
- git diff --check; ./gradlew -q help; :appointment-core:tasks --all

Closes #134
