### PR TITLE
build: align dependencies catalog with 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- **Dependency governance**: `bluetape4k-dependencies` aligned to the published
+  `1.2.0` BOM.
 - **Bluetape4k**: `1.6.2` → `1.7.0`
 - **Kotlin**: `2.3.20` → `2.3.21`
 - **Java baseline**: Java 25 toolchain → Java 21 (`.java-version`, `build.gradle.kts` 정렬)

--- a/docs/lessons/2026-06-01-dependencies-1-2-0-sync.md
+++ b/docs/lessons/2026-06-01-dependencies-1-2-0-sync.md
@@ -1,0 +1,22 @@
+# Dependencies 1.2.0 Sync
+
+## Context
+
+`bluetape4k-dependencies:1.2.0` was published after the final upstream BOM
+matrix became Maven Central-visible.
+
+## Decision
+
+Move the clinic appointment shared catalog from `1.1.4` to `1.2.0`.
+
+## Outcome
+
+The example app now consumes the published 1.2.0 dependency-governance baseline.
+
+## Verification
+
+- `sync-shared-versions.py --workspace .. --write --check --summary` updated
+  the catalog line.
+- Maven Central returned HTTP 200 for
+  `io.github.bluetape4k:bluetape4k-dependencies:1.2.0`.
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@
 
 [versions]
 # ── BOM (source of truth) ──────────────────────────────────────────────────
-bluetape4k-dependencies = "1.1.4"
+bluetape4k-dependencies = "1.2.0"
 
 # ── Plugin versions (always required) ─────────────────────────────────────
 kotlin = "2.3.21"


### PR DESCRIPTION
## Summary

- align the shared bluetape4k-dependencies catalog line with 1.2.0
- record the downstream sync in CHANGELOG and lessons

## Verification

- ./gradlew help --no-daemon --console=plain
- git diff --check
- Maven Central HTTP 200 for bluetape4k-dependencies 1.2.0
