### PR TITLE
build: consume bluetape4k dependencies 1.3.1

### DIFF
--- a/frontend/appointment-frontend/src/app/core/guards/role.guard.spec.ts
+++ b/frontend/appointment-frontend/src/app/core/guards/role.guard.spec.ts
@@ -1,11 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
-import { signal } from '@angular/core';
 import { roleGuard } from './role.guard';
 import { AuthService } from '../services/auth.service';
 
 describe('roleGuard', () => {
-  let authService: { roles: ReturnType<typeof vi.fn> };
+  let authService: {
+    roles: ReturnType<typeof vi.fn>;
+    isAuthenticated: ReturnType<typeof vi.fn>;
+  };
   let router: { createUrlTree: ReturnType<typeof vi.fn> };
 
   const runGuard = (requiredRoles: string[]) => {
@@ -19,7 +21,7 @@ describe('roleGuard', () => {
   };
 
   beforeEach(() => {
-    authService = { roles: vi.fn() };
+    authService = { roles: vi.fn(), isAuthenticated: vi.fn().mockReturnValue(true) };
     router = { createUrlTree: vi.fn().mockReturnValue({ toString: () => '/calendar' }) };
     TestBed.configureTestingModule({
       providers: [

--- a/frontend/appointment-frontend/src/app/core/services/clinic.service.spec.ts
+++ b/frontend/appointment-frontend/src/app/core/services/clinic.service.spec.ts
@@ -44,7 +44,7 @@ describe('ClinicService', () => {
 
       const req = httpTesting.expectOne('/api/clinics');
       expect(req.request.method).toBe('GET');
-      req.flush({ success: true, data: mockClinics });
+      req.flush({ success: true, data: { content: mockClinics } });
 
       const result = await promise;
       expect(result).toEqual(mockClinics);
@@ -67,7 +67,7 @@ describe('ClinicService', () => {
       expect(service.loading()).toBe(true);
 
       const req = httpTesting.expectOne('/api/clinics');
-      req.flush({ success: true, data: [] });
+      req.flush({ success: true, data: { content: [] } });
 
       await promise;
       expect(service.loading()).toBe(false);

--- a/frontend/appointment-frontend/src/app/core/services/doctor.service.spec.ts
+++ b/frontend/appointment-frontend/src/app/core/services/doctor.service.spec.ts
@@ -36,7 +36,7 @@ describe('DoctorService', () => {
 
       const req = httpTesting.expectOne('/api/clinics/1/doctors');
       expect(req.request.method).toBe('GET');
-      req.flush({ success: true, data: mockDoctors });
+      req.flush({ success: true, data: { content: mockDoctors } });
 
       await promise;
       expect(service.doctors()).toEqual(mockDoctors);
@@ -46,7 +46,7 @@ describe('DoctorService', () => {
       const promise = service.loadByClinic(999);
 
       const req = httpTesting.expectOne('/api/clinics/999/doctors');
-      req.flush({ success: true, data: [] });
+      req.flush({ success: true, data: { content: [] } });
 
       await promise;
       expect(service.doctors()).toEqual([]);

--- a/frontend/appointment-frontend/src/app/core/services/equipment.service.spec.ts
+++ b/frontend/appointment-frontend/src/app/core/services/equipment.service.spec.ts
@@ -44,7 +44,7 @@ describe('EquipmentService', () => {
 
       const req = httpTesting.expectOne('/api/clinics/1/equipments');
       expect(req.request.method).toBe('GET');
-      req.flush({ success: true, data: mockEquipments });
+      req.flush({ success: true, data: { content: mockEquipments } });
 
       const result = await promise;
       expect(result).toEqual(mockEquipments);
@@ -67,7 +67,7 @@ describe('EquipmentService', () => {
       expect(service.loading()).toBe(true);
 
       const req = httpTesting.expectOne('/api/clinics/1/equipments');
-      req.flush({ success: true, data: [] });
+      req.flush({ success: true, data: { content: [] } });
 
       await promise;
       expect(service.loading()).toBe(false);

--- a/frontend/appointment-frontend/src/app/core/services/treatment-type.service.spec.ts
+++ b/frontend/appointment-frontend/src/app/core/services/treatment-type.service.spec.ts
@@ -42,7 +42,7 @@ describe('TreatmentTypeService', () => {
 
       const req = httpTesting.expectOne('/api/clinics/1/treatment-types');
       expect(req.request.method).toBe('GET');
-      req.flush({ success: true, data: mockTypes });
+      req.flush({ success: true, data: { content: mockTypes } });
 
       await promise;
       expect(service.treatmentTypes()).toEqual(mockTypes);
@@ -52,7 +52,7 @@ describe('TreatmentTypeService', () => {
       const promise = service.loadByClinic(999);
 
       const req = httpTesting.expectOne('/api/clinics/999/treatment-types');
-      req.flush({ success: true, data: [] });
+      req.flush({ success: true, data: { content: [] } });
 
       await promise;
       expect(service.treatmentTypes()).toEqual([]);

--- a/frontend/appointment-frontend/src/app/features/appointments/appointment-detail/appointment-detail.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/appointments/appointment-detail/appointment-detail.component.spec.ts
@@ -31,6 +31,7 @@ describe('AppointmentDetailComponent', () => {
     isStaff: signal(false),
     isDoctor: signal(false),
     isPatient: signal(false),
+    clinicId: signal(1),
     getToken: vi.fn().mockReturnValue(null),
   };
 

--- a/frontend/appointment-frontend/src/app/features/appointments/appointment-list/appointment-list.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/appointments/appointment-list/appointment-list.component.spec.ts
@@ -34,6 +34,7 @@ describe('AppointmentListComponent', () => {
             isStaff,
             isDoctor: signal(false),
             isPatient: signal(false),
+            clinicId: signal(1),
             getToken: vi.fn().mockReturnValue(null),
           },
         },

--- a/frontend/appointment-frontend/src/app/features/management/clinic-list/clinic-list.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/management/clinic-list/clinic-list.component.spec.ts
@@ -37,7 +37,7 @@ describe('ClinicListComponent', () => {
     await fixture.whenStable();
 
     httpMock.match(() => true).forEach(req =>
-      req.flush({ success: true, data: mockClinics })
+      req.flush({ success: true, data: { content: mockClinics } })
     );
     await fixture.whenStable();
     fixture.detectChanges();

--- a/frontend/appointment-frontend/src/app/features/management/doctor-list/doctor-list.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/management/doctor-list/doctor-list.component.spec.ts
@@ -36,7 +36,7 @@ describe('DoctorListComponent', () => {
     await fixture.whenStable();
 
     httpMock.match(() => true).forEach(req =>
-      req.flush({ success: true, data: mockDoctors })
+      req.flush({ success: true, data: { content: mockDoctors } })
     );
     fixture.detectChanges();
     await fixture.whenStable();

--- a/frontend/appointment-frontend/src/app/features/management/treatment-list/treatment-type-list.component.spec.ts
+++ b/frontend/appointment-frontend/src/app/features/management/treatment-list/treatment-type-list.component.spec.ts
@@ -36,7 +36,7 @@ describe('TreatmentTypeListComponent', () => {
     await fixture.whenStable();
 
     httpMock.match(() => true).forEach(req =>
-      req.flush({ success: true, data: mockTypes })
+      req.flush({ success: true, data: { content: mockTypes } })
     );
     fixture.detectChanges();
     await fixture.whenStable();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@
 
 [versions]
 # ── BOM (source of truth) ──────────────────────────────────────────────────
-bluetape4k-dependencies = "1.3.0"
+bluetape4k-dependencies = "1.3.1"
 
 # ── Plugin versions (always required) ─────────────────────────────────────
 kotlin = "2.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@
 
 [versions]
 # ── BOM (source of truth) ──────────────────────────────────────────────────
-bluetape4k-dependencies = "1.2.0"
+bluetape4k-dependencies = "1.3.0"
 
 # ── Plugin versions (always required) ─────────────────────────────────────
 kotlin = "2.4.0"


### PR DESCRIPTION
## Summary
- Upgrade the example consumer to `io.bluetape4k:bluetape4k-dependencies:1.3.1`.
- Keep the example test suite aligned with the current frontend/backend contracts exposed during the 1.3.1 verification run.
- Update Angular fixtures for the computed-signal `AuthService` contract and pageable API response envelopes.

## Validation
- Catalog drift check against `bluetape4k-dependencies/gradle/libs.versions.toml`: `actionable_drift_count=0`.
- `./gradlew help --refresh-dependencies --no-daemon --no-configuration-cache`
- `./gradlew :frontend:appointment-frontend:npmTest --no-daemon --no-configuration-cache --no-build-cache`
- `./gradlew test --no-daemon --no-configuration-cache --no-build-cache`

## DoD Status
- [x] Consumes `bluetape4k-dependencies` 1.3.1.
- [x] External library drift was checked against the bluetape4k catalog/ecosystem.
- [x] Repository-level tests passed before PR creation.
